### PR TITLE
Make package assets independent of domain vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ from git worktrees.
 - Treat `integration_tests/profiles/*` as CI-only configuration, not local
   runbooks.
 - Treat `.github/workflows/*` as CI pipeline definitions, not local runbooks.
-- Never merge to `main`; the user reviews and merges PRs.
+- Never merge to `main` without Aaron's explicit approval.
 
 ## Seed And Data Safety
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -16,7 +16,9 @@ vars:
   ## Data quality
   # Enables neutral data_quality structural/logical/analytical result models.
   # Production projects can leave this false/omitted unless they want to build these queryable result tables.
-  data_quality_enabled: true            # Enables neutral data_quality structural/logical/analytical result models.
+  data_quality_enabled: false           # Keeps optional data-quality result models out of this compatibility run.
+  enable_data_quality_failure_keys: false  # Adds the optional key-only logical failure drilldown table.
+  data_quality_domain_input_requirements: []  # Optional additional component-to-input dependency mappings.
 
   ## Synthetic data validation
   # These vars are for this integration_tests project. They are not normal production Tuva Core settings.
@@ -27,6 +29,43 @@ vars:
   # Tuva Core resolves assets from tuva-core/<installed-package-version>/.
   custom_bucket_name: tuva-public-resources  # Default public bucket for package data assets.
   tuva_seed_buckets: {}                # Optional per-family bucket overrides, keyed by seed family.
+
+  ## Standalone package behavior
+  # Importing a standalone package enables it. These vars change package behavior;
+  # none is a package-level on/off switch or an external-asset version pin.
+  ccsr:
+    wide_condition_enabled: true       # Includes the optional wide condition-category output.
+    wide_procedure_enabled: true       # Includes the optional wide procedure-category output.
+    record_type: ip                    # Category logic: ip (inpatient) or op (outpatient).
+    dxccsr_version: "'2023.1'"         # HCUP diagnosis CCSR version stored in package outputs.
+    prccsr_version: "'2023.1'"         # HCUP procedure CCSR version stored in package outputs.
+
+  cms_chronic_conditions:
+    # Optional package-specific relation overrides. Null uses the corresponding Tuva Core ref.
+    cms_chronic_conditions_pharmacy_claim_override: null
+    cms_chronic_conditions_encounter_override: null
+    cms_chronic_conditions_condition_override: null
+    cms_chronic_conditions_procedure_override: null
+    cms_chronic_conditions_patient_override: null
+    # Backward-compatible Core relation override names used as secondary fallbacks.
+    core_pharmacy_claim_override: null
+    core_encounter_override: null
+    core_condition_override: null
+    core_procedure_override: null
+    core_patient_override: null
+    # Optional output location overrides. Omitted values use target.database and
+    # <tuva_schema_prefix>_chronic_conditions (or chronic_conditions without a prefix).
+    # cms_chronic_conditions_database: analytics
+    # cms_chronic_conditions_schema: chronic_conditions
+    # tuva_database: analytics          # Legacy shared database fallback.
+
+  cms_hcc:
+    cms_hcc_payment_year: 2018         # Matches the shipped small synthetic dataset.
+    hcc_recapture_chronic_hccs: false  # False uses package-owned chronic-HCC definitions; true uses chronic_hccs.
+    hcc_recapture_suspect_list: false  # True additionally requires a user-supplied suspect_hccs relation.
+
+  quality_measures:
+    quality_measures_period_end: "2018-12-31"  # Matches the shipped small synthetic dataset.
 
   ## Schema naming
   # Optional prefix for output schemas, e.g. dev_aaron_core, dev_aaron_input_layer.

--- a/macros/cross_database_utils/load_seed.sql
+++ b/macros/cross_database_utils/load_seed.sql
@@ -189,6 +189,51 @@ copy  {{ this }}
 {% endmacro %}
 
 
+{% macro snowflake_seed_rows_loaded(column_names, data, uri, pattern) %}
+{% set normalized_column_names = [] %}
+{% for column_name in column_names %}
+  {% do normalized_column_names.append(column_name | string | lower) %}
+{% endfor %}
+
+{% if data | length == 0 %}
+  {% do exceptions.raise_compiler_error(
+      "Snowflake seed load returned no result for s3://" ~ uri ~ "/" ~ pattern ~ "."
+  ) %}
+{% endif %}
+
+{% if 'rows_loaded' not in normalized_column_names %}
+  {% set copy_status = data[0][0] if data[0] | length > 0 else 'COPY returned no status' %}
+  {% do exceptions.raise_compiler_error(
+      "Snowflake seed load processed no files from s3://"
+      ~ uri ~ "/" ~ pattern ~ ". Result: " ~ copy_status
+  ) %}
+{% endif %}
+
+{% set rows_loaded_index = normalized_column_names.index('rows_loaded') %}
+{% set loaded = namespace(rows=0) %}
+{% for row in data %}
+  {% set loaded.rows = loaded.rows + (row[rows_loaded_index] | int) %}
+{% endfor %}
+
+{% if loaded.rows == 0 %}
+  {% set statuses = [] %}
+  {% if 'status' in normalized_column_names %}
+    {% set status_index = normalized_column_names.index('status') %}
+    {% for row in data %}
+      {% do statuses.append(row[status_index] | string) %}
+    {% endfor %}
+  {% endif %}
+  {% set copy_status = statuses | join(', ') if statuses | length > 0 else 'COPY loaded zero rows' %}
+  {% do exceptions.raise_compiler_error(
+      "Snowflake seed load loaded zero rows from s3://"
+      ~ uri ~ "/" ~ pattern ~ ". Result: " ~ copy_status
+  ) %}
+{% endif %}
+
+{{ return(loaded.rows) }}
+{% endmacro %}
+
+
 {% macro snowflake__load_seed(uri,pattern,compression,headers,null_marker) %}
 {% do the_tuva_project.reset_seed_relation() %}
 {% set sql %}
