### PR TITLE
fix(quality-measures): dedupe long models before join, not after

### DIFF
--- a/models/data_marts/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_long.sql
+++ b/models/data_marts/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_long.sql
@@ -3,7 +3,7 @@
    )
 }}
 
-with denominator as (
+with denominator_ranked as (
 
     select
           person_id
@@ -13,7 +13,49 @@ with denominator as (
         , measure_name
         , measure_version
         , denominator_flag
+        , row_number() over (
+            partition by
+                  person_id
+                , performance_period_begin
+                , performance_period_end
+                , measure_id
+                , measure_name
+            order by
+                case when performance_period_end is null then 1 else 0 end
+                , performance_period_end desc
+          ) as rn
     from {{ ref('quality_measures__int_adh_statins_denominator') }}
+
+)
+
+, denominator as (
+
+    select
+          person_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from denominator_ranked
+    where rn = 1
+
+)
+
+, numerator_ranked as (
+
+    select
+          person_id
+        , evidence_date
+        , evidence_value
+        , row_number() over (
+            partition by person_id
+            order by
+                case when evidence_date is null then 1 else 0 end
+                , evidence_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_adh_statins_numerator') }}
 
 )
 
@@ -23,7 +65,24 @@ with denominator as (
           person_id
         , evidence_date
         , evidence_value
-    from {{ ref('quality_measures__int_adh_statins_numerator') }}
+    from numerator_ranked
+    where rn = 1
+
+)
+
+, exclusions_ranked as (
+
+    select
+          person_id
+        , exclusion_date
+        , exclusion_reason
+        , row_number() over (
+            partition by person_id
+            order by
+                case when exclusion_date is null then 1 else 0 end
+                , exclusion_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_adh_statins_exclusions') }}
 
 )
 
@@ -33,7 +92,8 @@ with denominator as (
           person_id
         , exclusion_date
         , exclusion_reason
-    from {{ ref('quality_measures__int_adh_statins_exclusions') }}
+    from exclusions_ranked
+    where rn = 1
 
 )
 
@@ -69,45 +129,11 @@ with denominator as (
         , denominator.measure_id
         , denominator.measure_name
         , denominator.measure_version
-        , (row_number() over (
-            partition by
-                  denominator.person_id
-                , denominator.performance_period_begin
-                , denominator.performance_period_end
-                , denominator.measure_id
-                , denominator.measure_name
-              order by
-                  case when numerator.evidence_date is null then 1 else 0 end
-                  , numerator.evidence_date desc
-                , case when exclusions.exclusion_date is null then 1 else 0 end
-                  , exclusions.exclusion_date desc
-          )) as rn
     from denominator
         left outer join numerator
             on denominator.person_id = numerator.person_id
         left outer join exclusions
             on denominator.person_id = exclusions.person_id
-
-)
-
-, deduped as (
-
-    select
-          person_id
-        , denominator_flag
-        , numerator_flag
-        , exclusion_flag
-        , evidence_date
-        , evidence_value
-        , exclusion_date
-        , exclusion_reason
-        , performance_period_begin
-        , performance_period_end
-        , measure_id
-        , measure_name
-        , measure_version
-    from measure_flags
-    where rn = 1
 
 )
 
@@ -127,7 +153,7 @@ with denominator as (
         , cast(measure_id as {{ dbt.type_string() }}) as measure_id
         , cast(measure_name as {{ dbt.type_string() }}) as measure_name
         , cast(measure_version as {{ dbt.type_string() }}) as measure_version
-    from deduped
+    from measure_flags
 
 )
 

--- a/models/data_marts/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_long.sql
+++ b/models/data_marts/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_long.sql
@@ -3,7 +3,7 @@
    )
 }}
 
-with denominator as (
+with denominator_ranked as (
 
     select
           person_id
@@ -13,7 +13,49 @@ with denominator as (
         , measure_name
         , measure_version
         , denominator_flag
+        , row_number() over (
+            partition by
+                  person_id
+                , performance_period_begin
+                , performance_period_end
+                , measure_id
+                , measure_name
+            order by
+                case when performance_period_end is null then 1 else 0 end
+                , performance_period_end desc
+          ) as rn
     from {{ ref('quality_measures__int_adh_diabetes_denominator') }}
+
+)
+
+, denominator as (
+
+    select
+          person_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from denominator_ranked
+    where rn = 1
+
+)
+
+, numerator_ranked as (
+
+    select
+          person_id
+        , evidence_date
+        , evidence_value
+        , row_number() over (
+            partition by person_id
+            order by
+                case when evidence_date is null then 1 else 0 end
+                , evidence_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_adh_diabetes_numerator') }}
 
 )
 
@@ -23,7 +65,24 @@ with denominator as (
           person_id
         , evidence_date
         , evidence_value
-    from {{ ref('quality_measures__int_adh_diabetes_numerator') }}
+    from numerator_ranked
+    where rn = 1
+
+)
+
+, exclusions_ranked as (
+
+    select
+          person_id
+        , exclusion_date
+        , exclusion_reason
+        , row_number() over (
+            partition by person_id
+            order by
+                case when exclusion_date is null then 1 else 0 end
+                , exclusion_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_adh_diabetes_exclusions') }}
 
 )
 
@@ -33,7 +92,8 @@ with denominator as (
           person_id
         , exclusion_date
         , exclusion_reason
-    from {{ ref('quality_measures__int_adh_diabetes_exclusions') }}
+    from exclusions_ranked
+    where rn = 1
 
 )
 
@@ -69,48 +129,11 @@ with denominator as (
         , denominator.measure_id
         , denominator.measure_name
         , denominator.measure_version
-        , (row_number() over (
-            partition by
-                  denominator.person_id
-                , denominator.performance_period_begin
-                , denominator.performance_period_end
-                , denominator.measure_id
-                , denominator.measure_name
-              order by
-                  case when numerator.evidence_date is null then 1 else 0 end
-                  , numerator.evidence_date desc
-                , case when exclusions.exclusion_date is null then 1 else 0 end
-                  , exclusions.exclusion_date desc
-          )) as rn
     from denominator
         left outer join numerator
             on denominator.person_id = numerator.person_id
         left outer join exclusions
             on denominator.person_id = exclusions.person_id
-
-)
-
-/*
-    Deduplicate measure rows by latest evidence date or exclusion date
-*/
-, deduped as (
-
-    select
-          person_id
-        , denominator_flag
-        , numerator_flag
-        , exclusion_flag
-        , evidence_date
-        , evidence_value
-        , exclusion_date
-        , exclusion_reason
-        , performance_period_begin
-        , performance_period_end
-        , measure_id
-        , measure_name
-        , measure_version
-    from measure_flags
-    where rn = 1
 
 )
 
@@ -130,7 +153,7 @@ with denominator as (
         , cast(measure_id as {{ dbt.type_string() }}) as measure_id
         , cast(measure_name as {{ dbt.type_string() }}) as measure_name
         , cast(measure_version as {{ dbt.type_string() }}) as measure_version
-    from deduped
+    from measure_flags
 
 )
 

--- a/models/data_marts/quality_measures/intermediate/cqm130_documentation_of_current_medications_in_the_medical_record/quality_measures__int_cqm130_long.sql
+++ b/models/data_marts/quality_measures/intermediate/cqm130_documentation_of_current_medications_in_the_medical_record/quality_measures__int_cqm130_long.sql
@@ -3,7 +3,7 @@
    )
 }}
 
-with denominator as (
+with denominator_ranked as (
 
     select
           person_id
@@ -13,7 +13,49 @@ with denominator as (
         , measure_name
         , measure_version
         , denominator_flag
+        , row_number() over (
+            partition by
+                  person_id
+                , performance_period_begin
+                , performance_period_end
+                , measure_id
+                , measure_name
+            order by
+                case when performance_period_end is null then 1 else 0 end
+                , performance_period_end desc
+          ) as rn
     from {{ ref('quality_measures__int_cqm130_denominator') }}
+
+)
+
+, denominator as (
+
+    select
+          person_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from denominator_ranked
+    where rn = 1
+
+)
+
+, numerator_ranked as (
+
+    select
+          person_id
+        , evidence_date
+        , evidence_value
+        , row_number() over (
+            partition by person_id
+            order by
+                case when evidence_date is null then 1 else 0 end
+                , evidence_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_cqm130_numerator') }}
 
 )
 
@@ -23,7 +65,24 @@ with denominator as (
           person_id
         , evidence_date
         , evidence_value
-    from {{ ref('quality_measures__int_cqm130_numerator') }}
+    from numerator_ranked
+    where rn = 1
+
+)
+
+, exclusions_ranked as (
+
+    select
+          person_id
+        , exclusion_date
+        , exclusion_reason
+        , row_number() over (
+            partition by person_id
+            order by
+                case when exclusion_date is null then 1 else 0 end
+                , exclusion_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_cqm130_exclusions') }}
 
 )
 
@@ -33,7 +92,8 @@ with denominator as (
           person_id
         , exclusion_date
         , exclusion_reason
-    from {{ ref('quality_measures__int_cqm130_exclusions') }}
+    from exclusions_ranked
+    where rn = 1
 
 )
 
@@ -69,48 +129,11 @@ with denominator as (
         , denominator.measure_id
         , denominator.measure_name
         , denominator.measure_version
-        , (row_number() over (
-            partition by
-                  denominator.person_id
-                , denominator.performance_period_begin
-                , denominator.performance_period_end
-                , denominator.measure_id
-                , denominator.measure_name
-              order by
-                  case when numerator.evidence_date is null then 1 else 0 end
-                  , numerator.evidence_date desc
-                , case when exclusions.exclusion_date is null then 1 else 0 end
-                  , exclusions.exclusion_date desc
-          )) as rn
     from denominator
         left outer join numerator
             on denominator.person_id = numerator.person_id
         left outer join exclusions
             on denominator.person_id = exclusions.person_id
-
-)
-
-/*
-    Deduplicate measure rows by latest evidence date or exclusion date
-*/
-, deduped as (
-
-    select
-          person_id
-        , denominator_flag
-        , numerator_flag
-        , exclusion_flag
-        , evidence_date
-        , evidence_value
-        , exclusion_date
-        , exclusion_reason
-        , performance_period_begin
-        , performance_period_end
-        , measure_id
-        , measure_name
-        , measure_version
-    from measure_flags
-    where rn = 1
 
 )
 
@@ -130,7 +153,7 @@ with denominator as (
         , cast(measure_id as {{ dbt.type_string() }}) as measure_id
         , cast(measure_name as {{ dbt.type_string() }}) as measure_name
         , cast(measure_version as {{ dbt.type_string() }}) as measure_version
-    from deduped
+    from measure_flags
 
 )
 

--- a/models/data_marts/quality_measures/intermediate/cqm438_statin_therapy_for_patients_with_cardiovascular_disease/quality_measures__int_cqm438_long.sql
+++ b/models/data_marts/quality_measures/intermediate/cqm438_statin_therapy_for_patients_with_cardiovascular_disease/quality_measures__int_cqm438_long.sql
@@ -3,7 +3,7 @@
    )
 }}
 
-with denominator as (
+with denominator_ranked as (
 
     select
           person_id
@@ -13,7 +13,49 @@ with denominator as (
         , measure_name
         , measure_version
         , denominator_flag
+        , row_number() over (
+            partition by
+                  person_id
+                , performance_period_begin
+                , performance_period_end
+                , measure_id
+                , measure_name
+            order by
+                case when performance_period_end is null then 1 else 0 end
+                , performance_period_end desc
+          ) as rn
     from {{ ref('quality_measures__int_cqm438_denominator') }}
+
+)
+
+, denominator as (
+
+    select
+          person_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from denominator_ranked
+    where rn = 1
+
+)
+
+, numerator_ranked as (
+
+    select
+          person_id
+        , evidence_date
+        , evidence_value
+        , row_number() over (
+            partition by person_id
+            order by
+                case when evidence_date is null then 1 else 0 end
+                , evidence_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_cqm438_numerator') }}
 
 )
 
@@ -23,7 +65,24 @@ with denominator as (
           person_id
         , evidence_date
         , evidence_value
-    from {{ ref('quality_measures__int_cqm438_numerator') }}
+    from numerator_ranked
+    where rn = 1
+
+)
+
+, exclusions_ranked as (
+
+    select
+          person_id
+        , exclusion_date
+        , exclusion_reason
+        , row_number() over (
+            partition by person_id
+            order by
+                case when exclusion_date is null then 1 else 0 end
+                , exclusion_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_cqm438_exclusions') }}
 
 )
 
@@ -33,7 +92,8 @@ with denominator as (
           person_id
         , exclusion_date
         , exclusion_reason
-    from {{ ref('quality_measures__int_cqm438_exclusions') }}
+    from exclusions_ranked
+    where rn = 1
 
 )
 
@@ -69,48 +129,11 @@ with denominator as (
         , denominator.measure_id
         , denominator.measure_name
         , denominator.measure_version
-        , (row_number() over (
-            partition by
-                  denominator.person_id
-                , denominator.performance_period_begin
-                , denominator.performance_period_end
-                , denominator.measure_id
-                , denominator.measure_name
-              order by
-                  case when numerator.evidence_date is null then 1 else 0 end
-                  , numerator.evidence_date desc
-                , case when exclusions.exclusion_date is null then 1 else 0 end
-                  , exclusions.exclusion_date desc
-          )) as rn
     from denominator
         left outer join numerator
             on denominator.person_id = numerator.person_id
         left outer join exclusions
             on denominator.person_id = exclusions.person_id
-
-)
-
-/*
-    Deduplicate measure rows by latest evidence date or exclusion date
-*/
-, deduped as (
-
-    select
-          person_id
-        , denominator_flag
-        , numerator_flag
-        , exclusion_flag
-        , evidence_date
-        , evidence_value
-        , exclusion_date
-        , exclusion_reason
-        , performance_period_begin
-        , performance_period_end
-        , measure_id
-        , measure_name
-        , measure_version
-    from measure_flags
-    where rn = 1
 
 )
 
@@ -130,7 +153,7 @@ with denominator as (
         , cast(measure_id as {{ dbt.type_string() }}) as measure_id
         , cast(measure_name as {{ dbt.type_string() }}) as measure_name
         , cast(measure_version as {{ dbt.type_string() }}) as measure_version
-    from deduped
+    from measure_flags
 
 )
 

--- a/models/data_marts/quality_measures/intermediate/nqf0420_pain_assessment_and_follow_up/quality_measures__int_nqf0420_long.sql
+++ b/models/data_marts/quality_measures/intermediate/nqf0420_pain_assessment_and_follow_up/quality_measures__int_nqf0420_long.sql
@@ -3,7 +3,7 @@
    )
 }}
 
-with denominator as (
+with denominator_ranked as (
 
     select
           person_id
@@ -13,7 +13,49 @@ with denominator as (
         , measure_name
         , measure_version
         , denominator_flag
+        , row_number() over (
+            partition by
+                  person_id
+                , performance_period_begin
+                , performance_period_end
+                , measure_id
+                , measure_name
+            order by
+                case when performance_period_end is null then 1 else 0 end
+                , performance_period_end desc
+          ) as rn
     from {{ ref('quality_measures__int_nqf0420_denominator') }}
+
+)
+
+, denominator as (
+
+    select
+          person_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from denominator_ranked
+    where rn = 1
+
+)
+
+, numerator_ranked as (
+
+    select
+          person_id
+        , evidence_date
+        , evidence_value
+        , row_number() over (
+            partition by person_id
+            order by
+                case when evidence_date is null then 1 else 0 end
+                , evidence_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_nqf0420_numerator') }}
 
 )
 
@@ -23,7 +65,24 @@ with denominator as (
           person_id
         , evidence_date
         , evidence_value
-    from {{ ref('quality_measures__int_nqf0420_numerator') }}
+    from numerator_ranked
+    where rn = 1
+
+)
+
+, exclusions_ranked as (
+
+    select
+          person_id
+        , exclusion_date
+        , exclusion_reason
+        , row_number() over (
+            partition by person_id
+            order by
+                case when exclusion_date is null then 1 else 0 end
+                , exclusion_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_nqf0420_exclusions') }}
 
 )
 
@@ -33,7 +92,8 @@ with denominator as (
           person_id
         , exclusion_date
         , exclusion_reason
-    from {{ ref('quality_measures__int_nqf0420_exclusions') }}
+    from exclusions_ranked
+    where rn = 1
 
 )
 
@@ -69,48 +129,11 @@ with denominator as (
         , denominator.measure_id
         , denominator.measure_name
         , denominator.measure_version
-        , (row_number() over (
-            partition by
-                  denominator.person_id
-                , denominator.performance_period_begin
-                , denominator.performance_period_end
-                , denominator.measure_id
-                , denominator.measure_name
-              order by
-                  case when numerator.evidence_date is null then 1 else 0 end
-                  , numerator.evidence_date desc
-                , case when exclusions.exclusion_date is null then 1 else 0 end
-                  , exclusions.exclusion_date desc
-          )) as rn
     from denominator
         left outer join numerator
             on denominator.person_id = numerator.person_id
         left outer join exclusions
             on denominator.person_id = exclusions.person_id
-
-)
-
-/*
-    Deduplicate measure rows by latest evidence date or exclusion date
-*/
-, deduped as (
-
-    select
-          person_id
-        , denominator_flag
-        , numerator_flag
-        , exclusion_flag
-        , evidence_date
-        , evidence_value
-        , exclusion_date
-        , exclusion_reason
-        , performance_period_begin
-        , performance_period_end
-        , measure_id
-        , measure_name
-        , measure_version
-    from measure_flags
-    where rn = 1
 
 )
 
@@ -130,7 +153,7 @@ with denominator as (
         , cast(measure_id as {{ dbt.type_string() }}) as measure_id
         , cast(measure_name as {{ dbt.type_string() }}) as measure_name
         , cast(measure_version as {{ dbt.type_string() }}) as measure_version
-    from deduped
+    from measure_flags
 
 )
 

--- a/models/data_marts/quality_measures/intermediate/supd_statin_use_in_persons_with_diabetes/quality_measures__int_supd_long.sql
+++ b/models/data_marts/quality_measures/intermediate/supd_statin_use_in_persons_with_diabetes/quality_measures__int_supd_long.sql
@@ -3,7 +3,7 @@
    )
 }}
 
-with denominator as (
+with denominator_ranked as (
 
     select
           person_id
@@ -12,7 +12,48 @@ with denominator as (
         , measure_id
         , measure_name
         , measure_version
+        , row_number() over (
+            partition by
+                  person_id
+                , performance_period_begin
+                , performance_period_end
+                , measure_id
+                , measure_name
+            order by
+                case when performance_period_end is null then 1 else 0 end
+                , performance_period_end desc
+          ) as rn
     from {{ ref('quality_measures__int_supd_denominator') }}
+
+)
+
+, denominator as (
+
+    select
+          person_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+    from denominator_ranked
+    where rn = 1
+
+)
+
+, numerator_ranked as (
+
+    select
+          person_id
+        , evidence_date
+        , evidence_value
+        , row_number() over (
+            partition by person_id
+            order by
+                case when evidence_date is null then 1 else 0 end
+                , evidence_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_supd_numerator') }}
 
 )
 
@@ -22,7 +63,24 @@ with denominator as (
           person_id
         , evidence_date
         , evidence_value
-    from {{ ref('quality_measures__int_supd_numerator') }}
+    from numerator_ranked
+    where rn = 1
+
+)
+
+, exclusions_ranked as (
+
+    select
+          person_id
+        , exclusion_date
+        , exclusion_reason
+        , row_number() over (
+            partition by person_id
+            order by
+                case when exclusion_date is null then 1 else 0 end
+                , exclusion_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_supd_exclusions') }}
 
 )
 
@@ -32,7 +90,8 @@ with denominator as (
           person_id
         , exclusion_date
         , exclusion_reason
-    from {{ ref('quality_measures__int_supd_exclusions') }}
+    from exclusions_ranked
+    where rn = 1
 
 )
 
@@ -68,48 +127,11 @@ with denominator as (
         , denominator.measure_id
         , denominator.measure_name
         , denominator.measure_version
-        , (row_number() over (
-            partition by
-                  denominator.person_id
-                , denominator.performance_period_begin
-                , denominator.performance_period_end
-                , denominator.measure_id
-                , denominator.measure_name
-              order by
-                  case when numerator.evidence_date is null then 1 else 0 end
-                  , numerator.evidence_date desc
-                , case when exclusions.exclusion_date is null then 1 else 0 end
-                  , exclusions.exclusion_date desc
-          )) as rn
     from denominator
         left outer join numerator
             on denominator.person_id = numerator.person_id
         left outer join exclusions
             on denominator.person_id = exclusions.person_id
-
-)
-
-/*
-    Deduplicate measure rows by latest evidence date or exclusion date
-*/
-, deduped as (
-
-    select
-          person_id
-        , denominator_flag
-        , numerator_flag
-        , exclusion_flag
-        , evidence_date
-        , evidence_value
-        , exclusion_date
-        , exclusion_reason
-        , performance_period_begin
-        , performance_period_end
-        , measure_id
-        , measure_name
-        , measure_version
-    from measure_flags
-    where rn = 1
 
 )
 
@@ -129,7 +151,7 @@ with denominator as (
         , cast(measure_id as {{ dbt.type_string() }}) as measure_id
         , cast(measure_name as {{ dbt.type_string() }}) as measure_name
         , cast(measure_version as {{ dbt.type_string() }}) as measure_version
-    from deduped
+    from measure_flags
 
 )
 


### PR DESCRIPTION
## Summary

Several `_long` intermediate models in `quality_measures` join `denominator`/`numerator`/`exclusions` on `person_id` at full fan-out grain, then deduplicate with a `row_number()` window *after* the join. Because each side can have multiple rows per person, the join produces a combinatorial row explosion before the final collapse. In practice this caused `adh_diabetes_long` alone to take ~12.9 hours to build in a dev environment.

`adhras_long` already avoided this by pre-deduplicating each side to one row per person before joining. This PR applies that same pattern to the other affected `_long` models:

- `quality_measures__int_adh_statins_long`
- `quality_measures__int_adh_diabetes_long`
- `quality_measures__int_cqm130_long`
- `quality_measures__int_cqm438_long`
- `quality_measures__int_nqf0420_long`
- `quality_measures__int_supd_long`

Each `denominator`/`numerator`/`exclusions` CTE now ranks and dedupes to one row per person (or per person/performance-period/measure for `denominator`) before the join, instead of joining first and deduping the combinatorial result afterward. The dedup ordering logic (latest non-null date wins) is preserved — it's just applied per-side pre-join rather than post-join.

## Test plan
- [ ] `dbt build` locally against DuckDB integration tests for the `quality_measures` package
- [ ] Confirm row counts for each `_long` model match pre-change output on a representative dataset
- [ ] Confirm build time improvement on the previously slow models (e.g. `adh_diabetes_long`)
