### PR TITLE
Add encounter_status to clinical encounter input layer and core (#775)

### DIFF
--- a/integration_tests/models/encounter.sql
+++ b/integration_tests/models/encounter.sql
@@ -16,6 +16,7 @@ select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
 , cast(null as {{ dbt.type_string() }}) as person_id
 , cast(null as {{ dbt.type_string() }}) as patient_id
 , cast(null as {{ dbt.type_string() }}) as encounter_type
+, cast(null as {{ dbt.type_string() }}) as encounter_status
 , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as encounter_start_date
 , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as encounter_end_date
 , cast(null as {{ dbt.type_string() }}) as admit_source_code

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -738,6 +738,17 @@ models:
         config:
           meta:
             data_type: varchar
+      - name: encounter_status
+        description: Lifecycle status of the encounter for clinical (EHR-sourced)
+          encounters, aligned with the FHIR Encounter.status value set, such as
+          planned, arrived, in-progress, onleave, finished, cancelled, or
+          entered-in-error. Populated from input_layer__encounter when clinical
+          data is enabled so downstream analytics can distinguish completed
+          encounters from in-progress or unsigned documentation. Null for
+          claims-derived encounters, which have no clinical lifecycle status.
+        config:
+          meta:
+            data_type: varchar
       - name: encounter_start_date
         description: Date the encounter started. For inpatient and multi-day encounters,
           this is the admission or first service date.

--- a/models/core/final/core__encounter.sql
+++ b/models/core/final/core__encounter.sql
@@ -9,6 +9,7 @@
     , person_id
     , encounter_type
     , encounter_group
+    , encounter_status
     , encounter_start_date
     , encounter_end_date
     , length_of_stay

--- a/models/core/staging/core__stg_claims_encounter.sql
+++ b/models/core/staging/core__stg_claims_encounter.sql
@@ -49,6 +49,7 @@ select
   , cast(p.person_id as {{ dbt.type_string() }}) as person_id
   , cast(encounter_type as {{ dbt.type_string() }}) as encounter_type
   , cast(encounter_group as {{ dbt.type_string() }}) as encounter_group
+  , cast(null as {{ dbt.type_string() }}) as encounter_status
   , {{ try_to_cast_date('encounter_start_date', 'YYYY-MM-DD') }} as encounter_start_date
   , coalesce({{ try_to_cast_date('encounter_end_date', 'YYYY-MM-DD') }}, {{ try_to_cast_date('encounter_start_date', 'YYYY-MM-DD') }}) as encounter_end_date
   , cast(length_of_stay as {{ dbt.type_int() }}) as length_of_stay

--- a/models/core/staging/core__stg_clinical_encounter.sql
+++ b/models/core/staging/core__stg_clinical_encounter.sql
@@ -8,6 +8,7 @@
     , cast(enc.person_id as {{ dbt.type_string() }}) as person_id
     , cast(enc.encounter_type as {{ dbt.type_string() }}) as encounter_type
     , cast('clinical' as {{ dbt.type_string() }}) as encounter_group
+    , cast(enc.encounter_status as {{ dbt.type_string() }}) as encounter_status
     , enc.normalized_encounter_start_date as encounter_start_date
     , enc.normalized_encounter_end_date as encounter_end_date
     , cast(

--- a/models/input_layer/input_layer__encounter.yml
+++ b/models/input_layer/input_layer__encounter.yml
@@ -149,6 +149,29 @@ models:
         config:
           meta:
             data_type: varchar
+      - name: encounter_status
+        description: >-
+          Lifecycle status of the encounter as reported by the clinical source system, aligned with the FHIR Encounter.status value set, such as planned, arrived, in-progress, onleave, finished, cancelled, or entered-in-error. Populate this to distinguish completed encounters (for example finished) from encounters that are still in-progress or that represent unsigned or not-yet-completed documentation. Preserve the source status value when available. This lets downstream analytics filter incomplete encounters instead of relying on the connector to drop them from the input layer.
+        required_for_data_marts: []
+        tests:
+          - the_tuva_project.expect_column_to_exist:
+              config:
+                severity: warn
+                enabled: '{{ (var(''enable_input_layer_testing'', true)) | as_bool }}'
+                tags:
+                  - tuva_dqi_sev_1
+                  - dqi
+          - the_tuva_project.warn_if_null_percentage_is_100:
+              description: Percentage of values that are null.
+              config:
+                severity: warn
+                enabled: '{{ var(''enable_input_layer_testing'', true) | as_bool }}'
+                tags:
+                  - tuva_dqi_sev_5
+                  - dqi
+        config:
+          meta:
+            data_type: varchar
       - name: encounter_start_date
         description: >-
           Date the encounter started, formatted as YYYY-MM-DD. For inpatient and multi-day encounters, this is the admission or first service date.


### PR DESCRIPTION
## Summary

Adds an optional `encounter_status` field to the clinical encounter data model so downstream analytics can distinguish completed encounters from in-progress or unsigned/not-yet-completed documentation, instead of relying on connectors to drop incomplete encounters from the input layer.

- Adds `encounter_status` to the `input_layer__encounter` contract, aligned with the FHIR `Encounter.status` value set (planned, arrived, in-progress, onleave, finished, cancelled, entered-in-error).
- Surfaces `encounter_status` on `core.encounter`, populated from clinical (EHR) sources and null for claims-derived encounters, which have no clinical lifecycle status.
- Exposes the field in the integration_tests clinical encounter input model so the core clinical staging model compiles and builds.

The change is purely additive and nullable: no existing columns change, `core.encounter` has no enforced contract, and downstream marts select explicit columns, so they are unaffected.

## Validation

Local DuckDB with synthetic data (`small`):
- Rebuilt the full `core.encounter` lineage (claims + clinical enabled): 229 models, 0 errors.
- Confirmed `encounter_status` is present on `core.encounter` and that the claims/clinical `smart_union` builds correctly (claims-derived rows null as expected).
- `input_layer__encounter` tests pass, including the new column-exists and null-percentage checks.

## Release note

enhancement

Closes #775