@@ -216,7 +261,13 @@ pattern = '.*\/{{pattern}}.*';
 {% if execute %}
 {# debugging { log(sql, True)} #}
 {% set results = load_result('snowsql') %}
-{{ log("Loaded data from external s3 resource\n  loaded to: " ~ this ~ "\n  from: s3://" ~ uri ~ "/" ~ pattern ~ "*\n  rows: " ~ results['data']|sum(attribute=2),True) }}
+{% set rows_loaded = the_tuva_project.snowflake_seed_rows_loaded(
+    results['table'].column_names,
+    results['data'],
+    uri,
+    pattern
+) %}
+{{ log("Loaded data from external s3 resource\n  loaded to: " ~ this ~ "\n  from: s3://" ~ uri ~ "/" ~ pattern ~ "*\n  rows: " ~ rows_loaded,True) }}
 {# debugging { log(results, True)} #}
 {% endif %}
 

--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -528,7 +528,6 @@ seeds:
         {%- if  var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_terminology{% else %}terminology{%- endif -%}
       alias: restructured_betos
       tags: terminology
-      enabled: "{{ var('claims_enabled', False) }}"
       column_types:
         hcpcs_cd: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}

--- a/seeds/value_sets/cms_provider_attribution/cms_provider_attribution_seeds.yml
+++ b/seeds/value_sets/cms_provider_attribution/cms_provider_attribution_seeds.yml
@@ -27,7 +27,6 @@ seeds:
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_value_sets{% else %}value_sets{%- endif -%}
       alias: _assignment_windows
       tags: cms_provider_attribution
-      enabled: "{{ var('provider_attribution_enabled', False) }}"
       column_types:
         performance_year: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(4) {%- endif -%}
@@ -62,7 +61,6 @@ seeds:
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_value_sets{% else %}value_sets{%- endif -%}
       alias: _primary_care_hcpcs_codes
       tags: cms_provider_attribution
-      enabled: "{{ var('provider_attribution_enabled', False) }}"
       column_types:
         hcpcs_code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(5) {%- endif -%}
@@ -90,7 +88,6 @@ seeds:
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_value_sets{% else %}value_sets{%- endif -%}
       alias: _provider_specialty_assignment_codes
       tags: cms_provider_attribution
-      enabled: "{{ var('provider_attribution_enabled', False) }}"
       column_types:
         specialty_code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(8) {%- endif -%}

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -171,6 +171,19 @@ class DataAssetContractTest(unittest.TestCase):
         self.assertNotIn("nullstr = ['',", load_macro)
         self.assertIn("escape_unenclosed_field = NONE", load_macro)
         self.assertIn("null_if = ('__TUVA_RESERVED_NULL_MARKER_1_0__')", load_macro)
+        self.assertIn(
+            "macro snowflake_seed_rows_loaded(column_names, data, uri, pattern)",
+            load_macro,
+        )
+        self.assertIn(
+            "normalized_column_names.index('rows_loaded')",
+            load_macro,
+        )
+        self.assertIn(
+            "Snowflake seed load processed no files from s3://",
+            load_macro,
+        )
+        self.assertNotIn("sum(attribute=2)", load_macro)
         self.assertIn("null_markers = ['']", load_macro)
         self.assertNotIn("null_markers = ['', '\\\\N'", load_macro)
         self.assertIn("set null_char = ''", load_macro)


### PR DESCRIPTION
## Summary

- keep every Tuva Core-owned external asset seed enabled independently of claims and provider-attribution model switches
- make the integration project a comprehensive catalog of retained standalone-package behavior vars, with data quality and parity disabled and no package-enable or asset-version vars
- read Snowflake `COPY INTO` results by the named `rows_loaded` column and raise an explicit missing/zero-asset error instead of failing on a positional tuple index

## Focused validation

- `python -m unittest discover -s tests/unit -v` — 9 passed
- integration `dbt deps` and clean parse
- positive and expected-failure coverage for named Snowflake COPY results
- `git diff --check`

## End-to-end validation

- exact local Core plus seven standalone-package candidate set
- Snowflake `snowflake-dev`, target `dev`, synthetic data `small`
- `dbt build --full-refresh --no-partial-parse --target dev`
- `PASS=872 WARN=0 ERROR=0 SKIP=0`
- 125 seeds, 520 materialized models, 12 ephemeral models, 222 data tests, and 5 unit tests
- all package-owned staged assets passed exact inventory and loader validation

The pre-publication smoke used an isolated Snowflake stage for the exact commit-bound assets. Public package-asset publication remains a post-merge release step.

Release-note label: `bug`
