### PR TITLE
Update provider seed version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -47,7 +47,7 @@ vars:
     reference_data: "1.0.0"
     terminology: "1.1.1"
     value_sets: "1.0.0"
-    provider_data: "1.0.0"
+    provider_data: "1.2.0"
     synthetic_data: "1.1.0"
   tuva_seed_buckets: {}
 


### PR DESCRIPTION
Updating the version number to `1.2.0` for the latest provider_data seeds released on Dolthub.