### PR TITLE
Scope encounter and service category joins by data_source

### DIFF
--- a/models/claims_preprocessing/encounters/encounter_models.yml
+++ b/models/claims_preprocessing/encounters/encounter_models.yml
@@ -1079,7 +1079,12 @@ models:
         description: 'Unique identifier for a claim. Each claim represents a distinct healthcare service or set of services provided to a patient.'
 
   - name: encounters__combined_claim_line_crosswalk
-    description: all claim lines that belong to an encounter
+    description: |-
+      all claim lines that belong to an encounter
+
+      Primary key: claim_id, claim_line_number, data_source, encounter_type.
+      claim_id is only unique within a data_source, so consumers must include
+      data_source when joining this model back to claim-level tables.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_claims_preprocessing
@@ -1093,6 +1098,8 @@ models:
         description: 'Unique identifier for a claim. Each claim represents a distinct healthcare service or set of services provided to a patient.'
       - name: claim_line_number
         description: 'Indicates the line number for the particular line of the claim.'
+      - name: data_source
+        description: 'Indicates the name of the source dataset the claim line came from. Part of the claim-line key: claim_id is only unique within a data_source.'
       - name: old_encounter_id
         description: 'Unique identifier for each encounter in the dataset.'
       - name: encounter_id

--- a/models/claims_preprocessing/encounters/final/acute_inpatient__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/acute_inpatient__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'acute inpatient'
     and
     cli.claim_line_attribution_number = 1
@@ -79,6 +81,8 @@ where claim_type = 'institutional'
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/ambulance__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/ambulance__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'ambulance - orphaned'
     and
     cli.claim_line_attribution_number = 1
@@ -113,6 +115,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/asc__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/asc__encounter_grain.sql
@@ -20,6 +20,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'ambulatory surgery center'
     and
     cli.claim_line_attribution_number = 1
@@ -106,6 +108,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/dialysis__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/dialysis__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'dialysis'
     and
     cli.claim_line_attribution_number = 1
@@ -96,6 +98,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/dme__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/dme__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'dme - orphaned'
     and
     cli.claim_line_attribution_number = 1
@@ -114,6 +116,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/emergency_department__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/emergency_department__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'emergency department'
     and
     cli.claim_line_attribution_number = 1
@@ -111,6 +113,8 @@ group by encounter_id
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/home_health__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/home_health__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'home health'
     and
     cli.claim_line_attribution_number = 1
@@ -98,6 +100,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/inpatient_hospice__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_hospice__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'inpatient hospice'
     and
     cli.claim_line_attribution_number = 1
@@ -104,6 +106,8 @@ group by encounter_id
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/inpatient_long_term__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_long_term__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'inpatient long term acute care'
     and
     cli.claim_line_attribution_number = 1
@@ -105,6 +107,8 @@ group by encounter_id
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/inpatient_psych__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_psych__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'inpatient psych'
     and
     cli.claim_line_attribution_number = 1
@@ -105,6 +107,8 @@ group by encounter_id
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/inpatient_rehab__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_rehab__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'inpatient rehabilitation'
     and
     cli.claim_line_attribution_number = 1
@@ -105,6 +107,8 @@ group by encounter_id
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/inpatient_snf__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_snf__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'inpatient skilled nursing'
     and
     cli.claim_line_attribution_number = 1
@@ -105,6 +107,8 @@ group by encounter_id
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/inpatient_substance_use__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_substance_use__encounter_grain.sql
@@ -16,6 +16,8 @@ with detail_values as (
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'inpatient substance use'
     and
     cli.claim_line_attribution_number = 1
@@ -105,6 +107,8 @@ group by encounter_id
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/lab__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/lab__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'lab - orphaned'
     and
     cli.claim_line_attribution_number = 1
@@ -114,6 +116,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
@@ -105,6 +105,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/orphaned_claim__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/orphaned_claim__encounter_grain.sql
@@ -29,6 +29,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     inner join {{ ref('encounters__orphaned_claims') }} as cli on stg.claim_id = cli.claim_id
     and
     stg.claim_line_number = cli.claim_line_number
+    and
+    stg.data_source = cli.data_source
     inner join encounter_date as d on cli.encounter_id = d.encounter_id
 )
 
@@ -117,6 +119,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_hospice__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_hospice__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient hospice'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_hospital_or_clinic__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_hospital_or_clinic__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient hospital or clinic'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_injections__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_injections__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient injections'
     and
     cli.claim_line_attribution_number = 1
