### PR TITLE
fix: scope encounter_id ranking by patient_data_source_id across institutional grains

### DIFF
--- a/models/claims_preprocessing/encounters/encounter_models.yml
+++ b/models/claims_preprocessing/encounters/encounter_models.yml
@@ -1065,6 +1065,8 @@ models:
     columns:
       - name: claim_id
         description: 'Unique identifier for a claim. Each claim represents a distinct healthcare service or set of services provided to a patient.'
+      - name: patient_data_source_id
+        description: 'Unique identifier for a patient within a data source.'
       - name: claim_line_number
         description: 'Indicates the line number for the particular line of the claim.'
       - name: encounter_id
@@ -1091,6 +1093,8 @@ models:
     columns:
       - name: claim_id
         description: 'Unique identifier for a claim. Each claim represents a distinct healthcare service or set of services provided to a patient.'
+      - name: patient_data_source_id
+        description: 'Unique identifier for a patient within a data source.'
       - name: claim_line_number
         description: 'Indicates the line number for the particular line of the claim.'
       - name: old_encounter_id

--- a/models/claims_preprocessing/encounters/final/acute_inpatient__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/acute_inpatient__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('acute_inpatient__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/final/emergency_department__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/emergency_department__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('emergency_department__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/final/inpatient_hospice__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_hospice__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('inpatient_hospice__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/final/inpatient_long_term__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_long_term__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('inpatient_long_term__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/final/inpatient_psych__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_psych__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('inpatient_psych__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/final/inpatient_rehab__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_rehab__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('inpatient_rehab__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/final/inpatient_snf__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_snf__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('inpatient_snf__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/final/inpatient_substance_use__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_substance_use__encounter_grain.sql
@@ -20,6 +20,7 @@ with detail_values as (
     and
     cli.claim_line_attribution_number = 1
     inner join {{ ref('inpatient_substance_use__start_end_dates') }} as ed on cli.old_encounter_id = ed.encounter_id
+    and cli.patient_data_source_id = ed.patient_data_source_id
 )
 
 , encounter_cross_walk as (

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__generate_encounter_id.sql
@@ -199,6 +199,14 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__generate_encounter_id.sql
@@ -199,14 +199,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__prof_claims.sql
@@ -23,12 +23,14 @@ with first_claim as (
     from first_claim as f
     inner join {{ ref('acute_inpatient__start_end_dates') }} as dat
         on f.encounter_id = dat.encounter_id
+        and f.patient_data_source_id = dat.patient_data_source_id
 
 )
 
 -- ensuring each prof claim is only attributed to one institutional claim with claim_attribution_number
 select
       dat.encounter_id
+    , dat.patient_data_source_id
     , dat.encounter_start_date
     , dat.encounter_end_date
     , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('acute_inpatient__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__match_claims_to_anchor.sql
@@ -5,6 +5,7 @@
 
 select
     dat.old_encounter_id
+  , med.patient_data_source_id
   , dat.encounter_start_date
   , dat.encounter_end_date
   , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id.sql
@@ -17,7 +17,15 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
   , encounter_id as original_anchor_claim
 from {{ ref('emergency_department__generate_encounter_id_pre_sort') }}

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id.sql
@@ -17,14 +17,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
   , encounter_id as original_anchor_claim

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__prof_claims.sql
@@ -15,12 +15,14 @@ with first_claim as (
     , dat.encounter_start_date
     from first_claim as f
     inner join {{ ref('emergency_department__start_end_dates') }} as dat on f.encounter_id = dat.encounter_id
+    and f.patient_data_source_id = dat.patient_data_source_id
 )
 
 
 -- ensuring each claim is only attributed to one encounter with claim_attribution_number
 , inst_and_prof as (
 select dat.encounter_id
+, dat.patient_data_source_id
 , dat.encounter_start_date
 , dat.encounter_end_date
 , prof.claim_id
@@ -33,6 +35,7 @@ and med.start_date between dat.encounter_start_date and dat.encounter_end_date
 union all
 
 select dat.encounter_id
+, dat.patient_data_source_id
 , dat.encounter_start_date
 , dat.encounter_end_date
 , med.claim_id
@@ -45,6 +48,7 @@ where dat.claim_id <> med.claim_id
 )
 
 select distinct encounter_id
+, patient_data_source_id
 , encounter_start_date
 , encounter_end_date
 , claim_id

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('emergency_department__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
@@ -353,13 +353,7 @@ select
 , patient_data_source_id
 , claim_line_number
 , encounter_id as old_encounter_id
--- Oasis fix: this final dense_rank previously ranked globally on (encounter_type, encounter_id)
--- with no patient scoping. encounter_id at this point can be a bare claim_id-derived value from
--- upstream models, which is only guaranteed unique within (claim_id, claim_line_number,
--- data_source) -- not globally, and a single data_source spans many different patients. Ordering
--- by patient_data_source_id first keeps this a single global sequence (no partition, so ranks
--- don't restart per patient and collide in value downstream) while guaranteeing two different
--- patients' rows never land on the same rank, since their sort tuples always differ.
+-- order by patient_data_source_id first so two different patients' rows never land on the same rank
 , dense_rank() over (
 order by patient_data_source_id, encounter_type, encounter_id) as encounter_id
 , encounter_type

--- a/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
@@ -8,6 +8,7 @@
 
 with cte as (
 select claim_id
+ , patient_data_source_id
  , claim_line_number
  , encounter_id
  , 'acute inpatient' as encounter_type
@@ -21,6 +22,7 @@ union all
 
 /* Intentionally bringing in professional claims assigned to inpatient stays in case admit is assigned to ED  */
 select claim_id
+ , patient_data_source_id
  , claim_line_number
  , encounter_id
  , 'emergency department' as encounter_type
@@ -33,6 +35,7 @@ where claim_attribution_number = 1
 union all
 
 select claim_id
+ , patient_data_source_id
  , claim_line_number
  , encounter_id
  , 'emergency department' as encounter_type
@@ -45,6 +48,7 @@ where claim_attribution_number = 1
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , encounter_id
 , 'inpatient psych' as encounter_type
@@ -57,6 +61,7 @@ where claim_attribution_number = 1
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , encounter_id
 , 'inpatient rehabilitation' as encounter_type
@@ -69,6 +74,7 @@ where claim_attribution_number = 1
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , encounter_id
 , 'inpatient long term acute care' as encounter_type
@@ -81,6 +87,7 @@ where claim_attribution_number = 1
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , encounter_id
 , 'inpatient skilled nursing' as encounter_type
@@ -93,6 +100,7 @@ where claim_attribution_number = 1
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , encounter_id
 , 'inpatient substance use' as encounter_type
@@ -106,6 +114,7 @@ union all
 
 /* Priority of sub office based types from office based group are set within office_visits__int_office_visits_union model */
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , encounter_type
@@ -118,6 +127,7 @@ where encounter_type = 'office visit radiology'
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , encounter_type
@@ -131,6 +141,7 @@ union all
 
 /* urgent care set at lower priority than ed and inpatient to avoid over flagging urgent care due to variations in billing practices */
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'urgent care' as encounter_type
@@ -142,6 +153,7 @@ from {{ ref('urgent_care__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient psych' as encounter_type
@@ -153,6 +165,7 @@ from {{ ref('outpatient_psych__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient rehabilitation' as encounter_type
@@ -164,6 +177,7 @@ from {{ ref('outpatient_rehab__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'ambulatory surgery center' as encounter_type
@@ -175,6 +189,7 @@ from {{ ref('asc__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'dialysis' as encounter_type
@@ -186,6 +201,7 @@ from {{ ref('dialysis__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient hospice' as encounter_type
@@ -197,6 +213,7 @@ from {{ ref('outpatient_hospice__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'home health' as encounter_type
@@ -208,6 +225,7 @@ from {{ ref('home_health__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient surgery' as encounter_type
@@ -219,6 +237,7 @@ from {{ ref('outpatient_surgery__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient injections' as encounter_type
@@ -230,6 +249,7 @@ from {{ ref('outpatient_injections__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient pt/ot/st' as encounter_type
@@ -241,6 +261,7 @@ from {{ ref('outpatient_ptotst__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient substance use' as encounter_type
@@ -252,6 +273,7 @@ from {{ ref('outpatient_substance_use__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient radiology' as encounter_type
@@ -264,6 +286,7 @@ union all
 
 /* Set as lowest outpatient priority "catch all", roll up to more specific encounter type when available */
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'outpatient hospital or clinic' as encounter_type
@@ -275,6 +298,7 @@ from {{ ref('outpatient_hospital_or_clinic__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , encounter_id
 , encounter_type
@@ -288,6 +312,7 @@ union all
 /* orphaned encounters are "last resort". Labs/DME/ambulance should roll up to inpatient/home health/etc. If unable to match, then they get their own encounter*/
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'lab - orphaned' as encounter_type
@@ -299,6 +324,7 @@ from {{ ref('lab__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'dme - orphaned' as encounter_type
@@ -310,6 +336,7 @@ from {{ ref('dme__match_claims_to_anchor') }}
 union all
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'ambulance - orphaned' as encounter_type
@@ -323,10 +350,18 @@ from {{ ref('ambulance__match_claims_to_anchor') }}
 
 select
   claim_id
+, patient_data_source_id
 , claim_line_number
 , encounter_id as old_encounter_id
+-- Oasis fix: this final dense_rank previously ranked globally on (encounter_type, encounter_id)
+-- with no patient scoping. encounter_id at this point can be a bare claim_id-derived value from
+-- upstream models, which is only guaranteed unique within (claim_id, claim_line_number,
+-- data_source) -- not globally, and a single data_source spans many different patients. Ordering
+-- by patient_data_source_id first keeps this a single global sequence (no partition, so ranks
+-- don't restart per patient and collide in value downstream) while guaranteeing two different
+-- patients' rows never land on the same rank, since their sort tuples always differ.
 , dense_rank() over (
-order by encounter_type, encounter_id) as encounter_id
+order by patient_data_source_id, encounter_type, encounter_id) as encounter_id
 , encounter_type
 , encounter_group
 , priority_number

--- a/models/claims_preprocessing/encounters/intermediate/encounters__int_institutional_claim_lines.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__int_institutional_claim_lines.sql
@@ -5,6 +5,7 @@
 
 with unioned as (
     select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'acute inpatient' as encounter_type
 , 'inpatient' as encounter_group
@@ -16,6 +17,7 @@ from {{ ref('acute_inpatient__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'emergency department' as encounter_type
 , 'outpatient' as encounter_group
@@ -27,6 +29,7 @@ from {{ ref('emergency_department__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient hospice' as encounter_type
 , 'inpatient' as encounter_group
@@ -38,6 +41,7 @@ from {{ ref('inpatient_hospice__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient psych' as encounter_type
 , 'inpatient' as encounter_group
@@ -49,6 +53,7 @@ from {{ ref('inpatient_psych__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient rehabilitation' as encounter_type
 , 'inpatient' as encounter_group
@@ -60,6 +65,7 @@ from {{ ref('inpatient_rehab__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient long term acute care' as encounter_type
 , 'inpatient' as encounter_group
@@ -72,6 +78,7 @@ from {{ ref('inpatient_long_term__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient skilled nursing' as encounter_type
 , 'inpatient' as encounter_group
@@ -83,6 +90,7 @@ from {{ ref('inpatient_snf__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient substance use' as encounter_type
 , 'inpatient' as encounter_group
@@ -95,6 +103,7 @@ from {{ ref('inpatient_substance_use__generate_encounter_id') }} as enc
 , final as (
     select
         enc.claim_id
+        , enc.patient_data_source_id
         , med.claim_line_number
         , enc.encounter_id
         , encounter_type

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__generate_encounter_id.sql
@@ -200,6 +200,14 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__generate_encounter_id.sql
@@ -200,14 +200,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__prof_claims.sql
@@ -23,12 +23,14 @@ with first_claim as (
     from first_claim as f
     inner join {{ ref('inpatient_hospice__start_end_dates') }} as dat
          on f.encounter_id = dat.encounter_id
+         and f.patient_data_source_id = dat.patient_data_source_id
 
 )
 
 -- ensuring each prof claim is only attributed to one institutional claim with claim_attribution_number
 select
       dat.encounter_id
+    , dat.patient_data_source_id
     , dat.encounter_start_date
     , dat.encounter_end_date
     , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('inpatient_hospice__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__generate_encounter_id.sql
@@ -200,6 +200,14 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__generate_encounter_id.sql
@@ -200,14 +200,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__prof_claims.sql
@@ -23,12 +23,14 @@ with first_claim as (
     from first_claim as f
     inner join {{ ref('inpatient_long_term__start_end_dates') }} as dat
          on f.encounter_id = dat.encounter_id
+         and f.patient_data_source_id = dat.patient_data_source_id
 
 )
 
 -- ensuring each prof claim is only attributed to one institutional claim with claim_attribution_number
 select
       dat.encounter_id
+    , dat.patient_data_source_id
     , dat.encounter_start_date
     , dat.encounter_end_date
     , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('inpatient_long_term__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__generate_encounter_id.sql
@@ -200,6 +200,14 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__generate_encounter_id.sql
@@ -200,14 +200,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__prof_claims.sql
@@ -23,12 +23,14 @@ with first_claim as (
     from first_claim as f
     inner join {{ ref('inpatient_psych__start_end_dates') }} as dat
         on f.encounter_id = dat.encounter_id
+        and f.patient_data_source_id = dat.patient_data_source_id
 
 )
 
 -- ensuring each prof claim is only attributed to one institutional claim with claim_attribution_number
 select
       dat.encounter_id
+    , dat.patient_data_source_id
     , dat.encounter_start_date
     , dat.encounter_end_date
     , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('inpatient_psych__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__generate_encounter_id.sql
@@ -200,6 +200,14 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__generate_encounter_id.sql
@@ -200,14 +200,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__prof_claims.sql
@@ -23,12 +23,14 @@ with first_claim as (
     from first_claim as f
     inner join {{ ref('inpatient_rehab__start_end_dates') }} as dat
         on f.encounter_id = dat.encounter_id
+        and f.patient_data_source_id = dat.patient_data_source_id
 
 )
 
 -- ensuring each prof claim is only attributed to one institutional claim with claim_attribution_number
 select
       dat.encounter_id
+    , dat.patient_data_source_id
     , dat.encounter_start_date
     , dat.encounter_end_date
     , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('inpatient_rehab__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__generate_encounter_id.sql
@@ -199,6 +199,14 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__generate_encounter_id.sql
@@ -199,14 +199,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__prof_claims.sql
@@ -23,12 +23,14 @@ with first_claim as (
     from first_claim as f
     inner join {{ ref('inpatient_snf__start_end_dates') }} as dat
         on f.encounter_id = dat.encounter_id
+        and f.patient_data_source_id = dat.patient_data_source_id
 
 )
 
 -- ensuring each prof claim is only attributed to one institutional claim with claim_attribution_number
 select
       dat.encounter_id
+    , dat.patient_data_source_id
     , dat.encounter_start_date
     , dat.encounter_end_date
     , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('inpatient_snf__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__generate_encounter_id.sql
@@ -200,6 +200,14 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
+  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
+  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
+  -- a single data_source spans many different patients (patient_data_source_id values). The
+  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
+  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
+  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
+  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
+  -- different patients' rows never land on the same rank, since their sort tuples always differ.
   , dense_rank() over (
-order by encounter_id) as encounter_id
+order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__generate_encounter_id.sql
@@ -200,14 +200,7 @@ order by start_date, end_date, claim_id) as encounter_claim_number
 order by start_date desc, end_date desc, claim_id desc) as encounter_claim_number_desc
   , close_flag
   , min_closing_row
-  -- Oasis fix: encounter_id here is a claim_id, which is only guaranteed unique within
-  -- (claim_id, claim_line_number, data_source) -- not globally, and not even per-patient, since
-  -- a single data_source spans many different patients (patient_data_source_id values). The
-  -- original dense_rank(order by encounter_id) ranked on that bare, collision-prone value, so
-  -- two unrelated patients sharing a data_source could be assigned the same final encounter_id.
-  -- Ordering by patient_data_source_id first keeps this a single global sequence (no partition,
-  -- so ranks don't restart per patient and collide in value downstream) while guaranteeing two
-  -- different patients' rows never land on the same rank, since their sort tuples always differ.
+  -- order by patient_data_source_id first so two different patients' rows never land on the same rank
   , dense_rank() over (
 order by patient_data_source_id, encounter_id) as encounter_id
 from add_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__prof_claims.sql
@@ -23,12 +23,14 @@ with first_claim as (
     from first_claim as f
     inner join {{ ref('inpatient_substance_use__start_end_dates') }} as dat
         on f.encounter_id = dat.encounter_id
+        and f.patient_data_source_id = dat.patient_data_source_id
 
 )
 
 -- ensuring each prof claim is only attributed to one institutional claim with claim_attribution_number
 select
       dat.encounter_id
+    , dat.patient_data_source_id
     , dat.encounter_start_date
     , dat.encounter_end_date
     , med.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__start_end_dates.sql
@@ -3,8 +3,13 @@
    )
 }}
 
+-- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
+-- different patients' rows ever land on the same encounter_id, their date ranges are not
+-- merged together.
 select encounter_id
+, patient_data_source_id
 , min(start_date) as encounter_start_date
 , max(end_date) as encounter_end_date
 from {{ ref('inpatient_substance_use__generate_encounter_id') }}
 group by encounter_id
+, patient_data_source_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__start_end_dates.sql
@@ -3,9 +3,7 @@
    )
 }}
 
--- Oasis fix: group by patient_data_source_id in addition to encounter_id so that if two
--- different patients' rows ever land on the same encounter_id, their date ranges are not
--- merged together.
+-- group by patient_data_source_id too, so rows from different patients aren't merged
 select encounter_id
 , patient_data_source_id
 , min(start_date) as encounter_start_date

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_claim_line.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_claim_line.sql
@@ -10,6 +10,7 @@ from {{ ref('office_visits__int_office_visits_union') }}
 
 , crosswalk_cte as (
 select old_encounter_id
+, patient_data_source_id
 , encounter_type
 from {{ ref('office_visits__int_office_visits_encounter_ranking') }}
 where relative_rank = 1
@@ -18,6 +19,7 @@ where relative_rank = 1
 select r.claim_id
 , r.claim_line_number
 , r.old_encounter_id
+, x.patient_data_source_id
 , x.encounter_type
 from rank_cte as r
 inner join crosswalk_cte as x on r.old_encounter_id = x.old_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_encounter_ranking.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_encounter_ranking.sql
@@ -10,6 +10,7 @@ from {{ ref('office_visits__int_office_visits_union') }}
 
 , dist_encounter as (
 select distinct old_encounter_id
+, patient_data_source_id
 , encounter_type
 , priority_number
 from rank_cte
@@ -17,6 +18,7 @@ from rank_cte
 
 select
 old_encounter_id
+, patient_data_source_id
 , encounter_type
 , priority_number
 , row_number() over (partition by old_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_union.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_union.sql
@@ -5,6 +5,7 @@
 
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'office visit radiology' as encounter_type
@@ -18,6 +19,7 @@ union distinct
 {% endif %}
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'office visit surgery' as encounter_type
@@ -31,6 +33,7 @@ union distinct
 {% endif %}
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'office visit injections' as encounter_type
@@ -44,6 +47,7 @@ union distinct
 {% endif %}
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'office visit pt/ot/st' as encounter_type
@@ -57,6 +61,7 @@ union distinct
 {% endif %}
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'office visit' as encounter_type
@@ -70,6 +75,7 @@ union distinct
 {% endif %}
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'telehealth' as encounter_type
@@ -83,6 +89,7 @@ union distinct
 {% endif %}
 
 select claim_id
+, patient_data_source_id
 , claim_line_number
 , old_encounter_id
 , 'office visit - other' as encounter_type


### PR DESCRIPTION
## Summary

`encounter_id` in each institutional-stay grain's `*__generate_encounter_id.sql` model is derived from `claim_id`, which is only guaranteed unique within `(claim_id, claim_line_number, data_source)` -- not globally, and not even per-patient, since a single `data_source` spans many different patients (`patient_data_source_id` values). The final `dense_rank() over (order by encounter_id)` in each grain ranked on that bare, collision-prone value with no patient scoping, so two unrelated patients sharing a `data_source` could be assigned the same final `encounter_id`.

Confirmed against real data: `core.encounter` had encounters shared by two patients with no overlapping claims, facility, or admission dates -- ruling out any legitimate clinical grouping relationship. This is a concrete instance of the risk described in #785.

## The fix

`dense_rank() over (order by patient_data_source_id, encounter_id) as encounter_id` -- global (not partitioned), ordered by both columns. Two different patients never land on the same rank (their sort tuples always differ), while a single globally consistent sequence means ranks don't restart per patient and collide in value in downstream group-bys/joins (the failure mode of a naive `partition by patient_data_source_id` fix, which we tried first and reverted after it caused new duplicate-key failures downstream).

## Grains fixed (8 "institutional stay" grains)

`acute_inpatient`, `emergency_department`, `inpatient_hospice`, `inpatient_long_term`, `inpatient_psych`, `inpatient_rehab`, `inpatient_snf`, `inpatient_substance_use`

For each grain:
- `*__generate_encounter_id.sql` -- corrected `dense_rank()`
- `*__start_end_dates.sql` -- added `patient_data_source_id` to select/group by
- `*__prof_claims.sql` -- added `patient_data_source_id` to the join against `*__start_end_dates`
- `*__encounter_grain.sql` -- added `patient_data_source_id` to the join against `*__start_end_dates`

## Shared crosswalk model

`encounters__combined_claim_line_crosswalk.sql` unions claim-to-encounter mappings from every encounter grain (not just the 8 above) and does its own final re-key with the same unscoped pattern. This is the model that produces the `encounter_id` ultimately exposed in `core.encounter` for every encounter type. Fixed by threading `patient_data_source_id` through all 20 unioned branches and the final `dense_rank()`, including through `encounters__int_institutional_claim_lines.sql`, `asc__match_claims_to_anchor.sql`, and the `office_visits` intermediate chain.

## Known residual risk (not fixed here)

The 16 other, "anchor-style" grains' `*__encounter_grain.sql` models, `encounters__orphaned_claims.sql`, and `core__stg_claims_medical_claim.sql` join the crosswalk/staging claims on `claim_id + claim_line_number` alone, without `data_source`/`patient_data_source_id` scoping. Per the same uniqueness rule driving this bug, this may be a latent instance of the same collision pattern -- but it's pre-existing, widespread across nearly every crosswalk consumer, and out of scope for this PR. Worth a dedicated follow-up.

## Validation

Validated against a live Snowflake production environment, where it resolved a real, reproducible cross-patient `encounter_id` collision.

Addresses #785 for the specific `dense_rank()`-on-`encounter_id` case; see the residual-risk note above for what's still open.