### PR TITLE
Fix member_months extension passthrough double-strip (#1347)

### DIFF
--- a/models/core/staging/core__int_member_months.sql
+++ b/models/core/staging/core__int_member_months.sql
@@ -12,7 +12,7 @@ with stg_eligibility as (
     , enrollment_start_date
     , enrollment_end_date
     , tuva_last_run
-    {{ select_extension_columns(ref('normalized__eligibility'), alias='elig') }}
+    {{ select_extension_columns(ref('normalized__eligibility'), alias='elig', strip_prefix=false) }}
     , data_source
   from {{ ref('normalized__eligibility') }} as elig
 )
@@ -35,7 +35,7 @@ select distinct
   , a.payer
   , a.{{ quote_column('plan') }}
   , a.tuva_last_run
-  {{ select_extension_columns(ref('normalized__eligibility'), alias='a') }}
+  {{ select_extension_columns(ref('normalized__eligibility'), alias='a', strip_prefix=false) }}
   , a.data_source
 from stg_eligibility as a
 inner join month_start_and_end_dates as b

--- a/models/core/staging/core__stg_claims_member_months.sql
+++ b/models/core/staging/core__stg_claims_member_months.sql
@@ -12,7 +12,7 @@ with final_before_attribution_fields as (
     , a.year_month
     , a.payer
     , a.{{ quote_column('plan') }}
-    {{ select_extension_columns(ref('core__int_member_months'), alias='a') }}
+    {{ select_extension_columns(ref('core__int_member_months'), alias='a', strip_prefix=false) }}
     , a.data_source
   from {{ ref('core__int_member_months') }} as a
 )
@@ -33,7 +33,7 @@ select
   , b.custom_attributed_provider_practice
   , b.custom_attributed_provider_organization
   , b.custom_attributed_provider_lob
-  {{ select_extension_columns(ref('core__int_member_months'), alias='a') }}
+  {{ select_extension_columns(ref('core__int_member_months'), alias='a', strip_prefix=false) }}
   , a.data_source
 
 from final_before_attribution_fields as a


### PR DESCRIPTION
@
## Closes #1347

### What happens
With `passthrough.strip: true` and an extension column on eligibility (e.g. `ext_cell_phone`), the member_months models fail to compile:

```
invalid identifier A.EXT_CELL_PHONE
```

### Why
The prefix gets stripped **twice**. `select_extension_columns()` always discovers column names by introspecting the *original* input relation (e.g. `normalized__eligibility`), so it keeps asking for `ext_cell_phone`. But an upstream CTE has already renamed that column to `cell_phone` via the first (stripping) call, so the second call references a column that no longer exists.

### Fix
This follows the convention already used by every other intermediate model in the repo (e.g. `int_eligibility_casting`, `core__int_patient_casting`, the `core__stg_claims_*` models): **intermediate models pass `strip_prefix=false`** so the prefix is preserved end-to-end (and downstream introspection can still identify the extension columns by prefix), and **only the final model strips**.

The prefix should be stripped exactly once, at the final output (`core__member_months`, which already calls the macro with the default strip behavior). This PR adds `strip_prefix=false` to the four intermediate call sites that were missing it:

- `models/core/staging/core__int_member_months.sql` (2 calls: `stg_eligibility`, `joined`)
- `models/core/staging/core__stg_claims_member_months.sql` (2 calls)

### Behavior impact
- Default config (`strip: false`): **no change** — extension columns keep their prefix through the whole chain, exactly as before.
- `strip: true`: previously a hard compile failure; now compiles and the prefix is stripped once in the final `core__member_months` output.

### Testing
Reproduced both the failure and the fix locally on DuckDB with a focused project mirroring the exact double-call CTE chain (`int` → `stg` → `final`) and an `ext_`-prefixed eligibility column:

- **Before** (`strip: true`): `Binder Error: Values list "a" does not have a column named "ext_cell_phone"` — matches the reported bug.
- **After** (`strip: true`): chain compiles and runs; final output column is `cell_phone` (stripped once), data intact.
- **After** (`strip: false`, default): final output column is `ext_cell_phone` (preserved) — confirms no regression for existing users.

The existing `extension_column_unit_tests.yml` unit tests for this chain also pass.
@