### PR TITLE
Add OMB 2024 standardized race_ethnicity to core.patient (#1282)

### DIFF
--- a/macros/core/standardize_race_ethnicity.sql
+++ b/macros/core/standardize_race_ethnicity.sql
@@ -32,7 +32,8 @@
         ethnicity_column: name/expression of the ethnicity column.
 #}
 case
-    when lower(trim(cast({{ ethnicity_column }} as {{ dbt.type_string() }}))) = 'hispanic or latino'
+    when lower(trim(cast({{ ethnicity_column }} as {{ dbt.type_string() }}))) like 'hispanic%'
+      or lower(trim(cast({{ ethnicity_column }} as {{ dbt.type_string() }}))) = 'latino'
         then 'Hispanic or Latino'
     when lower(trim(cast({{ race_column }} as {{ dbt.type_string() }}))) = 'white'
         then 'White'

--- a/macros/core/standardize_race_ethnicity.sql
+++ b/macros/core/standardize_race_ethnicity.sql
@@ -1,0 +1,51 @@
+{% macro standardize_race_ethnicity(race_column, ethnicity_column) -%}
+{#
+    Derives a single standardized race/ethnicity category aligned with the
+    2024 OMB SPD 15 (Statistical Policy Directive No. 15) minimum categories:
+
+        - American Indian or Alaska Native
+        - Asian
+        - Black or African American
+        - Hispanic or Latino
+        - Middle Eastern or North African
+        - Native Hawaiian or Pacific Islander
+        - White
+
+    Tuva stores race and ethnicity as separate fields, so this macro collapses
+    them into one standardized category using a Hispanic-ethnicity-first
+    convention: when ethnicity indicates Hispanic or Latino the category is
+    'Hispanic or Latino', otherwise the mapped race category is used. This is a
+    pragmatic single-column rollup; the OMB 2024 standard itself favors a
+    combined multi-select question where a person can report more than one
+    category.
+
+    Values that cannot be classified into an OMB minimum category (other race,
+    asked but unknown, unknown, or missing) are returned as null.
+
+    Middle Eastern or North African is a new OMB 2024 minimum category that does
+    not exist in the legacy Tuva race terminology, so it is only produced when a
+    source explicitly supplies it. Existing race and ethnicity columns are left
+    unchanged; this derivation is purely additive.
+
+    Arguments:
+        race_column: name/expression of the race column (Tuva race description).
+        ethnicity_column: name/expression of the ethnicity column.
+#}
+case
+    when lower(trim(cast({{ ethnicity_column }} as {{ dbt.type_string() }}))) = 'hispanic or latino'
+        then 'Hispanic or Latino'
+    when lower(trim(cast({{ race_column }} as {{ dbt.type_string() }}))) = 'white'
+        then 'White'
+    when lower(trim(cast({{ race_column }} as {{ dbt.type_string() }}))) = 'black or african american'
+        then 'Black or African American'
+    when lower(trim(cast({{ race_column }} as {{ dbt.type_string() }}))) = 'asian'
+        then 'Asian'
+    when lower(trim(cast({{ race_column }} as {{ dbt.type_string() }}))) = 'american indian or alaska native'
+        then 'American Indian or Alaska Native'
+    when lower(trim(cast({{ race_column }} as {{ dbt.type_string() }}))) in ('native hawaiian or other pacific islander', 'native hawaiian or pacific islander')
+        then 'Native Hawaiian or Pacific Islander'
+    when lower(trim(cast({{ race_column }} as {{ dbt.type_string() }}))) in ('middle eastern or north african', 'mena')
+        then 'Middle Eastern or North African'
+    else null
+end
+{%- endmacro %}

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -2811,6 +2811,23 @@ models:
           meta:
             terminology: https://thetuvaproject.com/terminology/ethnicity
             data_type: varchar
+      - name: race_ethnicity
+        description: >-
+          Single standardized race/ethnicity category aligned with the 2024 OMB
+          SPD 15 minimum categories (American Indian or Alaska Native, Asian,
+          Black or African American, Hispanic or Latino, Middle Eastern or North
+          African, Native Hawaiian or Pacific Islander, White). Derived from the
+          race and ethnicity columns using a Hispanic-ethnicity-first
+          convention: when ethnicity is Hispanic or Latino the category is
+          Hispanic or Latino, otherwise the mapped race category is used. Values
+          that cannot be classified into an OMB minimum category (other race,
+          asked but unknown, unknown, or missing) are null. Middle Eastern or
+          North African is not present in the legacy race terminology, so it only
+          appears when a source explicitly supplies it. The original race and
+          ethnicity columns are unchanged.
+        config:
+          meta:
+            data_type: varchar
       - name: age
         description: Patient age calculated from birth_date and tuva_last_run.
         config:

--- a/models/core/final/core__patient.sql
+++ b/models/core/final/core__patient.sql
@@ -47,6 +47,7 @@ cast(
     , phone
     , email
     , ethnicity
+    , {{ standardize_race_ethnicity('race', 'ethnicity') }} as race_ethnicity
 {%- endset -%}
 
 {%- set final_metadata_columns -%}


### PR DESCRIPTION
## Summary

Adds a derived, standardized `race_ethnicity` category to `core.patient`, aligned with the 2024 OMB SPD 15 minimum categories (American Indian or Alaska Native, Asian, Black or African American, Hispanic or Latino, Middle Eastern or North African, Native Hawaiian or Pacific Islander, White).

- New `standardize_race_ethnicity` macro collapses the existing `race` and `ethnicity` columns into a single OMB category using a Hispanic-ethnicity-first convention; values that do not map to an OMB minimum category (other race, asked but unknown, unknown, missing) are null.
- `core.patient.race_ethnicity` is populated from this macro.

The change is additive and non-breaking: the existing `race` and `ethnicity` columns are unchanged, no terminology seeds are modified, and `core.patient` has no enforced contract. Middle Eastern or North African is a new OMB category not present in the legacy race terminology, so it is only produced when a source supplies it directly (a follow-up input-layer enhancement).

## Validation

Local DuckDB with synthetic data (`small`):
- Rebuilt `core.patient`; uniqueness and not-null tests pass.
- Verified the derivation against every race/ethnicity combination in the synthetic data. This surfaced (and the PR fixes) a matching issue: source `ethnicity` values are `hispanic`/`non-hispanic` rather than the terminology descriptions, so the macro matches `like 'hispanic%'` (plus `latino`), which captures Hispanic variants while correctly excluding `non-hispanic` and `not hispanic or latino`.

## Release note

enhancement

Closes #1282