### PR TITLE
Split PT/OT/ST into separate service_category_3 values (#1016)

### DIFF
--- a/docs/docs/core-platform/service-categories.md
+++ b/docs/docs/core-platform/service-categories.md
@@ -37,6 +37,9 @@ The Tuva Project Service Category Grouper has three levels in a hierarchy with e
 | inpatient | inpatient rehabilitation | inpatient rehabilitation |
 | inpatient | inpatient substance use | inpatient substance use |
 | inpatient | skilled nursing | skilled nursing |
+| office-based | office-based pt/ot/st | physical therapy |
+| office-based | office-based pt/ot/st | occupational therapy |
+| office-based | office-based pt/ot/st | speech therapy |
 | office-based | office-based pt/ot/st | office-based pt/ot/st |
 | office-based | office-based radiology | ct |
 | office-based | office-based radiology | general |
@@ -54,6 +57,9 @@ The Tuva Project Service Category Grouper has three levels in a hierarchy with e
 | outpatient | outpatient hospice | outpatient hospice |
 | outpatient | outpatient hospital or clinic | outpatient hospital or clinic |
 | outpatient | outpatient psychiatric | outpatient psychiatric |
+| outpatient | outpatient pt/ot/st | physical therapy |
+| outpatient | outpatient pt/ot/st | occupational therapy |
+| outpatient | outpatient pt/ot/st | speech therapy |
 | outpatient | outpatient pt/ot/st | outpatient pt/ot/st |
 | outpatient | outpatient radiology | ct |
 | outpatient | outpatient radiology | general |

--- a/docs/docs/knowledge/claims-groupers-and-algos/service-categories.md
+++ b/docs/docs/knowledge/claims-groupers-and-algos/service-categories.md
@@ -32,6 +32,9 @@ The Tuva Project Service Category Grouper has three levels in a hierarchy with e
 | inpatient | inpatient rehabilitation | inpatient rehabilitation |
 | inpatient | inpatient substance use | inpatient substance use |
 | inpatient | skilled nursing | skilled nursing |
+| office-based | office-based pt/ot/st | physical therapy |
+| office-based | office-based pt/ot/st | occupational therapy |
+| office-based | office-based pt/ot/st | speech therapy |
 | office-based | office-based pt/ot/st | office-based pt/ot/st |
 | office-based | office-based radiology | ct |
 | office-based | office-based radiology | general |
@@ -49,6 +52,9 @@ The Tuva Project Service Category Grouper has three levels in a hierarchy with e
 | outpatient | outpatient hospice | outpatient hospice |
 | outpatient | outpatient hospital or clinic | outpatient hospital or clinic |
 | outpatient | outpatient psychiatric | outpatient psychiatric |
+| outpatient | outpatient pt/ot/st | physical therapy |
+| outpatient | outpatient pt/ot/st | occupational therapy |
+| outpatient | outpatient pt/ot/st | speech therapy |
 | outpatient | outpatient pt/ot/st | outpatient pt/ot/st |
 | outpatient | outpatient radiology | ct |
 | outpatient | outpatient radiology | general |

--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_physical_therapy_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_physical_therapy_professional.sql
@@ -10,7 +10,29 @@ select distinct
     , med.claim_line_id
     , 'office-based' as service_category_1
     , 'office-based pt/ot/st' as service_category_2
-    , 'office-based pt/ot/st' as service_category_3
+    /* Split into discipline: prefer the HCPCS therapy modifier, then fall back
+       to the rendering provider specialty, then the pt/ot/st umbrella. */
+    , coalesce(
+          med.therapy_modifier_discipline
+        , case
+            when med.rend_primary_specialty_description in (
+                    'Physical Therapist'
+                  , 'Physical Therapist in Private Practice'
+                  , 'Physical Therapy Assistant'
+                ) then 'physical therapy'
+            when med.rend_primary_specialty_description in (
+                    'Occupational Health'
+                  , 'Occupational Medicine'
+                  , 'Occupational Therapist in Private Practice'
+                  , 'Occupational Therapy Assistant'
+                ) then 'occupational therapy'
+            when med.rend_primary_specialty_description in (
+                    'Speech Language Pathologist'
+                  , 'Speech-Language Assistant'
+                ) then 'speech therapy'
+          end
+        , 'office-based pt/ot/st'
+      ) as service_category_3
     , '{{ this.name }}' as source_model_name
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('service_category__stg_medical_claim') }} as med

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_institutional.sql
@@ -9,7 +9,10 @@ select distinct
     , med.data_source
     , 'outpatient' as service_category_1
     , 'outpatient pt/ot/st' as service_category_2
