### PR TITLE
Make extension-column unit tests hermetic re: passthrough prefix (#1348)

### DIFF
--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -31,6 +31,11 @@ unit_tests:
       enabled: "{{ var('claims_preprocessing_enabled', var('claims_enabled', var('tuva_marts_enabled', false))) | as_bool }}"
     overrides:
       vars:
+        # Pin the passthrough config so the test is hermetic and does not break
+        # when a project configures a non-default prefix or strip setting.
+        passthrough:
+          prefix: 'x_'
+          strip: false
         _extension_columns_override: ['x_temp_person_id', 'x_temp_first_name']
     given:
       - input: ref('normalized__eligibility')
@@ -82,6 +87,11 @@ unit_tests:
       enabled: "{{ var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool }}"
     overrides:
       vars:
+        # Pin the passthrough config so the test is hermetic and does not break
+        # when a project configures a non-default prefix or strip setting.
+        passthrough:
+          prefix: 'x_'
+          strip: false
         _extension_columns_override: ['x_temp_person_id', 'x_temp_first_name']
     given:
       - input: ref('core__stg_claims_member_months')


### PR DESCRIPTION
## Closes #1348

### Problem
The unit tests in `models/core/extension_column_unit_tests.yml` hardcode `x_`-prefixed columns (e.g. `x_temp_person_id`). `select_extension_columns()` only emits columns matching the configured `passthrough.prefix`, so if a project sets a non-default prefix (e.g. `ext_`), those columns get filtered out of the model output while the test fixtures still expect them:

```
Invalid column name: 'x_temp_person_id' in unit test fixture for expected output.
```

Reproduce: set `passthrough.prefix: 'ext_'` in `dbt_project.yml` and run the tests.

### Fix
Pin the passthrough configuration inside each test's `overrides.vars` so the tests are hermetic — self-contained and independent of the consuming project's config:

```yaml
overrides:
  vars:
    passthrough:
      prefix: 'x_'
      strip: false
    _extension_columns_override: ['x_temp_person_id', 'x_temp_first_name']
```

This keeps the tests aligned with the `x_`-prefixed fixtures they already assert, regardless of what prefix/strip a project configures. It also makes them robust to the `strip: true` case (see #1347).

### Testing
Ran both unit tests locally on DuckDB:

- Default run: both **PASS**.
- Simulating a project that overrides the prefix (`--vars '{passthrough: {prefix: "ext_", strip: true}}'`): both still **PASS**, because the in-test `overrides.vars` pin takes precedence — this is the exact scenario reported as broken.
