### PR TITLE
Use `schema` instead of `target_schema` on snapshots

### DIFF
--- a/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
@@ -6,7 +6,7 @@
 
 {{
   config({
-      "target_schema": schema_var
+      "schema": schema_var
     , "alias": "patient_risk_factors_snapshot"
     , "tags": "cms_hcc"
     , "strategy": "check"

--- a/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
@@ -6,7 +6,7 @@
 
 {{
   config({
-      "target_schema": schema_var
+      "schema": schema_var
     , "alias": "patient_risk_scores_snapshot"
     , "tags": "cms_hcc"
     , "strategy": "check"

--- a/snapshots/quality_measures/quality_measures__summary_counts_snapshot.sql
+++ b/snapshots/quality_measures/quality_measures__summary_counts_snapshot.sql
@@ -6,7 +6,7 @@
 
 {{
   config({
-      "target_schema": schema_var
+      "schema": schema_var
     , "alias": "summary_counts_snapshot"
     , "tags": "quality_measures"
     , "strategy": "check"

--- a/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
+++ b/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
@@ -6,7 +6,7 @@
 
 {{
   config({
-      "target_schema": schema_var
+      "schema": schema_var
     , "alias": "summary_long_snapshot"
     , "tags": "quality_measures"
     , "strategy": "check"


### PR DESCRIPTION
## Summary

- Switch the four snapshots (`cms_hcc__patient_risk_factors_snapshot`,
  `cms_hcc__patient_risk_scores_snapshot`, `quality_measures__summary_counts_snapshot`,
  `quality_measures__summary_long_snapshot`) from `target_schema` to `schema` in their
  `config()` blocks.
- `target_schema` is applied literally and bypasses `generate_schema_name`, so snapshots
  ignored deployer schema customization (e.g. custom prefixes/suffixes and the
  `GITHUB_RUN_ID` CI prefix) while every model in the same mart honored it. Using `schema`
  routes snapshots through the same macro as the rest of the project.
- Also removes the last uses of `target_schema`, which dbt deprecated in favor of `schema`
  for snapshots (project requires dbt >= 1.10).

## Behavior change

- Snapshot relations now land in the same custom-schema namespace as their mart models.
  Deployments that were relying on the literal `<prefix>_cms_hcc` / `<prefix>_quality_measures`
  paths and that also override `generate_schema_name` may see snapshots move to a new schema;
  no change for the default (unmodified) configuration.

## Validation

- `dbt build --vars '{snapshots_enabled: true, claims_enabled: true}'` — snapshots build and
  land in the expected schema.
- Re-ran with a custom `tuva_schema_prefix` and confirmed snapshot schemas match their mart
  models.

## Release note label

- fix