-    , 'outpatient pt/ot/st' as service_category_3
+    /* Split into discipline using the HCPCS therapy modifier; institutional
+       claims carry no rendering specialty, so fall back to the pt/ot/st
+       umbrella when no discipline modifier is present. */
+    , coalesce(med.therapy_modifier_discipline, 'outpatient pt/ot/st') as service_category_3
     , '{{ this.name }}' as source_model_name
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('service_category__stg_medical_claim') }} as med

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_professional.sql
@@ -10,7 +10,29 @@ select distinct
   , med.claim_line_id
   , 'outpatient' as service_category_1
   , 'outpatient pt/ot/st' as service_category_2
-  , 'outpatient pt/ot/st' as service_category_3
+  /* Split into discipline: prefer the HCPCS therapy modifier, then fall back
+     to the rendering provider specialty, then the pt/ot/st umbrella. */
+  , coalesce(
+        med.therapy_modifier_discipline
+      , case
+          when med.primary_specialty_description in (
+                  'Physical Therapist'
+                , 'Physical Therapist in Private Practice'
+                , 'Physical Therapy Assistant'
+              ) then 'physical therapy'
+          when med.primary_specialty_description in (
+                  'Occupational Health'
+                , 'Occupational Medicine'
+                , 'Occupational Therapist in Private Practice'
+                , 'Occupational Therapy Assistant'
+              ) then 'occupational therapy'
+          when med.primary_specialty_description in (
+                  'Speech Language Pathologist'
+                , 'Speech-Language Assistant'
+              ) then 'speech therapy'
+        end
+      , 'outpatient pt/ot/st'
+    ) as service_category_3
   , '{{ this.name }}' as source_model_name
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('service_category__stg_medical_claim') }} as med

--- a/models/claims_preprocessing/service_category/service_category__pt_ot_st_unit_tests.yml
+++ b/models/claims_preprocessing/service_category/service_category__pt_ot_st_unit_tests.yml
@@ -1,0 +1,69 @@
+version: 2
+
+# Validates the PT/OT/ST service_category_3 split. service_category_2 stays the
+# 'outpatient pt/ot/st' umbrella; service_category_3 resolves to the individual
+# discipline using the HCPCS therapy modifier first (GP/GO/GN), then the
+# rendering provider specialty, then the umbrella when neither is conclusive.
+
+unit_tests:
+  - name: test_service_category_pt_ot_st_split_by_discipline
+    description: >
+      Verifies service_category_3 splits outpatient pt/ot/st into physical,
+      occupational, and speech therapy: the therapy modifier takes precedence
+      over the provider specialty, the specialty is used as a fallback, and rows
+      with no discipline signal stay in the pt/ot/st umbrella.
+    model: service_category__outpatient_physical_therapy_professional
+    config:
+      enabled: "{{ var('claims_enabled', False) | as_bool }}"
+    overrides:
+      vars:
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('service_category__stg_medical_claim')
+        format: sql
+        rows: |
+          -- modifier wins
+          select 'C1' as claim_id, 1 as claim_line_number, 'test' as data_source, 'C1|1' as claim_line_id
+            , '213' as ccs_category, 'Physical Therapist' as primary_specialty_description
+            , '21' as place_of_service_code, 'physical therapy' as therapy_modifier_discipline
+          union all
+          -- specialty fallback (no modifier)
+          select 'C2', 1, 'test', 'C2|1'
+            , '212', 'Occupational Therapist in Private Practice', '22', cast(null as varchar)
+          union all
+          -- specialty fallback, selected via specialty (no qualifying ccs)
+          select 'C3', 1, 'test', 'C3|1'
+            , cast(null as varchar), 'Speech Language Pathologist', '22', cast(null as varchar)
+          union all
+          -- no discipline signal -> umbrella (selected via ccs)
+          select 'C4', 1, 'test', 'C4|1'
+            , '215', 'Cardiology', '22', cast(null as varchar)
+          union all
+          -- modifier takes precedence over a conflicting specialty
+          select 'C5', 1, 'test', 'C5|1'
+            , '213', 'Speech Language Pathologist', '22', 'physical therapy'
+      - input: ref('service_category__stg_professional')
+        format: sql
+        rows: |
+          select 'C1' as claim_id, 1 as claim_line_number, 'test' as data_source
+          union all select 'C2', 1, 'test'
+          union all select 'C3', 1, 'test'
+          union all select 'C4', 1, 'test'
+          union all select 'C5', 1, 'test'
+    expect:
+      rows:
+        - claim_id: 'C1'
+          service_category_2: 'outpatient pt/ot/st'
+          service_category_3: 'physical therapy'
+        - claim_id: 'C2'
+          service_category_2: 'outpatient pt/ot/st'
+          service_category_3: 'occupational therapy'
+        - claim_id: 'C3'
+          service_category_2: 'outpatient pt/ot/st'
+          service_category_3: 'speech therapy'
+        - claim_id: 'C4'
+          service_category_2: 'outpatient pt/ot/st'
+          service_category_3: 'outpatient pt/ot/st'
+        - claim_id: 'C5'
+          service_category_2: 'outpatient pt/ot/st'
+          service_category_3: 'physical therapy'

