### PR TITLE
Fix hcc_recapture uniqueness grain to include reason

### DIFF
--- a/models/data_marts/hcc_recapture/final_models.yml
+++ b/models/data_marts/hcc_recapture/final_models.yml
@@ -304,6 +304,7 @@ models:
               - filtered_by_hierarchy_flag
               - hcc_type
               - hcc_source
+              - reason
     columns:
       - name: person_id
         description: A unique identifier for a person.
@@ -432,6 +433,14 @@ models:
         tests:
           - accepted_values:
               values: [ 'payer', 'clinical' ]
+        config:
+          meta:
+            data_type: varchar
+            is_primary_key: true
+      - name: reason
+        description: >
+          Explains how the HCC was identified. The same HCC can appear more than once for a person when it is found for
+          different reasons (for example, Observation suspect vs Medication suspect).
         config:
           meta:
             data_type: varchar

--- a/models/data_marts/hcc_recapture/intermediate/hccs/hcc_recapture__int_recapturable_hccs.sql
+++ b/models/data_marts/hcc_recapture/intermediate/hccs/hcc_recapture__int_recapturable_hccs.sql
@@ -53,6 +53,7 @@ select
     , base.recapturable_flag
     , base.hcc_type
     , base.hcc_source
+    , base.reason
     , CASE WHEN mhier.hcc_hierarchy_group IS NOT NULL THEN 0 ELSE 1 END as filtered_by_hierarchy_flag
 from base
 left join min_hierarchy as mhier

--- a/models/data_marts/hcc_recapture/intermediate_models.yml
+++ b/models/data_marts/hcc_recapture/intermediate_models.yml
@@ -27,6 +27,7 @@ models:
               - external_hcc_flag
               - hcc_type
               - hcc_source
+              - reason
     columns:
       - name: person_id
         description: A unique identifier for a person.
@@ -72,6 +73,10 @@ models:
         description: >
           Whether the claim is eligible for risk adjustment as determined based on a list of accepted CPT/HCPCs codes from CMS. These are available
           on the CMS risk adjustment website: https://www.cms.gov/medicare/payment/medicare-advantage-rates-statistics/risk-adjustment
+      - name: reason
+        description: >
+          Explains how the HCC was identified. The same HCC can appear more than once for a person when it is found for
+          different reasons (for example, Observation suspect vs Medication suspect).
   
   - name: hcc_recapture__int_gap_status
     description: >
@@ -228,6 +233,7 @@ models:
               - claim_id
               - hcc_type
               - hcc_source
+              - reason
     columns:
       - name: person_id
         description: A unique identifier for a person.
@@ -272,7 +278,11 @@ models:
       - name: eligible_claim_flag
         description: >
           Whether the claim is eligible for risk adjustment as determined based on a list of accepted CPT/HCPCs codes from CMS. These are available
-          on the CMS risk adjustment website: https://www.cms.gov/medicare/payment/medicare-advantage-rates-statistics/risk-adjustment               
+          on the CMS risk adjustment website: https://www.cms.gov/medicare/payment/medicare-advantage-rates-statistics/risk-adjustment
+      - name: reason
+        description: >
+          Explains how the HCC was identified. The same HCC can appear more than once for a person when it is found for
+          different reasons (for example, Observation suspect vs Medication suspect).
 
   - name: hcc_recapture__int_suspect_hccs
     description: Suspect HCCs which are identified from sources besides medical claims conditions.
@@ -295,6 +305,7 @@ models:
             - hcc_type
             - hcc_source
             - claim_id
+            - reason
     columns:
       - name: person_id
         description: A unique identifier for a person.
@@ -317,6 +328,10 @@ models:
           This is the year that the HCC should be coded. Typically the collection year + 1, but for open HCCs it will be the collection year + 2. 
           To illustrate, if we have an HCC claim in 2023, but not in 2024, that means it is open in 2024. The payment year is 2024 + 1 = 2025. So 
           an open HCC from 2023 will have a payment year = 2025.
+      - name: reason
+        description: >
+          Explains how the HCC was identified. The same HCC can appear more than once for a person when it is found for
+          different reasons (for example, Observation suspect vs Medication suspect).
       - name: recapture_flag
         description: > 
           Whether or not the HCC is recapturable. Includes the following values:


### PR DESCRIPTION
## Summary
- `hcc_recapture` uniqueness tests treated multiple suspecting reasons for the same HCC as duplicates because the grain omitted `reason` (the 0.17.2 `int_hccs` bug used `suspect_hcc_flag`; on current main the successor models still omit `reason` even after `hcc_type` / `hcc_source`).
- Add `reason` to the uniqueness grain for `int_all_hccs`, `int_suspect_hccs`, `int_recapturable_hccs` (the `int_hccs` successor), and final `hcc_status`.
- Pass `reason` through `hcc_recapture__int_recapturable_hccs` so the uniqueness test matches the model grain.

## Validation
- `scripts/dbt-local deps` (dbt-core 1.11.7 / DuckDB)
- `scripts/dbt-local build --select +hcc_recapture__hcc_status --full-refresh`
- Affected uniqueness tests passed:
  - `...int_suspect_hccs...__reason`
  - `...int_all_hccs...__reason`
  - `...int_recapturable_hccs...__reason`
  - `...hcc_status...__reason`
- Unrelated upstream relationship / extension-column failures on synthetic data remain outside this change

Release-note label: bug

Closes #1373