@@ -113,6 +115,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_psych__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_psych__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient psych'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_ptotst__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_ptotst__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient pt/ot/st'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_radiology__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_radiology__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient radiology'
     and
     cli.claim_line_attribution_number = 1
@@ -106,6 +108,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_rehab__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_rehab__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient rehabilitation'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_substance_use__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_substance_use__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient substance use'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/outpatient_surgery__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_surgery__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'outpatient surgery'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/final/urgent_care__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/urgent_care__encounter_grain.sql
@@ -23,6 +23,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_type = 'urgent care'
     and
     cli.claim_line_attribution_number = 1
@@ -99,6 +101,8 @@ order by sum(paid_amount) desc) as paid_order
     left outer join {{ ref('service_category__service_category_grouper') }} as scr on d.claim_id = scr.claim_id
     and
     scr.claim_line_number = d.claim_line_number
+    and
+    scr.data_source = d.data_source
     group by d.encounter_id
 )
 

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__prof_claims.sql
@@ -33,6 +33,7 @@ select
     , dat.encounter_end_date
     , med.claim_id
     , med.claim_line_number
+    , med.data_source
     , row_number() over (
         partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -16,5 +17,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('ambulance__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
     , end_date
@@ -17,5 +18,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__generate_encounter_id.sql
@@ -5,12 +5,14 @@
 with base_data as (
     select distinct
         m.patient_data_source_id
+      , m.data_source
       , m.start_date
       , m.end_date
       , m.claim_id
     from {{ ref('encounters__stg_medical_claim') }} as m
     inner join {{ ref('asc__anchor_events') }} as u
       on m.claim_id = u.claim_id
+      and m.data_source = u.data_source
 )
 
 -- Determine Previous Maximum End Date
@@ -74,6 +76,7 @@ with base_data as (
 -- Merge Encounters with Claims
 select
     nd.patient_data_source_id
+  , nd.data_source
   , nd.start_date
   , nd.end_date
   , nd.claim_id

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__match_claims_to_anchor.sql
@@ -9,8 +9,9 @@ select
   , dat.encounter_end_date
   , med.claim_id
   , med.claim_line_number
+  , med.data_source
   , row_number() over (
-        partition by med.claim_id, med.claim_line_number
+        partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.old_encounter_id
     ) as claim_attribution_number
 from {{ ref('encounters__stg_medical_claim') }} as med

--- a/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -16,5 +17,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('dialysis__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/dme/dme__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dme/dme__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -16,5 +17,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/dme/dme__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dme/dme__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('dme__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/dme/dme__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dme/dme__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__prof_claims.sql
@@ -25,8 +25,10 @@ select dat.encounter_id
 , dat.encounter_end_date
 , prof.claim_id
 , prof.claim_line_number
+, prof.data_source
 from {{ ref('encounters__stg_medical_claim') }} as med
 inner join {{ ref('encounters__stg_professional') }} as prof on med.claim_line_id = prof.claim_line_id
+and med.data_source = prof.data_source
 inner join join_first_claim_dates as dat on med.patient_data_source_id = dat.patient_data_source_id
 and med.start_date between dat.encounter_start_date and dat.encounter_end_date
 
@@ -37,8 +39,10 @@ select dat.encounter_id
 , dat.encounter_end_date
 , med.claim_id
 , med.claim_line_number
+, med.data_source
 from {{ ref('encounters__stg_medical_claim') }} as med
 inner join {{ ref('encounters__stg_outpatient_institutional') }} as inst on med.claim_id = inst.claim_id
+and med.data_source = inst.data_source
 inner join join_first_claim_dates as dat on med.patient_data_source_id = dat.patient_data_source_id
 and med.start_date between dat.encounter_start_date and dat.encounter_end_date
 where dat.claim_id <> med.claim_id
@@ -49,6 +53,7 @@ select distinct encounter_id
 , encounter_end_date
 , claim_id
 , claim_line_number
-, row_number() over (partition by claim_id, claim_line_number
+, data_source
+, row_number() over (partition by claim_id, claim_line_number, data_source
 order by encounter_id) as claim_attribution_number
 from inst_and_prof

--- a/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
@@ -9,6 +9,7 @@
 with cte as (
 select claim_id
  , claim_line_number
+ , data_source
  , encounter_id
  , 'acute inpatient' as encounter_type
  , 'inpatient' as encounter_group
@@ -22,6 +23,7 @@ union all
 /* Intentionally bringing in professional claims assigned to inpatient stays in case admit is assigned to ED  */
 select claim_id
  , claim_line_number
+ , data_source
  , encounter_id
  , 'emergency department' as encounter_type
  , 'outpatient' as encounter_group
@@ -34,6 +36,7 @@ union all
 
 select claim_id
  , claim_line_number
+ , data_source
  , encounter_id
  , 'emergency department' as encounter_type
  , 'outpatient' as encounter_group
@@ -46,6 +49,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , encounter_id
 , 'inpatient psych' as encounter_type
 , 'inpatient' as encounter_group
@@ -58,6 +62,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , encounter_id
 , 'inpatient rehabilitation' as encounter_type
 , 'inpatient' as encounter_group
@@ -70,6 +75,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , encounter_id
 , 'inpatient long term acute care' as encounter_type
 , 'inpatient' as encounter_group
@@ -82,6 +88,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , encounter_id
 , 'inpatient skilled nursing' as encounter_type
 , 'inpatient' as encounter_group
@@ -94,6 +101,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , encounter_id
 , 'inpatient substance use' as encounter_type
 , 'inpatient' as encounter_group
@@ -107,6 +115,7 @@ union all
 /* Priority of sub office based types from office based group are set within office_visits__int_office_visits_union model */
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , encounter_type
 , 'office based' as encounter_group
@@ -119,6 +128,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , encounter_type
 , 'office based' as encounter_group
@@ -132,6 +142,7 @@ union all
 /* urgent care set at lower priority than ed and inpatient to avoid over flagging urgent care due to variations in billing practices */
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'urgent care' as encounter_type
 , 'outpatient' as encounter_group
@@ -143,6 +154,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient psych' as encounter_type
 , 'outpatient' as encounter_group
@@ -154,6 +166,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient rehabilitation' as encounter_type
 , 'outpatient' as encounter_group
@@ -165,6 +178,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'ambulatory surgery center' as encounter_type
 , 'outpatient' as encounter_group
@@ -176,6 +190,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'dialysis' as encounter_type
 , 'outpatient' as encounter_group
@@ -187,6 +202,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient hospice' as encounter_type
 , 'outpatient' as encounter_group
@@ -198,6 +214,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'home health' as encounter_type
 , 'outpatient' as encounter_group
@@ -209,6 +226,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient surgery' as encounter_type
 , 'outpatient' as encounter_group
@@ -220,6 +238,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient injections' as encounter_type
 , 'outpatient' as encounter_group
@@ -231,6 +250,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient pt/ot/st' as encounter_type
 , 'outpatient' as encounter_group
@@ -242,6 +262,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient substance use' as encounter_type
 , 'outpatient' as encounter_group
@@ -253,6 +274,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient radiology' as encounter_type
 , 'outpatient' as encounter_group
@@ -265,6 +287,7 @@ union all
 /* Set as lowest outpatient priority "catch all", roll up to more specific encounter type when available */
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'outpatient hospital or clinic' as encounter_type
 , 'outpatient' as encounter_group
@@ -276,6 +299,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , encounter_id
 , encounter_type
 , encounter_group
@@ -289,6 +313,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'lab - orphaned' as encounter_type
 , 'other' as encounter_group
@@ -300,6 +325,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'dme - orphaned' as encounter_type
 , 'other' as encounter_group
@@ -311,6 +337,7 @@ union all
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'ambulance - orphaned' as encounter_type
 , 'other' as encounter_group
@@ -324,6 +351,7 @@ from {{ ref('ambulance__match_claims_to_anchor') }}
 select
   claim_id
 , claim_line_number
+, data_source
 , encounter_id as old_encounter_id
 , dense_rank() over (
 order by encounter_type, encounter_id) as encounter_id
@@ -331,6 +359,6 @@ order by encounter_type, encounter_id) as encounter_id
 , encounter_group
 , priority_number
 , anchor_claim_id
-, row_number() over (partition by claim_id, claim_line_number
+, row_number() over (partition by claim_id, claim_line_number, data_source
 order by priority_number, case when claim_id = anchor_claim_id then 1 else 99 end) as claim_line_attribution_number
 from cte

--- a/models/claims_preprocessing/encounters/intermediate/encounters__int_institutional_claim_lines.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__int_institutional_claim_lines.sql
@@ -5,6 +5,7 @@
 
 with unioned as (
     select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'acute inpatient' as encounter_type
 , 'inpatient' as encounter_group
@@ -16,6 +17,7 @@ from {{ ref('acute_inpatient__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'emergency department' as encounter_type
 , 'outpatient' as encounter_group
@@ -27,6 +29,7 @@ from {{ ref('emergency_department__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient hospice' as encounter_type
 , 'inpatient' as encounter_group
@@ -38,6 +41,7 @@ from {{ ref('inpatient_hospice__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient psych' as encounter_type
 , 'inpatient' as encounter_group
@@ -49,6 +53,7 @@ from {{ ref('inpatient_psych__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient rehabilitation' as encounter_type
 , 'inpatient' as encounter_group
@@ -60,6 +65,7 @@ from {{ ref('inpatient_rehab__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient long term acute care' as encounter_type
 , 'inpatient' as encounter_group
@@ -72,6 +78,7 @@ from {{ ref('inpatient_long_term__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient skilled nursing' as encounter_type
 , 'inpatient' as encounter_group
@@ -83,6 +90,7 @@ from {{ ref('inpatient_snf__generate_encounter_id') }} as enc
 union all
 
 select enc.claim_id
+, enc.patient_data_source_id
 , enc.encounter_id
 , 'inpatient substance use' as encounter_type
 , 'inpatient' as encounter_group
@@ -96,6 +104,7 @@ from {{ ref('inpatient_substance_use__generate_encounter_id') }} as enc
     select
         enc.claim_id
         , med.claim_line_number
+        , med.data_source
         , enc.encounter_id
         , encounter_type
         , encounter_group
@@ -103,6 +112,7 @@ from {{ ref('inpatient_substance_use__generate_encounter_id') }} as enc
         , anchor_claim_id
     from unioned as enc
     inner join {{ ref('encounters__stg_medical_claim') }} as med on enc.claim_id = med.claim_id
+        and enc.patient_data_source_id = med.patient_data_source_id
 )
 
 select * from final

--- a/models/claims_preprocessing/encounters/intermediate/encounters__orphaned_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__orphaned_claims.sql
@@ -15,10 +15,13 @@ with cte as (
   , stg.start_date
   , stg.end_date
   , stg.patient_data_source_id
+  , stg.data_source
   from {{ ref('encounters__stg_medical_claim') }} as stg
   left outer join {{ ref('encounters__combined_claim_line_crosswalk') }} as enc on stg.claim_id = enc.claim_id
   and
   stg.claim_line_number = enc.claim_line_number
+  and
+  stg.data_source = enc.data_source
   where enc.claim_id is null -- missing from encounter mapping table
 )
 
@@ -30,6 +33,7 @@ with cte as (
 select
   claim_id
 , claim_line_number
+, data_source
 , dense_rank() over (
 order by patient_data_source_id, claim_id) + max_encounter.max_encounter_id as encounter_id
 , 'orphaned claim' as encounter_type

--- a/models/claims_preprocessing/encounters/intermediate/home_health/home_health__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/home_health/home_health__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -16,5 +17,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/home_health/home_health__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/home_health/home_health__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('home_health__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/home_health/home_health__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/home_health/home_health__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__prof_claims.sql
@@ -33,6 +33,7 @@ select
     , dat.encounter_end_date
     , med.claim_id
     , med.claim_line_number
+    , med.data_source
     , row_number() over (
         partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__prof_claims.sql
@@ -33,6 +33,7 @@ select
     , dat.encounter_end_date
     , med.claim_id
     , med.claim_line_number
+    , med.data_source
     , row_number() over (
         partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__prof_claims.sql
@@ -33,6 +33,7 @@ select
     , dat.encounter_end_date
     , med.claim_id
     , med.claim_line_number
+    , med.data_source
     , row_number() over (
         partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__prof_claims.sql
@@ -33,6 +33,7 @@ select
     , dat.encounter_end_date
     , med.claim_id
     , med.claim_line_number
+    , med.data_source
     , row_number() over (
         partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__prof_claims.sql
@@ -33,6 +33,7 @@ select
     , dat.encounter_end_date
     , med.claim_id
     , med.claim_line_number
+    , med.data_source
     , row_number() over (
         partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__prof_claims.sql
@@ -33,6 +33,7 @@ select
     , dat.encounter_end_date
     , med.claim_id
     , med.claim_line_number
+    , med.data_source
     , row_number() over (
         partition by med.claim_id, med.claim_line_number, med.data_source
         order by dat.encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/lab/lab__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/lab/lab__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -16,5 +17,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/lab/lab__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/lab/lab__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('lab__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/lab/lab__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/lab/lab__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_detail_values.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_detail_values.sql
@@ -80,6 +80,8 @@ order by stg.claim_type, stg.start_date) as encounter_row_number --institutional
     and
     stg.claim_line_number = cli.claim_line_number
     and
+    stg.data_source = cli.data_source
+    and
     cli.encounter_group = 'office based'
     and
     cli.claim_line_attribution_number = 1

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits.sql
@@ -6,6 +6,7 @@
 with anchor as (
     select distinct
         mc.patient_data_source_id
+      , mc.data_source
       , mc.start_date
       , mc.claim_id
       , mc.claim_line_number
@@ -16,11 +17,13 @@ with anchor as (
     inner join {{ ref('service_category__combined_professional') }} as p -- joining in all sc regardless of final priority
       on mc.claim_id = p.claim_id
       and mc.claim_line_number = p.claim_line_number
+      and mc.data_source = p.data_source
     where p.service_category_1 = 'office-based'
 )
 
 select
     patient_data_source_id
+  , data_source
   , start_date
   , claim_id
   , claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_claim_line.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_claim_line.sql
@@ -17,6 +17,7 @@ where relative_rank = 1
 
 select r.claim_id
 , r.claim_line_number
+, r.data_source
 , r.old_encounter_id
 , x.encounter_type
 from rank_cte as r

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_em.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_em.sql
@@ -5,6 +5,7 @@
 
 select distinct
     ov.patient_data_source_id
+    , ov.data_source
     , ov.start_date
     , ov.claim_id
     , ov.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_injections.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_injections.sql
@@ -5,6 +5,7 @@
 
 select distinct
     ov.patient_data_source_id
+    , ov.data_source
     , ov.start_date
     , ov.claim_id
     , ov.claim_line_number
@@ -12,4 +13,5 @@ select distinct
 from {{ ref('office_visits__int_office_visits') }} as ov
 inner join {{ ref('encounters__stg_medical_claim') }} as mc on mc.claim_id = ov.claim_id
     and mc.claim_line_number = ov.claim_line_number
+    and mc.data_source = ov.data_source
 where substring(hcpcs_code, 1, 1) = 'J'

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_ptotst.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_ptotst.sql
@@ -5,6 +5,7 @@
 
 select distinct
     ov.patient_data_source_id
+    , ov.data_source
     , ov.start_date
     , ov.claim_id
     , ov.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_radiology.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_radiology.sql
@@ -10,6 +10,7 @@ with max_encounter as (
 
 select distinct
     ov.patient_data_source_id
+    , ov.data_source
     , ov.start_date
     , ov.claim_id
     , ov.claim_line_number
@@ -20,5 +21,7 @@ from {{ ref('office_visits__int_office_visits') }} as ov
 cross join max_encounter as mx
 inner join {{ ref('encounters__stg_medical_claim') }} as mc on mc.claim_id = ov.claim_id
     and mc.claim_line_number = ov.claim_line_number
+    and mc.data_source = ov.data_source
 inner join {{ ref('service_category__office_based_radiology') }} as scrad on mc.claim_id = scrad.claim_id
     and mc.claim_line_number = scrad.claim_line_number
+    and mc.data_source = scrad.data_source

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_surgery.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_surgery.sql
@@ -5,6 +5,7 @@
 
 select distinct
     ov.patient_data_source_id
+    , ov.data_source
     , ov.start_date
     , ov.claim_id
     , ov.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_telehealth.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_telehealth.sql
@@ -5,6 +5,7 @@
 
 select distinct
     ov.patient_data_source_id
+    , ov.data_source
     , ov.start_date
     , ov.claim_id
     , ov.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_union.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_union.sql
@@ -6,6 +6,7 @@
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'office visit radiology' as encounter_type
 , 0 as priority_number
@@ -19,6 +20,7 @@ union distinct
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'office visit surgery' as encounter_type
 , 1 as priority_number
@@ -32,6 +34,7 @@ union distinct
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'office visit injections' as encounter_type
 , 2 as priority_number
@@ -45,6 +48,7 @@ union distinct
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'office visit pt/ot/st' as encounter_type
 , 3 as priority_number
@@ -58,6 +62,7 @@ union distinct
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'office visit' as encounter_type
 , 4 as priority_number
@@ -71,6 +76,7 @@ union distinct
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'telehealth' as encounter_type
 , 5 as priority_number
@@ -84,6 +90,7 @@ union distinct
 
 select claim_id
 , claim_line_number
+, data_source
 , old_encounter_id
 , 'office visit - other' as encounter_type
 , 9999 as priority_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -16,5 +17,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('outpatient_hospice__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
     select distinct
         claim_id
+      , data_source
       , patient_data_source_id
       , start_date
     from {{ ref('encounters__stg_medical_claim') }}
@@ -18,5 +19,6 @@ with service_category as (
 
 select distinct
     claim_id
+  , data_source
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('outpatient_hospital_or_clinic__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__anchor_events.sql
@@ -6,16 +6,19 @@
 with multiple_sources as (
 select distinct
     med.patient_data_source_id
+    , med.data_source
     , med.start_date
 from {{ ref('encounters__stg_medical_claim') }} as med
 inner join {{ ref('encounters__stg_outpatient_institutional') }} as outpatient
     on med.claim_id = outpatient.claim_id
+    and med.data_source = outpatient.data_source
 where substring(med.hcpcs_code, 1, 1) = 'J'
 )
 
 
 select distinct
     patient_data_source_id
+    , data_source
     , start_date
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from multiple_sources

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__generate_encounter_id.sql
@@ -4,6 +4,7 @@
 }}
 
 select patient_data_source_id
+, data_source
 , start_date
 , dense_rank() over (
 order by patient_data_source_id, start_date) as old_encounter_id

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -15,5 +16,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('outpatient_psych__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -15,5 +16,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('outpatient_ptotst__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
     patient_data_source_id
+    , data_source
     , start_date
     , hcpcs_code
   from {{ ref('encounters__stg_medical_claim') }}
@@ -15,6 +16,7 @@ with service_category as (
 
 select distinct
     patient_data_source_id
+    , data_source
     , start_date
     , hcpcs_code
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__generate_encounter_id.sql
@@ -4,6 +4,7 @@
 }}
 
 select patient_data_source_id
+, data_source
 , start_date
 , hcpcs_code
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -15,5 +16,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('outpatient_rehab__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -16,5 +17,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__generate_encounter_id.sql
@@ -4,13 +4,17 @@
 }}
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('outpatient_substance_use__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__anchor_events.sql
@@ -6,6 +6,7 @@
 with service_category as (
   select distinct
       claim_id
+    , data_source
     , patient_data_source_id
     , start_date
   from {{ ref('encounters__stg_medical_claim') }}
@@ -15,5 +16,6 @@ with service_category as (
 
 select distinct
 claim_id
+, data_source
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from service_category

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__generate_encounter_id.sql
@@ -4,13 +4,17 @@
 }}
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('outpatient_surgery__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__anchor_events.sql
@@ -5,6 +5,7 @@
 
   select distinct
       claim_id
+    , data_source
   from {{ ref('encounters__stg_medical_claim') }}
   where
     service_category_2 in ('urgent care') --both inst and prof anchor

--- a/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__generate_encounter_id.sql
@@ -5,13 +5,17 @@
 
 with anchor as (
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
 from {{ ref('encounters__stg_medical_claim') }} as m
 inner join {{ ref('urgent_care__anchor_events') }} as u on m.claim_id = u.claim_id
+and
+m.data_source = u.data_source
 )
 
 select patient_data_source_id
+, data_source
 , start_date
 , claim_id
 , dense_rank() over (

--- a/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__match_claims_to_anchor.sql
@@ -4,6 +4,7 @@
 }}
 
 select distinct m.patient_data_source_id
+ , m.data_source
  , m.start_date
  , m.claim_id
  , m.claim_line_number

--- a/models/claims_preprocessing/encounters/staging/encounters__stg_inpatient_institutional.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__stg_inpatient_institutional.sql
@@ -5,6 +5,7 @@
 
 select
   claim_id
+, data_source
 , service_type
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('service_category__stg_inpatient_institutional') }} as a

--- a/models/claims_preprocessing/encounters/staging/encounters__stg_outpatient_institutional.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__stg_outpatient_institutional.sql
@@ -6,6 +6,7 @@
 
 select
   claim_id
+, data_source
 , service_type
 , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('service_category__stg_outpatient_institutional') }} as a

--- a/models/claims_preprocessing/provider_attribution/staging/provider_attribution__stg_medical_claim.sql
+++ b/models/claims_preprocessing/provider_attribution/staging/provider_attribution__stg_medical_claim.sql
@@ -7,6 +7,7 @@ with all_encounters as (
     select
         claim_id
       , claim_line_number
+      , data_source
       , encounter_id
     from {{ ref('encounters__combined_claim_line_crosswalk') }}
     where claim_line_attribution_number = 1
@@ -16,6 +17,7 @@ with all_encounters as (
     select
         claim_id
       , claim_line_number
+      , data_source
       , encounter_id
     from {{ ref('encounters__orphaned_claims') }}
 )
@@ -36,7 +38,9 @@ from {{ ref('normalized__medical_claim') }} as med
 inner join {{ ref('service_category__service_category_grouper') }} as srv_group
   on med.claim_id = srv_group.claim_id
   and med.claim_line_number = srv_group.claim_line_number
+  and med.data_source = srv_group.data_source
   and srv_group.duplicate_row_number = 1
 inner join all_encounters as enc
   on med.claim_id = enc.claim_id
   and med.claim_line_number = enc.claim_line_number
+  and med.data_source = enc.data_source

--- a/models/claims_preprocessing/service_category/final/service_category__service_category_grouper.sql
+++ b/models/claims_preprocessing/service_category/final/service_category__service_category_grouper.sql
@@ -113,7 +113,7 @@ with service_category_1_mapping as (
         , original_service_cat_2
         , original_service_cat_3
         , source_model_name
-        , row_number() over (partition by claim_id, claim_line_number
+        , row_number() over (partition by claim_id, claim_line_number, data_source
 order by coalesce(priority, 99999)) as duplicate_row_number
     from service_category_1_mapping
 )

--- a/models/claims_preprocessing/service_category/intermediate/service_category__dialysis_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__dialysis_institutional.sql
@@ -14,6 +14,7 @@ select distinct
 from {{ ref('service_category__stg_medical_claim') }} as med
 inner join {{ ref('service_category__stg_outpatient_institutional') }} as outpatient
   on med.claim_id = outpatient.claim_id
+  and med.data_source = outpatient.data_source
 where
   substring(med.bill_type_code, 1, 2) in ('72')
   or med.primary_taxonomy_code in (

--- a/models/core/final/core__medical_claim.sql
+++ b/models/core/final/core__medical_claim.sql
@@ -89,6 +89,7 @@ with all_encounters as (
     select
         claim_id
         , claim_line_number
+        , data_source
         , encounter_id
         , encounter_type
         , encounter_group
@@ -100,6 +101,7 @@ with all_encounters as (
     select
         claim_id
         , claim_line_number
+        , data_source
         , encounter_id
         , encounter_type
         , encounter_group
@@ -114,10 +116,12 @@ from {{ ref('normalized__medical_claim') }} as med
 inner join {{ ref('service_category__service_category_grouper') }} as srv_group
     on med.claim_id = srv_group.claim_id
     and med.claim_line_number = srv_group.claim_line_number
+    and med.data_source = srv_group.data_source
     and srv_group.duplicate_row_number = 1
 inner join all_encounters as x
     on med.claim_id = x.claim_id
     and med.claim_line_number = x.claim_line_number
+    and med.data_source = x.data_source
 left outer join {{ ref('claims_enrollment__flag_claims_with_enrollment') }} as enroll
     on med.claim_id = enroll.claim_id
     and med.claim_line_number = enroll.claim_line_number

--- a/models/core/intermediate/int_condition_from_claims.sql
+++ b/models/core/intermediate/int_condition_from_claims.sql
@@ -7,6 +7,7 @@ with encounter_crosswalk as (
     select
         claim_id
         , claim_line_number
+        , data_source
         , encounter_id
     from {{ ref('encounters__combined_claim_line_crosswalk') }}
     where claim_line_attribution_number = 1
@@ -37,6 +38,7 @@ with encounter_crosswalk as (
     left join encounter_crosswalk as enc
         on diag.claim_id = enc.claim_id
         and diag.claim_line_number = enc.claim_line_number
+        and diag.data_source = enc.data_source
 )
 
 select distinct

--- a/models/core/intermediate/int_procedure_from_claims.sql
+++ b/models/core/intermediate/int_procedure_from_claims.sql
@@ -7,6 +7,7 @@ with encounter_crosswalk as (
     select
         claim_id
         , claim_line_number
+        , data_source
         , encounter_id
     from {{ ref('encounters__combined_claim_line_crosswalk') }}
     where claim_line_attribution_number = 1
@@ -15,6 +16,7 @@ with encounter_crosswalk as (
 , distinct_claim_encounters as (
     select distinct
         claim_id
+        , data_source
         , encounter_id
     from encounter_crosswalk
 )
@@ -45,6 +47,7 @@ with encounter_crosswalk as (
     left join encounter_crosswalk as enc
         on procedure_source.claim_id = enc.claim_id
         and procedure_source.claim_line_number = enc.claim_line_number
+        and procedure_source.data_source = enc.data_source
     where procedure_source.claim_line_number is not null
 )
 
@@ -73,6 +76,7 @@ with encounter_crosswalk as (
     from {{ ref('normalized__medical_claim_procedures') }} as procedure_source
     left join distinct_claim_encounters as enc
         on procedure_source.claim_id = enc.claim_id
+        and procedure_source.data_source = enc.data_source
     where procedure_source.claim_line_number is null
 )
 

--- a/tests/test_encounter_id_single_data_source.sql
+++ b/tests/test_encounter_id_single_data_source.sql
@@ -1,0 +1,28 @@
+{{ config(
+     enabled = var('claims_enabled', False) | as_bool
+   )
+}}
+
+/*
+  claim_id is only unique within a data_source (the input-layer primary key is
+  claim_id + claim_line_number + data_source), so any join keyed on claim_id
+  alone can pull claim lines from a second source into an encounter. An
+  encounter that spans more than one data_source is always that bug, never a
+  legitimate grouping.
+*/
+
+select
+    encounter_id
+  , count(distinct data_source) as data_source_count
+from {{ ref('encounters__combined_claim_line_crosswalk') }}
+group by encounter_id
+having count(distinct data_source) > 1
+
+union all
+
+select
+    encounter_id
+  , count(distinct data_source) as data_source_count
+from {{ ref('encounters__orphaned_claims') }}
+group by encounter_id
+having count(distinct data_source) > 1


### PR DESCRIPTION
`claim_id` is only unique within a `data_source` — the declared primary key in
`input_layer__medical_claim.yml` is claim_id + claim_line_number + data_source,
and that combination is the only uniqueness test the package enforces. So any
join keyed on `claim_id` (or `claim_id + claim_line_number`) alone can pair
claim lines that belong to two different source systems, which merges unrelated
patients into one encounter.

### What changed

- `encounters__combined_claim_line_crosswalk` and `encounters__orphaned_claims`
  publish `data_source`, and `claim_line_attribution_number` is ranked within
  claim_id + claim_line_number + data_source instead of across sources.
- Every consumer of the crosswalk, the orphaned-claims model and
  `service_category__service_category_grouper` joins on `data_source`: the 26
  encounter grains, `core__medical_claim`, `int_condition_from_claims`,
  `int_procedure_from_claims` and `provider_attribution__stg_medical_claim`.
- The anchor-event lookups and the institutional/outpatient service-type
  lookups carry `data_source` so the per-grain encounter-id models can scope
  their joins back to the claim table.
- `service_category__service_category_grouper` deduplicates within
  claim_id + claim_line_number + data_source. Previously two claim lines with
  the same id in different sources competed for one winning service category,
  and the loser was dropped by every consumer filtering
  `duplicate_row_number = 1`.
- `encounters__int_institutional_claim_lines` fans an encounter out to its claim
  lines within the same patient and source, rather than to every claim that
  happens to share a `claim_id`.
- Adds `tests/test_encounter_id_single_data_source.sql`: an encounter that spans
  more than one `data_source` is flagged

### Verification

Built on DuckDB against synthetic claims containing two data sources that reuse
the same `claim_id` values for different patients:

- claim ids that exist in only one source: encounter grouping and attribution
  are identical before and after, so single-source deployments see no
  change at all.
- claim ids reused across sources: 2 encounter ids spanned two data sources
  before, 0 after. `core.encounter` went from 44 rows / 41 distinct
  encounter_ids to 42 / 42.
- the existing
  `dbt_utils_unique_combination_of_columns_core__encounter_encounter_id__data_source`
  test **fails on `tuva-1.0` today and passes with this change**.

### Warehouse Compatibility

The changes are plain join predicates and `partition by` clauses
with no adapter-specific syntax, so I would not expect warehouse-specific
behaviour, but this touches 100+ files and I would rather that be confirmed than
assumed. Please run Snowflake, BigQuery, Databricks, Redshift and Fabric before
merging