--- a/models/claims_preprocessing/service_category/staging/service_category__stg_medical_claim.sql
+++ b/models/claims_preprocessing/service_category/staging/service_category__stg_medical_claim.sql
@@ -41,6 +41,15 @@ with ccs_release_year as (
     , p.primary_specialty_description
     , rend.primary_specialty_description as rend_primary_specialty_description
     , n.modality
+    /* Therapy discipline from the HCPCS therapy modifiers Medicare requires on
+       therapy lines: GP = physical therapy, GO = occupational therapy,
+       GN = speech-language pathology. Used to split the pt/ot/st service
+       category into its individual disciplines. */
+    , case
+        when 'GP' in (m.hcpcs_modifier_1, m.hcpcs_modifier_2, m.hcpcs_modifier_3, m.hcpcs_modifier_4) then 'physical therapy'
+        when 'GO' in (m.hcpcs_modifier_1, m.hcpcs_modifier_2, m.hcpcs_modifier_3, m.hcpcs_modifier_4) then 'occupational therapy'
+        when 'GN' in (m.hcpcs_modifier_1, m.hcpcs_modifier_2, m.hcpcs_modifier_3, m.hcpcs_modifier_4) then 'speech therapy'
+      end as therapy_modifier_discipline
     , m.data_source
   from {{ ref('normalized_input__medical_claim') }} as m
   left outer join {{ ref('ccsr__dxccsr_v2023_1_cleaned_map') }} as dx on m.diagnosis_code_1 = dx.icd_10_cm_code
@@ -86,6 +95,7 @@ select
   , f.primary_specialty_description
   , f.rend_primary_specialty_description
   , f.modality
+  , f.therapy_modifier_discipline
   , f.data_source
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from final as f


### PR DESCRIPTION
## Closes #1016

> It would be great to split PT/OT/ST into their own service category 3 categories. Currently, both service category 2 and 3 are simply PT/OT/ST.

### What changed
The therapy service-category models set both `service_category_2` and `service_category_3` to the same umbrella value (`outpatient pt/ot/st` / `office-based pt/ot/st`), so the individual disciplines couldn't be told apart.

- `service_category_2` is unchanged — it stays the `pt/ot/st` umbrella.
- `service_category_3` now resolves to **`physical therapy`**, **`occupational therapy`**, or **`speech therapy`**.

This mirrors how `service_category_2 = 'outpatient radiology'` already fans out into `ct` / `general` / `mri` / `pet` in `service_category_3`.

### How the discipline is determined
1. **HCPCS therapy modifier** (primary) — Medicare requires a discipline modifier on therapy lines: `GP` = physical, `GO` = occupational, `GN` = speech. This is surfaced once as a `therapy_modifier_discipline` column in `service_category__stg_medical_claim` (works for institutional claims too, which carry no rendering specialty).
2. **Rendering provider specialty** (fallback, professional/office-based only) — e.g. `Physical Therapist` → physical therapy.
3. **Umbrella fallback** — when neither signal is conclusive the row stays in the existing `pt/ot/st` value, so **category membership is unchanged; only `service_category_3` is refined**.

### Files
- `service_category__stg_medical_claim.sql` — add `therapy_modifier_discipline` (additive).
- `service_category__outpatient_physical_therapy_institutional.sql`, `...outpatient_physical_therapy_professional.sql`, `...office_based_physical_therapy_professional.sql` — set `service_category_3` from the discipline.
- Docs: `core-platform/service-categories.md` and `knowledge/claims-groupers-and-algos/service-categories.md` updated to list the new values.

### Testing
Added `service_category__pt_ot_st_unit_tests.yml` covering modifier precedence, specialty fallback, and the umbrella default. Passes locally on DuckDB:

```
dbt test --select test_service_category_pt_ot_st_split_by_discipline
1 of 1 PASS ... test_service_category_pt_ot_st_split_by_discipline
```

The modifier `IN`-list expression was also verified directly on DuckDB (including NULL handling). No downstream model filters on `service_category_3 = '...pt/ot/st'`, and there is no `accepted_values` test on the column, so nothing downstream breaks.

### Note
Discipline assignment depends on therapy modifiers / provider specialty being populated in the source data. Lines lacking both stay in the `pt/ot/st` umbrella rather than being misclassified.
