### PR TITLE
Split Snowflake and all-warehouse release CI

### DIFF
--- a/.github/workflows/ci-all-warehouses.yml
+++ b/.github/workflows/ci-all-warehouses.yml
@@ -1,0 +1,368 @@
+name: Tuva CI -- All Warehouses
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Internal version-changing pull request number to validate
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: tuva-ci-all-dispatch-pr-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    name: Resolve release pull request and package sources
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      base_sha: ${{ steps.resolve.outputs.base_sha }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      merge_sha: ${{ steps.resolve.outputs.merge_sha }}
+      schema_prefix: ${{ steps.resolve.outputs.schema_prefix }}
+      concurrency_key: ${{ steps.resolve.outputs.concurrency_key }}
+      source_lock: ${{ steps.resolve.outputs.source_lock }}
+    steps:
+      - name: Pin the release candidate and package mains
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            if (context.ref !== "refs/heads/main") {
+              core.setFailed("Tuva CI -- All Warehouses must be dispatched from main.");
+              return;
+            }
+
+            const rawPrNumber = process.env.PR_NUMBER.trim();
+            if (!/^\d+$/.test(rawPrNumber)) {
+              core.setFailed(`Invalid pull request number: ${rawPrNumber}`);
+              return;
+            }
+
+            const prNumber = Number(rawPrNumber);
+            const baseRepository =
+              `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
+            const exactSha = /^[0-9a-f]{40}$/i;
+            const releasePackages = [
+              {
+                repository: "ahrq_quality_indicators",
+                dbtPackage: "ahrq_quality_indicators",
+                envVar: "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA"
+              },
+              {
+                repository: "ccsr",
+                dbtPackage: "ccsr",
+                envVar: "TUVA_CI_CCSR_SHA"
+              },
+              {
+                repository: "cms_chronic_conditions",
+                dbtPackage: "cms_chronic_conditions",
+                envVar: "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA"
+              },
+              {
+                repository: "cms_hcc",
+                dbtPackage: "cms_hcc",
+                envVar: "TUVA_CI_CMS_HCC_SHA"
+              },
+              {
+                repository: "fhir_preprocessing",
+                dbtPackage: "fhir_preprocessing",
+                envVar: "TUVA_CI_FHIR_PREPROCESSING_SHA"
+              },
+              {
+                repository: "nyu_ed_classification",
+                dbtPackage: "nyu_ed_classification",
+                envVar: "TUVA_CI_NYU_ED_CLASSIFICATION_SHA"
+              },
+              {
+                repository: "quality_measures",
+                dbtPackage: "quality_measures",
+                envVar: "TUVA_CI_QUALITY_MEASURES_SHA"
+              },
+              {
+                repository: "semantic-layer",
+                dbtPackage: "semantic_layer",
+                envVar: "TUVA_CI_SEMANTIC_LAYER_SHA"
+              }
+            ];
+
+            async function getPullRequest() {
+              let pr;
+              for (let attempt = 0; attempt < 5; attempt += 1) {
+                ({ data: pr } = await github.rest.pulls.get({
+                  ...context.repo,
+                  pull_number: prNumber
+                }));
+                if (pr.mergeable !== null) {
+                  break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+              }
+              return pr;
+            }
+
+            function validatePullRequest(pr) {
+              if (pr.state !== "open") {
+                throw new Error(`PR #${prNumber} is not open.`);
+              }
+              if (pr.base.ref !== "main") {
+                throw new Error(
+                  `PR #${prNumber} targets ${pr.base.ref}, not main.`
+                );
+              }
+              const headRepository =
+                String(pr.head.repo?.full_name || "").toLowerCase();
+              if (headRepository !== baseRepository) {
+                throw new Error(
+                  `PR #${prNumber} must use a branch in ${baseRepository}.`
+                );
+              }
+              if (pr.mergeable !== true) {
+                throw new Error(`PR #${prNumber} is not currently mergeable.`);
+              }
+            }
+
+            async function getTestMerge(pr) {
+              const { data: mergeCommit } = await github.rest.repos.getCommit({
+                ...context.repo,
+                ref: `refs/pull/${prNumber}/merge`
+              });
+              const parentShas = mergeCommit.parents.map((parent) => parent.sha);
+              if (
+                parentShas.length !== 2 ||
+                parentShas[0] !== pr.base.sha ||
+                parentShas[1] !== pr.head.sha
+              ) {
+                throw new Error(
+                  `PR #${prNumber} changed while its test merge was being resolved.`
+                );
+              }
+              return mergeCommit;
+            }
+
+            async function projectVersion(ref) {
+              const { data } = await github.rest.repos.getContent({
+                ...context.repo,
+                path: "dbt_project.yml",
+                ref
+              });
+              if (Array.isArray(data) || data.type !== "file" || !data.content) {
+                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
+              }
+              const text = Buffer.from(
+                data.content.replace(/\n/g, ""),
+                data.encoding || "base64"
+              ).toString("utf8");
+              const versionPattern =
+                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
+              const matches = [...text.matchAll(versionPattern)];
+              if (matches.length !== 1) {
+                throw new Error(
+                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
+                );
+              }
+              return matches[0][2];
+            }
+
+            function parseSemver(version) {
+              const numeric = "(?:0|[1-9][0-9]*)";
+              const nonNumeric = "(?:[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)";
+              const prereleaseIdentifier = `(?:${numeric}|${nonNumeric})`;
+              const prerelease =
+                `(${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)`;
+              const buildIdentifier = "[0-9A-Za-z-]+";
+              const pattern = new RegExp(
+                `^(${numeric})\\.(${numeric})\\.(${numeric})` +
+                `(?:-${prerelease})?` +
+                `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))?$`
+              );
+              const match = version.match(pattern);
+              if (!match) {
+                throw new Error(`invalid SemVer version: ${version}`);
+              }
+              return {
+                core: match.slice(1, 4).map((item) => BigInt(item)),
+                prerelease: match[4] ? match[4].split(".") : null
+              };
+            }
+
+            function compareSemverPrecedence(leftVersion, rightVersion) {
+              const left = parseSemver(leftVersion);
+              const right = parseSemver(rightVersion);
+              for (let index = 0; index < 3; index += 1) {
+                if (left.core[index] !== right.core[index]) {
+                  return left.core[index] > right.core[index] ? 1 : -1;
+                }
+              }
+              if (left.prerelease === null && right.prerelease === null) {
+                return 0;
+              }
+              if (left.prerelease === null) {
+                return 1;
+              }
+              if (right.prerelease === null) {
+                return -1;
+              }
+              const length = Math.max(
+                left.prerelease.length,
+                right.prerelease.length
+              );
+              for (let index = 0; index < length; index += 1) {
+                const leftPart = left.prerelease[index];
+                const rightPart = right.prerelease[index];
+                if (leftPart === undefined) {
+                  return -1;
+                }
+                if (rightPart === undefined) {
+                  return 1;
+                }
+                if (leftPart === rightPart) {
+                  continue;
+                }
+                const leftIsNumeric = /^[0-9]+$/.test(leftPart);
+                const rightIsNumeric = /^[0-9]+$/.test(rightPart);
+                if (leftIsNumeric && rightIsNumeric) {
+                  return BigInt(leftPart) > BigInt(rightPart) ? 1 : -1;
+                }
+                if (leftIsNumeric !== rightIsNumeric) {
+                  return leftIsNumeric ? -1 : 1;
+                }
+                return leftPart > rightPart ? 1 : -1;
+              }
+              return 0;
+            }
+
+            try {
+              const pr = await getPullRequest();
+              validatePullRequest(pr);
+              const mergeCommit = await getTestMerge(pr);
+
+              const [baseVersion, releaseVersion, standalonePackages] =
+                await Promise.all([
+                  projectVersion(pr.base.sha),
+                  projectVersion(mergeCommit.sha),
+                  Promise.all(
+                    releasePackages.map(async (item) => {
+                      const { data: commit } = await github.rest.repos.getCommit({
+                        owner: context.repo.owner,
+                        repo: item.repository,
+                        ref: "main"
+                      });
+                      if (!exactSha.test(commit.sha)) {
+                        throw new Error(
+                          `Could not resolve ${item.repository} main to an exact commit.`
+                        );
+                      }
+                      return {
+                        repository: `${context.repo.owner}/${item.repository}`,
+                        dbt_package: item.dbtPackage,
+                        branch: "main",
+                        revision: commit.sha.toLowerCase(),
+                        env_var: item.envVar
+                      };
+                    })
+                  )
+                ]);
+
+              if (compareSemverPrecedence(releaseVersion, baseVersion) <= 0) {
+                throw new Error(
+                  `PR #${prNumber} must increase the Tuva Core package version ` +
+                  `with greater SemVer precedence (${baseVersion} -> ${releaseVersion}).`
+                );
+              }
+
+              const currentPr = await getPullRequest();
+              validatePullRequest(currentPr);
+              const currentMerge = await getTestMerge(currentPr);
+              if (
+                currentPr.base.sha !== pr.base.sha ||
+                currentPr.head.sha !== pr.head.sha ||
+                currentMerge.sha !== mergeCommit.sha
+              ) {
+                throw new Error(
+                  `PR #${prNumber} changed while package sources were being resolved.`
+                );
+              }
+
+              const sourceLock = {
+                core: {
+                  repository: `${context.repo.owner}/${context.repo.repo}`,
+                  source: "pull_request_test_merge",
+                  revision: mergeCommit.sha.toLowerCase()
+                },
+                base_version: baseVersion,
+                release_version: releaseVersion,
+                standalone_packages: standalonePackages
+              };
+
+              core.setOutput("pr_number", String(prNumber));
+              core.setOutput("base_sha", pr.base.sha);
+              core.setOutput("head_sha", pr.head.sha);
+              core.setOutput("merge_sha", mergeCommit.sha);
+              core.setOutput(
+                "schema_prefix",
+                `ci_all_pr_${prNumber}_${pr.head.sha.slice(0, 8)}`
+              );
+              core.setOutput("concurrency_key", `all-worker-pr-${prNumber}`);
+              core.setOutput("source_lock", JSON.stringify(sourceLock));
+              core.notice(
+                `Pinned release CI ${baseVersion} -> ${releaseVersion} at ` +
+                `${mergeCommit.sha} with eight standalone package mains.`
+              );
+            } catch (error) {
+              core.setFailed(`Could not resolve release CI: ${error.message}`);
+            }
+
+  run_all_warehouses:
+    name: Run release candidate on all warehouses
+    needs: resolve
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    uses: ./.github/workflows/ci.yml
+    with:
+      checkout_ref: ${{ needs.resolve.outputs.merge_sha }}
+      warehouse: all
+      scope: all-packages
+      source_lock: ${{ needs.resolve.outputs.source_lock }}
+      schema_prefix: ${{ needs.resolve.outputs.schema_prefix }}
+      concurrency_key: ${{ needs.resolve.outputs.concurrency_key }}
+      publish_status: true
+      pr_number: ${{ needs.resolve.outputs.pr_number }}
+      base_sha: ${{ needs.resolve.outputs.base_sha }}
+      head_sha: ${{ needs.resolve.outputs.head_sha }}
+      merge_sha: ${{ needs.resolve.outputs.merge_sha }}
+    secrets:
+      DBT_SNOWFLAKE_CI_ACCOUNT: ${{ secrets.DBT_SNOWFLAKE_CI_ACCOUNT }}
+      DBT_SNOWFLAKE_CI_WAREHOUSE: ${{ secrets.DBT_SNOWFLAKE_CI_WAREHOUSE }}
+      DBT_SNOWFLAKE_CI_DATABASE: ${{ secrets.DBT_SNOWFLAKE_CI_DATABASE }}
+      DBT_SNOWFLAKE_CI_ROLE: ${{ secrets.DBT_SNOWFLAKE_CI_ROLE }}
+      DBT_SNOWFLAKE_CI_SCHEMA: ${{ secrets.DBT_SNOWFLAKE_CI_SCHEMA }}
+      DBT_SNOWFLAKE_CI_USER: ${{ secrets.DBT_SNOWFLAKE_CI_USER }}
+      DBT_SNOWFLAKE_CI_PASSWORD: ${{ secrets.DBT_SNOWFLAKE_CI_PASSWORD }}
+      DBT_BIGQUERY_CI_TOKEN: ${{ secrets.DBT_BIGQUERY_CI_TOKEN }}
+      DBT_BIGQUERY_CI_PROJECT: ${{ secrets.DBT_BIGQUERY_CI_PROJECT }}
+      DBT_DATABRICKS_CI_HOST: ${{ secrets.DBT_DATABRICKS_CI_HOST }}
+      DBT_DATABRICKS_CI_HTTP_PATH: ${{ secrets.DBT_DATABRICKS_CI_HTTP_PATH }}
+      DBT_DATABRICKS_CI_TOKEN: ${{ secrets.DBT_DATABRICKS_CI_TOKEN }}
+      DBT_DATABRICKS_CI_CATALOG: ${{ secrets.DBT_DATABRICKS_CI_CATALOG }}
+      DBT_FABRIC_CI_SERVER: ${{ secrets.DBT_FABRIC_CI_SERVER }}
+      DBT_FABRIC_CI_DATABASE: ${{ secrets.DBT_FABRIC_CI_DATABASE }}
+      DBT_FABRIC_CI_SCHEMA: ${{ secrets.DBT_FABRIC_CI_SCHEMA }}
+      DBT_FABRIC_CI_CLIENT_ID: ${{ secrets.DBT_FABRIC_CI_CLIENT_ID }}
+      DBT_FABRIC_CI_CLIENT_SECRET: ${{ secrets.DBT_FABRIC_CI_CLIENT_SECRET }}
+      DBT_FABRIC_CI_TENANT_ID: ${{ secrets.DBT_FABRIC_CI_TENANT_ID }}
+      DBT_REDSHIFT_CI_HOST: ${{ secrets.DBT_REDSHIFT_CI_HOST }}
+      DBT_REDSHIFT_CI_USER: ${{ secrets.DBT_REDSHIFT_CI_USER }}
+      DBT_REDSHIFT_CI_PASSWORD: ${{ secrets.DBT_REDSHIFT_CI_PASSWORD }}
+      DBT_REDSHIFT_CI_DATABASE: ${{ secrets.DBT_REDSHIFT_CI_DATABASE }}

--- a/.github/workflows/ci-external-pr.yml
+++ b/.github/workflows/ci-external-pr.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Pin the reviewed pull request revision
         id: resolve
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
         with:

--- a/.github/workflows/ci-external-pr.yml
+++ b/.github/workflows/ci-external-pr.yml
@@ -134,8 +134,8 @@ jobs:
             }
             if (baseVersion !== mergeVersion) {
               core.setFailed(
-                "Version-changing pull requests must use an internal branch so the " +
-                "automatic full release matrix can run safely."
+                "Version-changing pull requests must use an internal branch and " +
+                "Tuva CI -- All Warehouses."
               );
               return;
             }
@@ -145,7 +145,7 @@ jobs:
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("merge_sha", mergeCommit.sha);
             core.setOutput("schema_prefix", `ci_pr_${prNumber}_${pr.head.sha.slice(0, 8)}`);
-            core.setOutput("concurrency_key", `pr-${prNumber}`);
+            core.setOutput("concurrency_key", `snowflake-external-pr-${prNumber}`);
 
   run_snowflake:
     name: Run reviewed code on Snowflake
@@ -158,6 +158,8 @@ jobs:
     with:
       checkout_ref: ${{ needs.resolve.outputs.merge_sha }}
       warehouse: snowflake
+      scope: core
+      source_lock: ""
       schema_prefix: ${{ needs.resolve.outputs.schema_prefix }}
       concurrency_key: ${{ needs.resolve.outputs.concurrency_key }}
       publish_status: true

--- a/.github/workflows/ci-external-pr.yml
+++ b/.github/workflows/ci-external-pr.yml
@@ -97,6 +97,49 @@ jobs:
               return;
             }
 
+            async function projectVersion(ref) {
+              const { data } = await github.rest.repos.getContent({
+                ...context.repo,
+                path: "dbt_project.yml",
+                ref
+              });
+              if (Array.isArray(data) || data.type !== "file" || !data.content) {
+                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
+              }
+              const text = Buffer.from(
+                data.content.replace(/\n/g, ""),
+                data.encoding || "base64"
+              ).toString("utf8");
+              const versionPattern =
+                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
+              const matches = [...text.matchAll(versionPattern)];
+              if (matches.length !== 1) {
+                throw new Error(
+                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
+                );
+              }
+              return matches[0][2];
+            }
+
+            let baseVersion;
+            let mergeVersion;
+            try {
+              [baseVersion, mergeVersion] = await Promise.all([
+                projectVersion(pr.base.sha),
+                projectVersion(mergeCommit.sha)
+              ]);
+            } catch (error) {
+              core.setFailed(`Could not inspect PR #${prNumber}'s version: ${error.message}`);
+              return;
+            }
+            if (baseVersion !== mergeVersion) {
+              core.setFailed(
+                "Version-changing pull requests must use an internal branch so the " +
+                "automatic full release matrix can run safely."
+              );
+              return;
+            }
+
             core.setOutput("pr_number", String(prNumber));
             core.setOutput("base_sha", pr.base.sha);
             core.setOutput("head_sha", pr.head.sha);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,9 +495,6 @@ jobs:
                 })
               )
             );
-            if (state === "error") {
-              core.setFailed(description);
-            }
 
   preflight_assets:
     name: Verify future-version data assets
@@ -1222,3 +1219,6 @@ jobs:
                 })
               )
             );
+            if (state === "error") {
+              core.setFailed(description);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     steps:
       - name: Normalize request
         id: resolve
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref || '' }}
           INPUT_WAREHOUSE: ${{ inputs.warehouse || '' }}
@@ -422,7 +422,7 @@ jobs:
       statuses: write
     steps:
       - name: Mark the tested pull request revision as pending
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
@@ -781,7 +781,7 @@ jobs:
       statuses: write
     steps:
       - name: Publish result for the tested pull request revision
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
           EXPECTED_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Tuva CI
+name: Tuva CI -- Snowflake
 
 on:
   pull_request:
@@ -16,11 +16,20 @@ on:
         required: true
         type: string
       warehouse:
-        description: Warehouse to validate
+        description: Fixed warehouse set to validate (snowflake or all)
         required: true
         type: string
+      scope:
+        description: Package scope to validate (core or all-packages)
+        required: true
+        type: string
+      source_lock:
+        description: Exact package source lock for all-packages scope
+        required: false
+        type: string
+        default: ""
       schema_prefix:
-        description: Explicit schema prefix for the build
+        description: Base schema prefix for the build
         required: true
         type: string
       concurrency_key:
@@ -28,7 +37,7 @@ on:
         required: true
         type: string
       publish_status:
-        description: Publish the required Snowflake commit status
+        description: Publish a commit status for the tested pull request
         required: false
         type: boolean
         default: false
@@ -105,7 +114,7 @@ permissions: {}
 concurrency:
   group: >-
     tuva-ci-${{
-      github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) ||
+      github.event_name == 'pull_request' && format('snowflake-pr-{0}', github.event.pull_request.number) ||
       inputs.concurrency_key ||
       format('run-{0}', github.run_id)
     }}
@@ -131,11 +140,11 @@ jobs:
       adapter_matrix: ${{ steps.resolve.outputs.adapter_matrix }}
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       schema_prefix: ${{ steps.resolve.outputs.schema_prefix }}
-      concurrency_key: ${{ steps.resolve.outputs.concurrency_key }}
       publish_status: ${{ steps.resolve.outputs.publish_status }}
-      mode: ${{ steps.resolve.outputs.mode }}
+      scope: ${{ steps.resolve.outputs.scope }}
       selector: ${{ steps.resolve.outputs.selector }}
       source_lock: ${{ steps.resolve.outputs.source_lock }}
+      status_context: ${{ steps.resolve.outputs.status_context }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       base_sha: ${{ steps.resolve.outputs.base_sha }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
@@ -147,6 +156,8 @@ jobs:
         env:
           INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref || '' }}
           INPUT_WAREHOUSE: ${{ inputs.warehouse || '' }}
+          INPUT_SCOPE: ${{ inputs.scope || '' }}
+          INPUT_SOURCE_LOCK: ${{ inputs.source_lock || '' }}
           INPUT_SCHEMA_PREFIX: ${{ inputs.schema_prefix || '' }}
           INPUT_CONCURRENCY_KEY: ${{ inputs.concurrency_key || '' }}
           INPUT_PUBLISH_STATUS: ${{ inputs.publish_status && 'true' || 'false' }}
@@ -163,9 +174,9 @@ jobs:
               "fabric",
               "redshift"
             ];
-            const defaultSelector =
+            const coreSelector =
               "package:integration_tests package:the_tuva_project";
-            const releaseSelector = [
+            const allPackagesSelector = [
               "package:integration_tests",
               "package:the_tuva_project",
               "package:ahrq_quality_indicators",
@@ -177,86 +188,61 @@ jobs:
               "package:quality_measures",
               "package:semantic_layer"
             ].join(" ");
-            const releasePackages = [
-              {
-                repository: "ahrq_quality_indicators",
-                dbtPackage: "ahrq_quality_indicators",
-                envVar: "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA"
-              },
-              {
-                repository: "ccsr",
-                dbtPackage: "ccsr",
-                envVar: "TUVA_CI_CCSR_SHA"
-              },
-              {
-                repository: "cms_chronic_conditions",
-                dbtPackage: "cms_chronic_conditions",
-                envVar: "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA"
-              },
-              {
-                repository: "cms_hcc",
-                dbtPackage: "cms_hcc",
-                envVar: "TUVA_CI_CMS_HCC_SHA"
-              },
-              {
-                repository: "fhir_preprocessing",
-                dbtPackage: "fhir_preprocessing",
-                envVar: "TUVA_CI_FHIR_PREPROCESSING_SHA"
-              },
-              {
-                repository: "nyu_ed_classification",
-                dbtPackage: "nyu_ed_classification",
-                envVar: "TUVA_CI_NYU_ED_CLASSIFICATION_SHA"
-              },
-              {
-                repository: "quality_measures",
-                dbtPackage: "quality_measures",
-                envVar: "TUVA_CI_QUALITY_MEASURES_SHA"
-              },
-              {
-                repository: "semantic-layer",
-                dbtPackage: "semantic_layer",
-                envVar: "TUVA_CI_SEMANTIC_LAYER_SHA"
-              }
+            const expectedStandalonePackages = [
+              [
+                `${context.repo.owner}/ahrq_quality_indicators`,
+                "ahrq_quality_indicators",
+                "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA"
+              ],
+              [
+                `${context.repo.owner}/ccsr`,
+                "ccsr",
+                "TUVA_CI_CCSR_SHA"
+              ],
+              [
+                `${context.repo.owner}/cms_chronic_conditions`,
+                "cms_chronic_conditions",
+                "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA"
+              ],
+              [
+                `${context.repo.owner}/cms_hcc`,
+                "cms_hcc",
+                "TUVA_CI_CMS_HCC_SHA"
+              ],
+              [
+                `${context.repo.owner}/fhir_preprocessing`,
+                "fhir_preprocessing",
+                "TUVA_CI_FHIR_PREPROCESSING_SHA"
+              ],
+              [
+                `${context.repo.owner}/nyu_ed_classification`,
+                "nyu_ed_classification",
+                "TUVA_CI_NYU_ED_CLASSIFICATION_SHA"
+              ],
+              [
+                `${context.repo.owner}/quality_measures`,
+                "quality_measures",
+                "TUVA_CI_QUALITY_MEASURES_SHA"
+              ],
+              [
+                `${context.repo.owner}/semantic-layer`,
+                "semantic_layer",
+                "TUVA_CI_SEMANTIC_LAYER_SHA"
+              ]
             ];
             const exactSha = /^[0-9a-f]{40}$/i;
-
-            async function projectVersion(ref) {
-              const { data } = await github.rest.repos.getContent({
-                ...context.repo,
-                path: "dbt_project.yml",
-                ref
-              });
-              if (Array.isArray(data) || data.type !== "file" || !data.content) {
-                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
-              }
-              const text = Buffer.from(
-                data.content.replace(/\n/g, ""),
-                data.encoding || "base64"
-              ).toString("utf8");
-              const versionPattern =
-                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
-              const matches = [...text.matchAll(versionPattern)];
-              if (matches.length !== 1) {
-                throw new Error(
-                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
-                );
-              }
-              return matches[0][2];
-            }
 
             const calledCheckoutRef = process.env.INPUT_CHECKOUT_REF.trim();
             const isReusableCall = calledCheckoutRef !== "";
 
             let shouldRun = true;
             let warehouse = "snowflake";
+            let scope = "core";
+            let sourceLock = "";
             let checkoutRef = "";
-            let schemaPrefix = "";
+            let schemaBase = "";
             let concurrencyKey = "";
             let publishStatus = false;
-            let mode = "default";
-            let selector = defaultSelector;
-            let sourceLock = "";
             let prNumber = "";
             let baseSha = "";
             let headSha = "";
@@ -271,8 +257,10 @@ jobs:
 
             if (isReusableCall) {
               warehouse = process.env.INPUT_WAREHOUSE.trim();
+              scope = process.env.INPUT_SCOPE.trim();
+              sourceLock = process.env.INPUT_SOURCE_LOCK.trim();
               checkoutRef = calledCheckoutRef;
-              schemaPrefix = process.env.INPUT_SCHEMA_PREFIX.trim();
+              schemaBase = process.env.INPUT_SCHEMA_PREFIX.trim();
               concurrencyKey = process.env.INPUT_CONCURRENCY_KEY.trim();
               publishStatus = process.env.INPUT_PUBLISH_STATUS === "true";
               prNumber = process.env.INPUT_PR_NUMBER.trim();
@@ -293,9 +281,10 @@ jobs:
               }
 
               warehouse = "snowflake";
+              scope = "core";
               checkoutRef = context.sha;
-              schemaPrefix = `ci_pr_${pr.number}_${pr.head.sha.slice(0, 8)}`;
-              concurrencyKey = `pr-${pr.number}`;
+              schemaBase = `ci_pr_${pr.number}_${pr.head.sha.slice(0, 8)}`;
+              concurrencyKey = `snowflake-pr-${pr.number}`;
               publishStatus = shouldRun;
               prNumber = String(pr.number);
               baseSha = pr.base.sha;
@@ -306,64 +295,15 @@ jobs:
               fail(`Unsupported event: ${context.eventName}`);
             }
 
-            if (shouldRun && !isReusableCall) {
-              try {
-                const [baseVersion, mergeVersion] = await Promise.all([
-                  projectVersion(baseSha),
-                  projectVersion(mergeSha)
-                ]);
-                if (baseVersion !== mergeVersion) {
-                  mode = "release";
-                  warehouse = "all";
-                  selector = releaseSelector;
-
-                  const standalonePackages = await Promise.all(
-                    releasePackages.map(async (item) => {
-                      const { data: commit } = await github.rest.repos.getCommit({
-                        owner: context.repo.owner,
-                        repo: item.repository,
-                        ref: "main"
-                      });
-                      if (!exactSha.test(commit.sha)) {
-                        throw new Error(
-                          `Could not resolve ${item.repository} main to an exact commit`
-                        );
-                      }
-                      return {
-                        repository: `${context.repo.owner}/${item.repository}`,
-                        dbt_package: item.dbtPackage,
-                        branch: "main",
-                        revision: commit.sha.toLowerCase(),
-                        env_var: item.envVar
-                      };
-                    })
-                  );
-                  sourceLock = JSON.stringify({
-                    core: {
-                      repository: `${context.repo.owner}/${context.repo.repo}`,
-                      source: "pull_request_test_merge",
-                      revision: mergeSha.toLowerCase()
-                    },
-                    base_version: baseVersion,
-                    release_version: mergeVersion,
-                    standalone_packages: standalonePackages
-                  });
-                  core.notice(
-                    `Release CI selected for version ${baseVersion} -> ${mergeVersion}`
-                  );
-                } else {
-                  core.notice(`Default CI selected; version remains ${mergeVersion}`);
-                }
-              } catch (error) {
-                fail(`Could not resolve CI mode: ${error.message}`);
-              }
+            const supportedRequests = new Set([
+              "snowflake:core",
+              "all:all-packages"
+            ]);
+            if (!supportedRequests.has(`${warehouse}:${scope}`)) {
+              fail(`Unsupported CI request: ${warehouse}:${scope}`);
             }
-
-            if (![...supportedWarehouses, "all"].includes(warehouse)) {
-              fail(`Unsupported warehouse: ${warehouse}`);
-            }
-            if (isReusableCall && warehouse !== "snowflake") {
-              fail("Reusable CI calls are restricted to default Snowflake CI.");
+            if (scope === "core" && sourceLock) {
+              fail("Core-only CI must not receive a standalone package source lock.");
             }
             if (shouldRun && !checkoutRef) {
               fail("checkout_ref is required.");
@@ -371,8 +311,49 @@ jobs:
             if (shouldRun && !exactSha.test(checkoutRef)) {
               fail("checkout_ref must be an exact 40-character commit SHA.");
             }
-            if (shouldRun && !/^[a-z0-9_]+$/.test(schemaPrefix)) {
-              fail(`Invalid schema prefix: ${schemaPrefix}`);
+            if (scope === "all-packages") {
+              try {
+                const parsedLock = JSON.parse(sourceLock);
+                const packages = parsedLock?.standalone_packages;
+                const expectedTriples = new Set(
+                  expectedStandalonePackages.map((item) => item.join("|"))
+                );
+                const actualTriples = new Set(
+                  Array.isArray(packages)
+                    ? packages.map((item) => [
+                        item.repository,
+                        item.dbt_package,
+                        item.env_var
+                      ].join("|"))
+                    : []
+                );
+                if (
+                  parsedLock?.core?.repository !==
+                    `${context.repo.owner}/${context.repo.repo}` ||
+                  parsedLock?.core?.source !== "pull_request_test_merge" ||
+                  parsedLock?.core?.revision !== checkoutRef.toLowerCase() ||
+                  typeof parsedLock?.base_version !== "string" ||
+                  typeof parsedLock?.release_version !== "string" ||
+                  parsedLock.base_version === parsedLock.release_version ||
+                  !Array.isArray(packages) ||
+                  packages.length !== expectedStandalonePackages.length ||
+                  actualTriples.size !== expectedTriples.size ||
+                  [...actualTriples].some((item) => !expectedTriples.has(item)) ||
+                  packages.some(
+                    (item) => item.branch !== "main" || !exactSha.test(item.revision)
+                  )
+                ) {
+                  throw new Error(
+                    "source lock must describe the checked-out Core revision and " +
+                    "the exact eight-package main-branch inventory"
+                  );
+                }
+              } catch (error) {
+                fail(`Invalid all-packages source lock: ${error.message}`);
+              }
+            }
+            if (shouldRun && !/^[a-z0-9_]+$/.test(schemaBase)) {
+              fail(`Invalid schema prefix base: ${schemaBase}`);
             }
             if (shouldRun && !concurrencyKey) {
               fail("concurrency_key is required.");
@@ -391,16 +372,31 @@ jobs:
               }
             }
 
+            const runId = process.env.GITHUB_RUN_ID || "";
+            const runAttempt = process.env.GITHUB_RUN_ATTEMPT || "";
+            if (shouldRun && (!/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt))) {
+              fail("GitHub run ID and attempt must be numeric.");
+            }
+            const schemaPrefix = schemaBase
+              ? `${schemaBase}_r${runId}_a${runAttempt}`
+              : "";
             const adapterMatrix = warehouse === "all" ? supportedWarehouses : [warehouse];
+            const selector = scope === "all-packages"
+              ? allPackagesSelector
+              : coreSelector;
+            const statusContext = scope === "all-packages"
+              ? "Tuva CI / All Warehouses"
+              : "Tuva CI / Snowflake";
+
             core.setOutput("should_run", String(shouldRun));
             core.setOutput("adapter_matrix", JSON.stringify(adapterMatrix));
             core.setOutput("checkout_ref", checkoutRef || "");
             core.setOutput("schema_prefix", schemaPrefix || "");
-            core.setOutput("concurrency_key", concurrencyKey || "");
             core.setOutput("publish_status", String(publishStatus));
-            core.setOutput("mode", mode);
+            core.setOutput("scope", scope);
             core.setOutput("selector", selector);
             core.setOutput("source_lock", sourceLock);
+            core.setOutput("status_context", statusContext);
             core.setOutput("pr_number", prNumber);
             core.setOutput("base_sha", baseSha);
             core.setOutput("head_sha", headSha);
@@ -419,44 +415,266 @@ jobs:
       needs.resolve.outputs.publish_status == 'true'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      pull-requests: read
       statuses: write
     steps:
       - name: Mark the tested pull request revision as pending
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          EXPECTED_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
-          CI_MODE: ${{ needs.resolve.outputs.mode }}
+          CI_SCOPE: ${{ needs.resolve.outputs.scope }}
+          STATUS_CONTEXT: ${{ needs.resolve.outputs.status_context }}
         with:
           script: |
             const targetUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const description = process.env.CI_MODE === "release"
-              ? "Full release compatibility matrix is running"
-              : "Required Snowflake Core build is running";
+            const prNumber = Number(process.env.PR_NUMBER);
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: prNumber
+            });
+            const { data: currentMerge } = await github.rest.repos.getCommit({
+              ...context.repo,
+              ref: `refs/pull/${prNumber}/merge`
+            });
+            const requestIsCurrent =
+              pr.state === "open" &&
+              pr.base.ref === "main" &&
+              pr.base.sha === process.env.EXPECTED_BASE_SHA &&
+              pr.head.sha === process.env.HEAD_SHA &&
+              currentMerge.sha === process.env.MERGE_SHA;
+            if (!requestIsCurrent) {
+              core.setFailed(
+                `PR #${prNumber} changed before CI could publish pending status.`
+              );
+              return;
+            }
+
+            const statusRefs = [process.env.HEAD_SHA, process.env.MERGE_SHA];
+            const latestStatuses = await Promise.all(
+              statusRefs.map(async (ref) => {
+                const { data: statuses } =
+                  await github.rest.repos.listCommitStatusesForRef({
+                    ...context.repo,
+                    ref,
+                    per_page: 100
+                  });
+                return statuses.find(
+                  (status) => status.context === process.env.STATUS_CONTEXT
+                );
+              })
+            );
+            const newerRunOwnsStatus = latestStatuses.some((status) => {
+              if (!status || status.target_url === targetUrl) {
+                return false;
+              }
+              const match = status.target_url?.match(/\/actions\/runs\/(\d+)/);
+              return match && BigInt(match[1]) > BigInt(context.runId);
+            });
+            if (newerRunOwnsStatus) {
+              core.setFailed("A newer CI run already owns this status context.");
+              return;
+            }
+
+            const description = process.env.CI_SCOPE === "all-packages"
+              ? "All-warehouse release CI is running"
+              : "Snowflake Core CI is running";
             await Promise.all(
-              [process.env.HEAD_SHA, process.env.MERGE_SHA].map((sha) =>
+              statusRefs.map((sha) =>
                 github.rest.repos.createCommitStatus({
                   ...context.repo,
                   sha,
                   state: "pending",
-                  context: "Tuva CI / Required",
+                  context: process.env.STATUS_CONTEXT,
                   description,
                   target_url: targetUrl
                 })
               )
             );
 
+  preflight_assets:
+    name: Verify future-version data assets
+    needs: resolve
+    if: >-
+      needs.resolve.result == 'success' &&
+      needs.resolve.outputs.should_run == 'true' &&
+      needs.resolve.outputs.scope == 'all-packages'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact release candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
+          persist-credentials: false
+
+      - name: Verify every declared asset exists in all public clouds
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+        run: |
+          python3 - <<'PY'
+          import concurrent.futures
+          import json
+          import os
+          import re
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+          from pathlib import Path
+
+          version_pattern = re.compile(
+              r"^version:\s*(['\"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$",
+              re.MULTILINE,
+          )
+          project_text = Path("dbt_project.yml").read_text(encoding="utf-8")
+          versions = version_pattern.findall(project_text)
+          if len(versions) != 1:
+              raise SystemExit(
+                  f"expected exactly one top-level version; found {len(versions)}"
+              )
+          package_version = versions[0][1]
+
+          source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
+          if source_lock.get("release_version") != package_version:
+              raise SystemExit(
+                  "source lock release version does not match dbt_project.yml"
+              )
+
+          catalog_text = Path("data_assets.yml").read_text(encoding="utf-8")
+          catalog_code = "\n".join(
+              line.split("#", 1)[0] for line in catalog_text.splitlines()
+          )
+          asset_paths = re.findall(r"^    path: (\S+)$", catalog_code, re.MULTILINE)
+          canonical_seeds = re.findall(
+              r"^  - seed: (\S+)$", catalog_code, re.MULTILINE
+          )
+          declared_path_keys = len(
+              re.findall(r"(?<![A-Za-z0-9_-])path\s*:", catalog_code)
+          )
+          declared_seed_keys = len(
+              re.findall(r"(?<![A-Za-z0-9_-])seed\s*:", catalog_code)
+          )
+          if not asset_paths:
+              raise SystemExit("data_assets.yml does not declare any asset paths")
+          if (
+              declared_path_keys != len(asset_paths)
+              or declared_seed_keys != len(canonical_seeds)
+              or len(canonical_seeds) != len(asset_paths)
+          ):
+              raise SystemExit(
+                  "data_assets.yml must use one canonical seed/path mapping per asset; "
+                  "release preflight refuses to skip unrecognized YAML declarations"
+              )
+          if len(asset_paths) != len(set(asset_paths)):
+              raise SystemExit("data_assets.yml contains duplicate asset paths")
+
+          providers = {
+              "s3": "https://tuva-public-resources.s3.amazonaws.com",
+              "gcs": "https://storage.googleapis.com/tuva-public-resources",
+              "azure": (
+                  "https://tuvapublicresources.blob.core.windows.net/"
+                  "tuva-public-resources"
+              ),
+          }
+          version_component = urllib.parse.quote(package_version, safe="")
+
+          def head_status(url):
+              last_error = None
+              for attempt in range(3):
+                  request = urllib.request.Request(
+                      url,
+                      method="HEAD",
+                      headers={"User-Agent": "tuva-core-release-ci"},
+                  )
+                  try:
+                      with urllib.request.urlopen(request, timeout=30) as response:
+                          return response.status, None
+                  except urllib.error.HTTPError as exc:
+                      return exc.code, None
+                  except (urllib.error.URLError, TimeoutError) as exc:
+                      last_error = str(exc)
+                  if attempt < 2:
+                      time.sleep(1 + attempt)
+              return None, last_error
+
+          def probe_payload(item):
+              provider, asset_path = item
+              encoded_path = urllib.parse.quote(asset_path, safe="/")
+              url = (
+                  f"{providers[provider]}/tuva-core/{version_component}/"
+                  f"{encoded_path}"
+              )
+              status, error = head_status(url)
+              if status is not None and 200 <= status < 300:
+                  return None
+              detail = f"HTTP {status}" if status is not None else error
+              return f"{provider}: {asset_path}: {detail}"
+
+          probes = [
+              (provider, asset_path)
+              for provider in providers
+              for asset_path in asset_paths
+          ]
+          with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
+              failures = [
+                  failure for failure in executor.map(probe_payload, probes) if failure
+              ]
+
+          if failures:
+              preview = "\n".join(failures[:50])
+              remainder = len(failures) - min(len(failures), 50)
+              if remainder:
+                  preview += f"\n... and {remainder} more missing objects"
+              raise SystemExit(
+                  f"future-version data asset preflight failed:\n{preview}"
+              )
+
+          receipt_failures = []
+          for provider, base_url in providers.items():
+              receipt_url = (
+                  f"{base_url}/tuva-core/{version_component}/_release.json"
+              )
+              status, error = head_status(receipt_url)
+              if status != 404:
+                  detail = f"HTTP {status}" if status is not None else error
+                  receipt_failures.append(f"{provider}: {detail}")
+          if receipt_failures:
+              raise SystemExit(
+                  "future-version snapshots must not have _release.json before merge:\n"
+                  + "\n".join(receipt_failures)
+              )
+
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a", encoding="utf-8") as output:
+              output.write("## Data asset preflight\n\n")
+              output.write(f"- Version: `{package_version}`\n")
+              output.write(f"- Declared objects per cloud: {len(asset_paths)}\n")
+              output.write(f"- Verified object paths: {len(probes)}\n")
+              output.write("- `_release.json` absent from all clouds: yes\n")
+          print(
+              f"Verified {len(asset_paths)} future-version assets across "
+              f"{len(providers)} clouds"
+          )
+          PY
+
   build:
     name: Build / ${{ matrix.warehouse }}
     needs:
       - resolve
       - mark_pending
+      - preflight_assets
     if: >-
       always() &&
       needs.resolve.result == 'success' &&
       needs.resolve.outputs.should_run == 'true' &&
-      (needs.mark_pending.result == 'success' || needs.mark_pending.result == 'skipped')
+      (needs.mark_pending.result == 'success' || needs.mark_pending.result == 'skipped') &&
+      (needs.preflight_assets.result == 'success' || needs.preflight_assets.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -465,7 +683,7 @@ jobs:
       matrix:
         warehouse: ${{ fromJson(needs.resolve.outputs.adapter_matrix) }}
     env:
-      CI_MODE: ${{ needs.resolve.outputs.mode }}
+      CI_SCOPE: ${{ needs.resolve.outputs.scope }}
       CI_DBT_SELECTOR: ${{ needs.resolve.outputs.selector }}
       TUVA_CI_SCHEMA_PREFIX: ${{ needs.resolve.outputs.schema_prefix }}
       CI_DBT_VARS: >-
@@ -518,8 +736,8 @@ jobs:
               ;;
           esac
 
-      - name: Configure release package sources
-        if: env.CI_MODE == 'release'
+      - name: Configure all-package sources
+        if: env.CI_SCOPE == 'all-packages'
         env:
           CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
         run: |
@@ -533,28 +751,60 @@ jobs:
           source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
           packages = source_lock.get("standalone_packages")
           if not isinstance(packages, list) or len(packages) != 8:
-              raise SystemExit("release source lock must contain eight standalone packages")
+              raise SystemExit("source lock must contain eight standalone packages")
 
           exact_sha = re.compile(r"^[0-9a-f]{40}$")
-          expected_env_vars = {
-              "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA",
-              "TUVA_CI_CCSR_SHA",
-              "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA",
-              "TUVA_CI_CMS_HCC_SHA",
-              "TUVA_CI_FHIR_PREPROCESSING_SHA",
-              "TUVA_CI_NYU_ED_CLASSIFICATION_SHA",
-              "TUVA_CI_QUALITY_MEASURES_SHA",
-              "TUVA_CI_SEMANTIC_LAYER_SHA",
+          owner = os.environ["GITHUB_REPOSITORY_OWNER"]
+          expected_packages = {
+              (
+                  f"{owner}/ahrq_quality_indicators",
+                  "ahrq_quality_indicators",
+                  "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA",
+              ),
+              (f"{owner}/ccsr", "ccsr", "TUVA_CI_CCSR_SHA"),
+              (
+                  f"{owner}/cms_chronic_conditions",
+                  "cms_chronic_conditions",
+                  "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA",
+              ),
+              (f"{owner}/cms_hcc", "cms_hcc", "TUVA_CI_CMS_HCC_SHA"),
+              (
+                  f"{owner}/fhir_preprocessing",
+                  "fhir_preprocessing",
+                  "TUVA_CI_FHIR_PREPROCESSING_SHA",
+              ),
+              (
+                  f"{owner}/nyu_ed_classification",
+                  "nyu_ed_classification",
+                  "TUVA_CI_NYU_ED_CLASSIFICATION_SHA",
+              ),
+              (
+                  f"{owner}/quality_measures",
+                  "quality_measures",
+                  "TUVA_CI_QUALITY_MEASURES_SHA",
+              ),
+              (
+                  f"{owner}/semantic-layer",
+                  "semantic_layer",
+                  "TUVA_CI_SEMANTIC_LAYER_SHA",
+              ),
           }
-          actual_env_vars = {item.get("env_var") for item in packages}
-          if actual_env_vars != expected_env_vars:
-              raise SystemExit("release source lock package inventory is invalid")
+          actual_packages = {
+              (
+                  item.get("repository"),
+                  item.get("dbt_package"),
+                  item.get("env_var"),
+              )
+              for item in packages
+          }
+          if actual_packages != expected_packages:
+              raise SystemExit("source lock package inventory is invalid")
 
           env_path = Path(os.environ["GITHUB_ENV"])
           with env_path.open("a", encoding="utf-8") as env_file:
               for item in packages:
                   revision = item.get("revision", "")
-                  if not exact_sha.fullmatch(revision):
+                  if item.get("branch") != "main" or not exact_sha.fullmatch(revision):
                       raise SystemExit(
                           f"invalid revision for {item.get('repository', 'unknown')}"
                       )
@@ -571,8 +821,8 @@ jobs:
           )
           PY
 
-      - name: Summarize release sources
-        if: env.CI_MODE == 'release'
+      - name: Summarize all-package sources
+        if: env.CI_SCOPE == 'all-packages'
         env:
           CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
         run: |
@@ -583,7 +833,7 @@ jobs:
 
           source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
           lines = [
-              "## Release CI source lock",
+              "## All-warehouse CI source lock",
               "",
               f"- Tuva Core test merge: `{source_lock['core']['revision']}`",
           ]
@@ -690,8 +940,8 @@ jobs:
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
-      - name: Prepare release evidence
-        if: always() && env.CI_MODE == 'release'
+      - name: Prepare all-warehouse evidence
+        if: always() && env.CI_SCOPE == 'all-packages'
         env:
           CI_WAREHOUSE: ${{ matrix.warehouse }}
           CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
@@ -707,6 +957,8 @@ jobs:
           evidence = {
               "warehouse": os.environ["CI_WAREHOUSE"],
               "github_run_id": os.environ["GITHUB_RUN_ID"],
+              "github_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "scope": "all-packages",
               "source_lock": json.loads(os.environ["CI_SOURCE_LOCK"]),
               "manifest": None,
               "run_results": None,
@@ -751,11 +1003,11 @@ jobs:
           )
           PY
 
-      - name: Upload release evidence
-        if: always() && env.CI_MODE == 'release'
+      - name: Upload all-warehouse evidence
+        if: always() && env.CI_SCOPE == 'all-packages'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: tuva-release-ci-${{ matrix.warehouse }}-${{ github.run_id }}
+          name: tuva-all-warehouses-ci-${{ matrix.warehouse }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             integration_tests/ci-evidence.json
             integration_tests/package-lock.yml
@@ -769,6 +1021,7 @@ jobs:
     needs:
       - resolve
       - mark_pending
+      - preflight_assets
       - build
     if: >-
       always() &&
@@ -787,8 +1040,11 @@ jobs:
           EXPECTED_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
           EXPECTED_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           EXPECTED_MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
-          CI_MODE: ${{ needs.resolve.outputs.mode }}
+          CI_SCOPE: ${{ needs.resolve.outputs.scope }}
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+          STATUS_CONTEXT: ${{ needs.resolve.outputs.status_context }}
           RESOLVE_RESULT: ${{ needs.resolve.result }}
+          PREFLIGHT_RESULT: ${{ needs.preflight_assets.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           PENDING_RESULT: ${{ needs.mark_pending.result }}
         with:
@@ -797,15 +1053,18 @@ jobs:
             const expectedBase = process.env.EXPECTED_BASE_SHA;
             const expectedHead = process.env.EXPECTED_HEAD_SHA;
             const expectedMerge = process.env.EXPECTED_MERGE_SHA;
-            const mode = process.env.CI_MODE;
+            const scope = process.env.CI_SCOPE;
+            const sourceLock = process.env.CI_SOURCE_LOCK;
+            const statusContext = process.env.STATUS_CONTEXT;
             const resolveResult = process.env.RESOLVE_RESULT;
+            const preflightResult = process.env.PREFLIGHT_RESULT;
             const buildResult = process.env.BUILD_RESULT;
             const pendingResult = process.env.PENDING_RESULT;
             const runUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let state = "error";
-            let description = `Required CI ended with ${buildResult}`;
+            let description = `CI ended with ${buildResult}`;
 
             try {
               const { data: pr } = await github.rest.pulls.get({
@@ -824,24 +1083,63 @@ jobs:
                 pr.head.sha === expectedHead &&
                 currentMerge.sha === expectedMerge;
 
+              let packageSourcesAreCurrent = true;
+              if (scope === "all-packages") {
+                const lockedPackages =
+                  JSON.parse(sourceLock).standalone_packages;
+                const currentPackages = await Promise.all(
+                  lockedPackages.map(async (packageSource) => {
+                    const [, repository] = packageSource.repository.split("/");
+                    const { data: commit } = await github.rest.repos.getCommit({
+                      owner: context.repo.owner,
+                      repo: repository,
+                      ref: "main"
+                    });
+                    return {
+                      repository: packageSource.repository,
+                      expected: packageSource.revision,
+                      current: commit.sha.toLowerCase()
+                    };
+                  })
+                );
+                packageSourcesAreCurrent = currentPackages.every(
+                  (item) => item.current === item.expected
+                );
+                if (!packageSourcesAreCurrent) {
+                  for (const item of currentPackages) {
+                    if (item.current !== item.expected) {
+                      core.warning(
+                        `${item.repository} main moved from ${item.expected} ` +
+                        `to ${item.current}.`
+                      );
+                    }
+                  }
+                }
+              }
+
               if (!requestIsCurrent) {
                 description = "PR changed while CI was running; rerun required";
+              } else if (!packageSourcesAreCurrent) {
+                description = "A standalone package main changed; rerun required";
               } else if (pendingResult !== "success") {
                 description = "CI could not publish its pending status";
               } else if (resolveResult !== "success") {
                 description = "CI request resolution failed";
+              } else if (preflightResult === "failure") {
+                state = "failure";
+                description = "Future-version data asset preflight failed";
               } else if (buildResult === "success") {
                 state = "success";
-                description = mode === "release"
-                  ? "Full release compatibility matrix passed"
+                description = scope === "all-packages"
+                  ? "All-warehouse release CI passed"
                   : "Snowflake Core build passed";
               } else if (buildResult === "failure") {
                 state = "failure";
-                description = mode === "release"
-                  ? "Full release compatibility matrix failed"
+                description = scope === "all-packages"
+                  ? "All-warehouse release CI failed"
                   : "Snowflake Core build failed";
               } else {
-                description = `Required CI ended with ${buildResult}`;
+                description = `CI ended with ${buildResult}`;
               }
             } catch (error) {
               core.warning(`Could not revalidate PR #${prNumber}: ${error.message}`);
@@ -858,7 +1156,7 @@ jobs:
                     per_page: 100
                   });
                 return statuses.find(
-                  (status) => status.context === "Tuva CI / Required"
+                  (status) => status.context === statusContext
                 );
               })
             );
@@ -880,7 +1178,7 @@ jobs:
                   ...context.repo,
                   sha,
                   state,
-                  context: "Tuva CI / Required",
+                  context: statusContext,
                   description,
                   target_url: runUrl
                 })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,6 +495,9 @@ jobs:
                 })
               )
             );
+            if (state === "error") {
+              core.setFailed(description);
+            }
 
   preflight_assets:
     name: Verify future-version data assets
@@ -688,7 +691,8 @@ jobs:
       TUVA_CI_SCHEMA_PREFIX: ${{ needs.resolve.outputs.schema_prefix }}
       CI_DBT_VARS: >-
         {"use_synthetic_data": true, "synthetic_data_size": "small",
-        "parity_enabled": false,
+        "parity_enabled": false, "data_quality_enabled": true,
+        "enable_data_quality_failure_keys": true,
         "tuva_schema_prefix": "${{ needs.resolve.outputs.schema_prefix }}"}
     steps:
       - name: Checkout exact commit
@@ -745,7 +749,6 @@ jobs:
           import json
           import os
           import re
-          import shutil
           from pathlib import Path
 
           source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
@@ -811,9 +814,21 @@ jobs:
                   env_file.write(f"{item['env_var']}={revision}\n")
 
           integration_dir = Path("integration_tests")
-          shutil.copyfile(
-              integration_dir / "packages.release.yml",
-              integration_dir / "packages.yml",
+          release_manifest = ["packages:", "  - local: ../"]
+          for item in packages:
+              release_manifest.extend(
+                  [
+                      f"  - git: https://github.com/{item['repository']}.git",
+                      (
+                          "    revision: \"{{ env_var('"
+                          + item["env_var"]
+                          + "') }}\""
+                      ),
+                  ]
+              )
+          (integration_dir / "packages.yml").write_text(
+              "\n".join(release_manifest) + "\n",
+              encoding="utf-8",
           )
           (integration_dir / "ci-source-lock.json").write_text(
               json.dumps(source_lock, indent=2, sort_keys=True) + "\n",
@@ -963,23 +978,44 @@ jobs:
               "manifest": None,
               "run_results": None,
           }
+          expected_dbt_packages = {
+              "integration_tests",
+              "the_tuva_project",
+              "ahrq_quality_indicators",
+              "ccsr",
+              "cms_chronic_conditions",
+              "cms_hcc",
+              "fhir_preprocessing",
+              "nyu_ed_classification",
+              "quality_measures",
+              "semantic_layer",
+          }
+          coverage_error = None
 
           manifest_path = target_dir / "manifest.json"
           if manifest_path.exists():
               manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
               nodes = manifest.get("nodes", {})
+              nodes_by_package = Counter(
+                  node.get("package_name", "unknown")
+                  for node in nodes.values()
+              )
+              missing_packages = sorted(
+                  expected_dbt_packages - nodes_by_package.keys()
+              )
+              if missing_packages:
+                  coverage_error = (
+                      "all-package build manifest has no enabled nodes for: "
+                      + ", ".join(missing_packages)
+                  )
               evidence["manifest"] = {
                   "dbt_version": manifest.get("metadata", {}).get("dbt_version"),
                   "node_count": len(nodes),
-                  "nodes_by_package": dict(
-                      sorted(
-                          Counter(
-                              node.get("package_name", "unknown")
-                              for node in nodes.values()
-                          ).items()
-                      )
-                  ),
+                  "nodes_by_package": dict(sorted(nodes_by_package.items())),
+                  "required_packages_present": not missing_packages,
               }
+          else:
+              coverage_error = "all-package build did not produce a dbt manifest"
 
           results_path = target_dir / "run_results.json"
           if results_path.exists():
@@ -1001,6 +1037,8 @@ jobs:
               json.dumps(evidence, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
+          if coverage_error:
+              raise SystemExit(coverage_error)
           PY
 
       - name: Upload all-warehouse evidence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-  workflow_dispatch:
-    inputs:
-      warehouse:
-        description: Warehouse to validate
-        required: true
-        type: choice
-        default: snowflake
-        options:
-          - snowflake
-          - bigquery
-          - databricks
-          - fabric
-          - redshift
-          - all
   workflow_call:
     inputs:
       checkout_ref:
@@ -121,7 +107,7 @@ concurrency:
     tuva-ci-${{
       github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) ||
       inputs.concurrency_key ||
-      format('manual-{0}', github.run_id)
+      format('run-{0}', github.run_id)
     }}
   cancel-in-progress: true
 
@@ -138,6 +124,8 @@ jobs:
   resolve:
     name: Resolve request
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}
       adapter_matrix: ${{ steps.resolve.outputs.adapter_matrix }}
@@ -145,6 +133,9 @@ jobs:
       schema_prefix: ${{ steps.resolve.outputs.schema_prefix }}
       concurrency_key: ${{ steps.resolve.outputs.concurrency_key }}
       publish_status: ${{ steps.resolve.outputs.publish_status }}
+      mode: ${{ steps.resolve.outputs.mode }}
+      selector: ${{ steps.resolve.outputs.selector }}
+      source_lock: ${{ steps.resolve.outputs.source_lock }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       base_sha: ${{ steps.resolve.outputs.base_sha }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
@@ -172,20 +163,111 @@ jobs:
               "fabric",
               "redshift"
             ];
+            const defaultSelector =
+              "package:integration_tests package:the_tuva_project";
+            const releaseSelector = [
+              "package:integration_tests",
+              "package:the_tuva_project",
+              "package:ahrq_quality_indicators",
+              "package:ccsr",
+              "package:cms_chronic_conditions",
+              "package:cms_hcc",
+              "package:fhir_preprocessing",
+              "package:nyu_ed_classification",
+              "package:quality_measures",
+              "package:semantic_layer"
+            ].join(" ");
+            const releasePackages = [
+              {
+                repository: "ahrq_quality_indicators",
+                dbtPackage: "ahrq_quality_indicators",
+                envVar: "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA"
+              },
+              {
+                repository: "ccsr",
+                dbtPackage: "ccsr",
+                envVar: "TUVA_CI_CCSR_SHA"
+              },
+              {
+                repository: "cms_chronic_conditions",
+                dbtPackage: "cms_chronic_conditions",
+                envVar: "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA"
+              },
+              {
+                repository: "cms_hcc",
+                dbtPackage: "cms_hcc",
+                envVar: "TUVA_CI_CMS_HCC_SHA"
+              },
+              {
+                repository: "fhir_preprocessing",
+                dbtPackage: "fhir_preprocessing",
+                envVar: "TUVA_CI_FHIR_PREPROCESSING_SHA"
+              },
+              {
+                repository: "nyu_ed_classification",
+                dbtPackage: "nyu_ed_classification",
+                envVar: "TUVA_CI_NYU_ED_CLASSIFICATION_SHA"
+              },
+              {
+                repository: "quality_measures",
+                dbtPackage: "quality_measures",
+                envVar: "TUVA_CI_QUALITY_MEASURES_SHA"
+              },
+              {
+                repository: "semantic-layer",
+                dbtPackage: "semantic_layer",
+                envVar: "TUVA_CI_SEMANTIC_LAYER_SHA"
+              }
+            ];
+            const exactSha = /^[0-9a-f]{40}$/i;
+
+            async function projectVersion(ref) {
+              const { data } = await github.rest.repos.getContent({
+                ...context.repo,
+                path: "dbt_project.yml",
+                ref
+              });
+              if (Array.isArray(data) || data.type !== "file" || !data.content) {
+                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
+              }
+              const text = Buffer.from(
+                data.content.replace(/\n/g, ""),
+                data.encoding || "base64"
+              ).toString("utf8");
+              const versionPattern =
+                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
+              const matches = [...text.matchAll(versionPattern)];
+              if (matches.length !== 1) {
+                throw new Error(
+                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
+                );
+              }
+              return matches[0][2];
+            }
 
             const calledCheckoutRef = process.env.INPUT_CHECKOUT_REF.trim();
             const isReusableCall = calledCheckoutRef !== "";
 
             let shouldRun = true;
-            let warehouse;
-            let checkoutRef;
-            let schemaPrefix;
-            let concurrencyKey;
+            let warehouse = "snowflake";
+            let checkoutRef = "";
+            let schemaPrefix = "";
+            let concurrencyKey = "";
             let publishStatus = false;
+            let mode = "default";
+            let selector = defaultSelector;
+            let sourceLock = "";
             let prNumber = "";
             let baseSha = "";
             let headSha = "";
             let mergeSha = "";
+            let resolutionError = "";
+
+            function fail(message) {
+              if (!resolutionError) {
+                resolutionError = message;
+              }
+            }
 
             if (isReusableCall) {
               warehouse = process.env.INPUT_WAREHOUSE.trim();
@@ -220,54 +302,92 @@ jobs:
               headSha = pr.head.sha;
               mergeSha = context.sha;
             } else {
-              warehouse = String(context.payload.inputs?.warehouse || "snowflake").trim();
-              checkoutRef = context.sha;
-              schemaPrefix = `ci_manual_${process.env.GITHUB_RUN_ID}`;
-              concurrencyKey = `manual-${process.env.GITHUB_RUN_ID}`;
+              shouldRun = false;
+              fail(`Unsupported event: ${context.eventName}`);
+            }
+
+            if (shouldRun && !isReusableCall) {
+              try {
+                const [baseVersion, mergeVersion] = await Promise.all([
+                  projectVersion(baseSha),
+                  projectVersion(mergeSha)
+                ]);
+                if (baseVersion !== mergeVersion) {
+                  mode = "release";
+                  warehouse = "all";
+                  selector = releaseSelector;
+
+                  const standalonePackages = await Promise.all(
+                    releasePackages.map(async (item) => {
+                      const { data: commit } = await github.rest.repos.getCommit({
+                        owner: context.repo.owner,
+                        repo: item.repository,
+                        ref: "main"
+                      });
+                      if (!exactSha.test(commit.sha)) {
+                        throw new Error(
+                          `Could not resolve ${item.repository} main to an exact commit`
+                        );
+                      }
+                      return {
+                        repository: `${context.repo.owner}/${item.repository}`,
+                        dbt_package: item.dbtPackage,
+                        branch: "main",
+                        revision: commit.sha.toLowerCase(),
+                        env_var: item.envVar
+                      };
+                    })
+                  );
+                  sourceLock = JSON.stringify({
+                    core: {
+                      repository: `${context.repo.owner}/${context.repo.repo}`,
+                      source: "pull_request_test_merge",
+                      revision: mergeSha.toLowerCase()
+                    },
+                    base_version: baseVersion,
+                    release_version: mergeVersion,
+                    standalone_packages: standalonePackages
+                  });
+                  core.notice(
+                    `Release CI selected for version ${baseVersion} -> ${mergeVersion}`
+                  );
+                } else {
+                  core.notice(`Default CI selected; version remains ${mergeVersion}`);
+                }
+              } catch (error) {
+                fail(`Could not resolve CI mode: ${error.message}`);
+              }
             }
 
             if (![...supportedWarehouses, "all"].includes(warehouse)) {
-              core.setFailed(`Unsupported warehouse: ${warehouse}`);
-              return;
+              fail(`Unsupported warehouse: ${warehouse}`);
             }
             if (isReusableCall && warehouse !== "snowflake") {
-              core.setFailed("Reusable CI calls are restricted to Snowflake.");
-              return;
+              fail("Reusable CI calls are restricted to default Snowflake CI.");
             }
             if (shouldRun && !checkoutRef) {
-              core.setFailed("checkout_ref is required.");
-              return;
+              fail("checkout_ref is required.");
             }
-            if (shouldRun && !/^[0-9a-f]{40}$/i.test(checkoutRef)) {
-              core.setFailed("checkout_ref must be an exact 40-character commit SHA.");
-              return;
+            if (shouldRun && !exactSha.test(checkoutRef)) {
+              fail("checkout_ref must be an exact 40-character commit SHA.");
             }
             if (shouldRun && !/^[a-z0-9_]+$/.test(schemaPrefix)) {
-              core.setFailed(`Invalid schema prefix: ${schemaPrefix}`);
-              return;
+              fail(`Invalid schema prefix: ${schemaPrefix}`);
             }
             if (shouldRun && !concurrencyKey) {
-              core.setFailed("concurrency_key is required.");
-              return;
+              fail("concurrency_key is required.");
             }
             if (publishStatus) {
-              if (warehouse !== "snowflake") {
-                core.setFailed("The required status may be published only by a Snowflake build.");
-                return;
-              }
-              const exactSha = /^[0-9a-f]{40}$/i;
               if (
                 !/^\d+$/.test(prNumber) ||
                 !exactSha.test(baseSha) ||
                 !exactSha.test(headSha) ||
                 !exactSha.test(mergeSha)
               ) {
-                core.setFailed("PR number and exact base, head, and merge commits are required.");
-                return;
+                fail("PR number and exact base, head, and merge commits are required.");
               }
               if (checkoutRef !== mergeSha) {
-                core.setFailed("The required status must describe the exact test-merge commit being built.");
-                return;
+                fail("The required status must describe the exact test-merge commit being built.");
               }
             }
 
@@ -278,15 +398,23 @@ jobs:
             core.setOutput("schema_prefix", schemaPrefix || "");
             core.setOutput("concurrency_key", concurrencyKey || "");
             core.setOutput("publish_status", String(publishStatus));
+            core.setOutput("mode", mode);
+            core.setOutput("selector", selector);
+            core.setOutput("source_lock", sourceLock);
             core.setOutput("pr_number", prNumber);
             core.setOutput("base_sha", baseSha);
             core.setOutput("head_sha", headSha);
             core.setOutput("merge_sha", mergeSha);
 
+            if (resolutionError) {
+              core.setFailed(resolutionError);
+            }
+
   mark_pending:
     name: Publish pending status
     needs: resolve
     if: >-
+      always() &&
       needs.resolve.outputs.should_run == 'true' &&
       needs.resolve.outputs.publish_status == 'true'
     runs-on: ubuntu-latest
@@ -298,18 +426,22 @@ jobs:
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
+          CI_MODE: ${{ needs.resolve.outputs.mode }}
         with:
           script: |
             const targetUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const description = process.env.CI_MODE === "release"
+              ? "Full release compatibility matrix is running"
+              : "Required Snowflake Core build is running";
             await Promise.all(
               [process.env.HEAD_SHA, process.env.MERGE_SHA].map((sha) =>
                 github.rest.repos.createCommitStatus({
                   ...context.repo,
                   sha,
                   state: "pending",
-                  context: "Tuva CI / Snowflake",
-                  description: "Snowflake dbt build is running",
+                  context: "Tuva CI / Required",
+                  description,
                   target_url: targetUrl
                 })
               )
@@ -322,6 +454,7 @@ jobs:
       - mark_pending
     if: >-
       always() &&
+      needs.resolve.result == 'success' &&
       needs.resolve.outputs.should_run == 'true' &&
       (needs.mark_pending.result == 'success' || needs.mark_pending.result == 'skipped')
     runs-on: ubuntu-latest
@@ -332,6 +465,9 @@ jobs:
       matrix:
         warehouse: ${{ fromJson(needs.resolve.outputs.adapter_matrix) }}
     env:
+      CI_MODE: ${{ needs.resolve.outputs.mode }}
+      CI_DBT_SELECTOR: ${{ needs.resolve.outputs.selector }}
+      TUVA_CI_SCHEMA_PREFIX: ${{ needs.resolve.outputs.schema_prefix }}
       CI_DBT_VARS: >-
         {"use_synthetic_data": true, "synthetic_data_size": "small",
         "parity_enabled": false,
@@ -382,9 +518,88 @@ jobs:
               ;;
           esac
 
+      - name: Configure release package sources
+        if: env.CI_MODE == 'release'
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import shutil
+          from pathlib import Path
+
+          source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
+          packages = source_lock.get("standalone_packages")
+          if not isinstance(packages, list) or len(packages) != 8:
+              raise SystemExit("release source lock must contain eight standalone packages")
+
+          exact_sha = re.compile(r"^[0-9a-f]{40}$")
+          expected_env_vars = {
+              "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA",
+              "TUVA_CI_CCSR_SHA",
+              "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA",
+              "TUVA_CI_CMS_HCC_SHA",
+              "TUVA_CI_FHIR_PREPROCESSING_SHA",
+              "TUVA_CI_NYU_ED_CLASSIFICATION_SHA",
+              "TUVA_CI_QUALITY_MEASURES_SHA",
+              "TUVA_CI_SEMANTIC_LAYER_SHA",
+          }
+          actual_env_vars = {item.get("env_var") for item in packages}
+          if actual_env_vars != expected_env_vars:
+              raise SystemExit("release source lock package inventory is invalid")
+
+          env_path = Path(os.environ["GITHUB_ENV"])
+          with env_path.open("a", encoding="utf-8") as env_file:
+              for item in packages:
+                  revision = item.get("revision", "")
+                  if not exact_sha.fullmatch(revision):
+                      raise SystemExit(
+                          f"invalid revision for {item.get('repository', 'unknown')}"
+                      )
+                  env_file.write(f"{item['env_var']}={revision}\n")
+
+          integration_dir = Path("integration_tests")
+          shutil.copyfile(
+              integration_dir / "packages.release.yml",
+              integration_dir / "packages.yml",
+          )
+          (integration_dir / "ci-source-lock.json").write_text(
+              json.dumps(source_lock, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Summarize release sources
+        if: env.CI_MODE == 'release'
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
+          lines = [
+              "## Release CI source lock",
+              "",
+              f"- Tuva Core test merge: `{source_lock['core']['revision']}`",
+          ]
+          for package in source_lock["standalone_packages"]:
+              lines.append(
+                  f"- {package['repository']} `main`: `{package['revision']}`"
+              )
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open(
+              "a", encoding="utf-8"
+          ) as summary:
+              summary.write("\n".join(lines) + "\n")
+          PY
+
       - name: Install dbt dependencies
         run: >-
-          dbt deps
+          dbt deps --upgrade
           --project-dir ./integration_tests
           --profiles-dir ./integration_tests/profiles/${{ matrix.warehouse }}
 
@@ -399,11 +614,12 @@ jobs:
           DBT_SNOWFLAKE_CI_USER: ${{ secrets.DBT_SNOWFLAKE_CI_USER }}
           DBT_SNOWFLAKE_CI_PASSWORD: ${{ secrets.DBT_SNOWFLAKE_CI_PASSWORD }}
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/snowflake
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/snowflake \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on BigQuery
@@ -414,11 +630,12 @@ jobs:
         run: |
           trap 'rm -f ./creds.json' EXIT
           printf '%s' "$DBT_BIGQUERY_CI_TOKEN" | base64 --decode > ./creds.json
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/bigquery
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/bigquery \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on Databricks
@@ -429,11 +646,12 @@ jobs:
           DBT_DATABRICKS_CI_TOKEN: ${{ secrets.DBT_DATABRICKS_CI_TOKEN }}
           DBT_DATABRICKS_CI_CATALOG: ${{ secrets.DBT_DATABRICKS_CI_CATALOG }}
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/databricks
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/databricks \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on Fabric
@@ -446,11 +664,12 @@ jobs:
           DBT_FABRIC_CI_CLIENT_SECRET: ${{ secrets.DBT_FABRIC_CI_CLIENT_SECRET }}
           DBT_FABRIC_CI_TENANT_ID: ${{ secrets.DBT_FABRIC_CI_TENANT_ID }}
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/fabric
           dbt build --full-refresh --cache-selected-only \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/fabric \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on Redshift
@@ -463,12 +682,87 @@ jobs:
           DBT_REDSHIFT_CI_THREADS: "4"
           DBT_REDSHIFT_CI_SEED_BATCH_SIZE: "2000"
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/redshift
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/redshift \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
+
+      - name: Prepare release evidence
+        if: always() && env.CI_MODE == 'release'
+        env:
+          CI_WAREHOUSE: ${{ matrix.warehouse }}
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from collections import Counter
+          from pathlib import Path
+
+          integration_dir = Path("integration_tests")
+          target_dir = integration_dir / "target"
+          evidence = {
+              "warehouse": os.environ["CI_WAREHOUSE"],
+              "github_run_id": os.environ["GITHUB_RUN_ID"],
+              "source_lock": json.loads(os.environ["CI_SOURCE_LOCK"]),
+              "manifest": None,
+              "run_results": None,
+          }
+
+          manifest_path = target_dir / "manifest.json"
+          if manifest_path.exists():
+              manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+              nodes = manifest.get("nodes", {})
+              evidence["manifest"] = {
+                  "dbt_version": manifest.get("metadata", {}).get("dbt_version"),
+                  "node_count": len(nodes),
+                  "nodes_by_package": dict(
+                      sorted(
+                          Counter(
+                              node.get("package_name", "unknown")
+                              for node in nodes.values()
+                          ).items()
+                      )
+                  ),
+              }
+
+          results_path = target_dir / "run_results.json"
+          if results_path.exists():
+              run_results = json.loads(results_path.read_text(encoding="utf-8"))
+              evidence["run_results"] = {
+                  "elapsed_time": run_results.get("elapsed_time"),
+                  "results": [
+                      {
+                          "unique_id": result.get("unique_id"),
+                          "status": result.get("status"),
+                          "execution_time": result.get("execution_time"),
+                          "failures": result.get("failures"),
+                      }
+                      for result in run_results.get("results", [])
+                  ],
+              }
+
+          (integration_dir / "ci-evidence.json").write_text(
+              json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload release evidence
+        if: always() && env.CI_MODE == 'release'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tuva-release-ci-${{ matrix.warehouse }}-${{ github.run_id }}
+          path: |
+            integration_tests/ci-evidence.json
+            integration_tests/package-lock.yml
+            integration_tests/packages.yml
+            integration_tests/ci-source-lock.json
+          if-no-files-found: warn
+          retention-days: 90
 
   finalize_status:
     name: Publish final status
@@ -493,6 +787,8 @@ jobs:
           EXPECTED_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
           EXPECTED_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           EXPECTED_MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
+          CI_MODE: ${{ needs.resolve.outputs.mode }}
+          RESOLVE_RESULT: ${{ needs.resolve.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           PENDING_RESULT: ${{ needs.mark_pending.result }}
         with:
@@ -501,13 +797,15 @@ jobs:
             const expectedBase = process.env.EXPECTED_BASE_SHA;
             const expectedHead = process.env.EXPECTED_HEAD_SHA;
             const expectedMerge = process.env.EXPECTED_MERGE_SHA;
+            const mode = process.env.CI_MODE;
+            const resolveResult = process.env.RESOLVE_RESULT;
             const buildResult = process.env.BUILD_RESULT;
             const pendingResult = process.env.PENDING_RESULT;
             const runUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let state = "error";
-            let description = `Snowflake dbt build ended with ${buildResult}`;
+            let description = `Required CI ended with ${buildResult}`;
 
             try {
               const { data: pr } = await github.rest.pulls.get({
@@ -527,21 +825,27 @@ jobs:
                 currentMerge.sha === expectedMerge;
 
               if (!requestIsCurrent) {
-                description = "PR changed while Snowflake CI was running; rerun required";
+                description = "PR changed while CI was running; rerun required";
               } else if (pendingResult !== "success") {
-                description = "Snowflake CI could not publish its pending status";
+                description = "CI could not publish its pending status";
+              } else if (resolveResult !== "success") {
+                description = "CI request resolution failed";
               } else if (buildResult === "success") {
                 state = "success";
-                description = "Snowflake dbt build passed";
+                description = mode === "release"
+                  ? "Full release compatibility matrix passed"
+                  : "Snowflake Core build passed";
               } else if (buildResult === "failure") {
                 state = "failure";
-                description = "Snowflake dbt build failed";
+                description = mode === "release"
+                  ? "Full release compatibility matrix failed"
+                  : "Snowflake Core build failed";
               } else {
-                description = `Snowflake dbt build ended with ${buildResult}`;
+                description = `Required CI ended with ${buildResult}`;
               }
             } catch (error) {
               core.warning(`Could not revalidate PR #${prNumber}: ${error.message}`);
-              description = "Snowflake CI could not revalidate the pull request";
+              description = "CI could not revalidate the pull request";
             }
 
             const statusRefs = [expectedHead, expectedMerge];
@@ -554,7 +858,7 @@ jobs:
                     per_page: 100
                   });
                 return statuses.find(
-                  (status) => status.context === "Tuva CI / Snowflake"
+                  (status) => status.context === "Tuva CI / Required"
                 );
               })
             );
@@ -564,7 +868,7 @@ jobs:
               )
             ) {
               core.notice(
-                "A newer Snowflake CI run owns the required status; " +
+                "A newer CI run owns the required status; " +
                 "this run will not overwrite it."
               );
               return;
@@ -576,7 +880,7 @@ jobs:
                   ...context.repo,
                   sha,
                   state,
-                  context: "Tuva CI / Snowflake",
+                  context: "Tuva CI / Required",
                   description,
                   target_url: runUrl
                 })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,15 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.10"
-  DBT_CORE_VERSION: "1.10.15"
-  DBT_SNOWFLAKE_VERSION: "1.10.8"
-  DBT_BIGQUERY_VERSION: "1.10.3"
-  DBT_DATABRICKS_VERSION: "1.10.19"
-  DBT_FABRIC_VERSION: "1.10.0"
-  DBT_REDSHIFT_VERSION: "1.10.2"
+  DBT_CORE_VERSION: "1.11.14"
+  DBT_SNOWFLAKE_VERSION: "1.11.6"
+  DBT_BIGQUERY_VERSION: "1.11.3"
+  DBT_DATABRICKS_VERSION: "1.12.4"
+  DBT_FABRIC_VERSION: "1.11.1"
+  DBT_REDSHIFT_VERSION: "1.11.1"
+  SQLPARSE_VERSION: "0.6.0"
+  DBT_SQLPARSE_OPTIONS: >-
+    {"MAX_GROUPING_DEPTH": 100, "MAX_GROUPING_TOKENS": 100000}
 
 jobs:
   resolve:
@@ -717,25 +720,28 @@ jobs:
           python -m pip install --upgrade pip
           case "${{ matrix.warehouse }}" in
             snowflake)
-              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-snowflake==${DBT_SNOWFLAKE_VERSION}"
+              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-snowflake==${DBT_SNOWFLAKE_VERSION}" "sqlparse==${SQLPARSE_VERSION}"
               ;;
             bigquery)
-              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-bigquery==${DBT_BIGQUERY_VERSION}"
+              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-bigquery==${DBT_BIGQUERY_VERSION}" "sqlparse==${SQLPARSE_VERSION}"
               ;;
             databricks)
-              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-databricks==${DBT_DATABRICKS_VERSION}" certifi
+              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-databricks==${DBT_DATABRICKS_VERSION}" "sqlparse==${SQLPARSE_VERSION}" certifi
               ;;
             fabric)
-              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-fabric==${DBT_FABRIC_VERSION}"
+              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-fabric==${DBT_FABRIC_VERSION}" "sqlparse==${SQLPARSE_VERSION}"
               ;;
             redshift)
-              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-redshift==${DBT_REDSHIFT_VERSION}"
+              pip install "dbt-core==${DBT_CORE_VERSION}" "dbt-redshift==${DBT_REDSHIFT_VERSION}" "sqlparse==${SQLPARSE_VERSION}"
               ;;
             *)
               echo "Unsupported warehouse: ${{ matrix.warehouse }}" >&2
               exit 1
               ;;
           esac
+          python -m pip check
+          dbt --version
+          python -c 'import sqlparse; print(f"sqlparse={sqlparse.__version__}")'
 
       - name: Configure all-package sources
         if: env.CI_SCOPE == 'all-packages'
@@ -881,6 +887,7 @@ jobs:
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/snowflake \
+            --sqlparse "$DBT_SQLPARSE_OPTIONS" \
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
@@ -897,6 +904,7 @@ jobs:
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/bigquery \
+            --sqlparse "$DBT_SQLPARSE_OPTIONS" \
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
@@ -913,6 +921,7 @@ jobs:
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/databricks \
+            --sqlparse "$DBT_SQLPARSE_OPTIONS" \
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
@@ -931,6 +940,7 @@ jobs:
           dbt build --full-refresh --cache-selected-only \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/fabric \
+            --sqlparse "$DBT_SQLPARSE_OPTIONS" \
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
@@ -949,6 +959,7 @@ jobs:
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/redshift \
+            --sqlparse "$DBT_SQLPARSE_OPTIONS" \
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,17 +169,23 @@ content is loaded from public object storage.
   `dbt build --full-refresh` against the small synthetic dataset. The build
   selects Tuva Core plus the integration-test project and runs unit and data
   tests. Parity remains disabled.
-- Additional warehouse validation is manually initiated from GitHub Actions.
-  Choose Snowflake, BigQuery, Databricks, Fabric, Redshift, or `all`; every
-  target runs the same fixed Core build.
+- A pull request that changes the top-level Tuva Core version automatically
+  switches to release CI. It builds the exact pull-request test-merge commit
+  plus all eight accepted standalone package `main` branches on Snowflake,
+  BigQuery, Databricks, Fabric, and Redshift with the small synthetic dataset.
+  Each package branch is resolved once to an exact commit shared by all jobs.
+- Individual warehouse troubleshooting is local; GitHub CI has no general
+  manual warehouse dispatcher.
 - DuckDB portability is validated locally as needed rather than in GitHub CI.
 - Pull-request comment commands do not trigger CI and CI does not accept
   arbitrary dbt commands, selectors, or flags.
 - Automatic secrets-backed CI does not execute fork code. After reviewing an
   external pull request, a maintainer runs `External PR Snowflake CI` from the
-  Actions tab and supplies only the pull-request number.
+  Actions tab and supplies only the pull-request number. Version-changing pull
+  requests must use an internal branch so release CI can run.
 - Standalone packages validate in their own repositories. Routine Tuva Core CI
-  does not install mutable standalone-package branches.
+  does not install standalone packages; release CI snapshots their `main`
+  branches to exact commits before building.
 - Parity comparisons are separate, manually initiated Snowflake validations.
 - Do not edit `.github/workflows/create-release.yml` unless the task explicitly
   targets release automation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,9 @@ content is loaded from public object storage.
 - In-repository pull requests automatically run `Tuva CI -- Snowflake`: one
   Snowflake `dbt build --full-refresh` against the small synthetic dataset. The
   build selects Tuva Core plus the integration-test project and runs unit and
-  data tests. Version changes do not alter this automatic path. Parity remains
-  disabled.
+  data tests. Data Quality, including its optional failure-key relation, is
+  enabled so the complete Core test surface executes. Version changes do not
+  alter this automatic path. Parity remains disabled.
 - Run `Tuva CI -- All Warehouses` manually from the Actions tab for the final
   release pull request. Its only input is the pull-request number. It accepts
   only an open, mergeable, same-repository pull request into `main` that changes
@@ -180,9 +181,10 @@ content is loaded from public object storage.
 - The all-warehouse workflow resolves the pull request test-merge and all eight
   standalone package `main` branches once to exact commits. It then runs Tuva
   Core, the integration-test project, and all eight packages on Snowflake,
-  BigQuery, Databricks, Fabric, and Redshift against synthetic small. Before
-  warehouse credentials are used, it verifies that every Core candidate asset
-  exists in S3, GCS, and Azure and that no `_release.json` has been finalized.
+  BigQuery, Databricks, Fabric, and Redshift against synthetic small with Data
+  Quality and its optional failure-key relation enabled. Before warehouse
+  credentials are used, it verifies that every Core candidate asset exists in
+  S3, GCS, and Azure and that no `_release.json` has been finalized.
 - CI does not expose individual warehouse dispatches. Troubleshoot a single
   warehouse locally when needed.
 - DuckDB portability is validated locally as needed rather than in GitHub CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,11 @@ from git worktrees.
   - `data_assets.yml` declares the exact package-owned object inventory. The
     publisher-generated `_release.json` is a completion receipt bound to the
     exact package git commit in `package_commit` and is not read by dbt at
-    runtime. Package tags must not be created until the matching receipt is
-    available from S3, GCS, and Azure and names the current `main` commit.
+    runtime. Future-version payload folders may be created before the matching
+    version change reaches `main`, but they are candidates rather than completed
+    snapshots and must not contain `_release.json`. Package tags must not be
+    created until the post-merge receipt is available from S3, GCS, and Azure
+    and names the current `main` commit.
   - Data asset changes must preserve cross-warehouse loading behavior.
 
 ## Mandatory Local Rules
@@ -165,27 +168,33 @@ content is loaded from public object storage.
 
 ## CI Guidance
 
-- In-repository pull requests automatically run one Snowflake
-  `dbt build --full-refresh` against the small synthetic dataset. The build
-  selects Tuva Core plus the integration-test project and runs unit and data
-  tests. Parity remains disabled.
-- A pull request that changes the top-level Tuva Core version automatically
-  switches to release CI. It builds the exact pull-request test-merge commit
-  plus all eight accepted standalone package `main` branches on Snowflake,
-  BigQuery, Databricks, Fabric, and Redshift with the small synthetic dataset.
-  Each package branch is resolved once to an exact commit shared by all jobs.
-- Individual warehouse troubleshooting is local; GitHub CI has no general
-  manual warehouse dispatcher.
+- In-repository pull requests automatically run `Tuva CI -- Snowflake`: one
+  Snowflake `dbt build --full-refresh` against the small synthetic dataset. The
+  build selects Tuva Core plus the integration-test project and runs unit and
+  data tests. Version changes do not alter this automatic path. Parity remains
+  disabled.
+- Run `Tuva CI -- All Warehouses` manually from the Actions tab for the final
+  release pull request. Its only input is the pull-request number. It accepts
+  only an open, mergeable, same-repository pull request into `main` that changes
+  the Tuva Core package version.
+- The all-warehouse workflow resolves the pull request test-merge and all eight
+  standalone package `main` branches once to exact commits. It then runs Tuva
+  Core, the integration-test project, and all eight packages on Snowflake,
+  BigQuery, Databricks, Fabric, and Redshift against synthetic small. Before
+  warehouse credentials are used, it verifies that every Core candidate asset
+  exists in S3, GCS, and Azure and that no `_release.json` has been finalized.
+- CI does not expose individual warehouse dispatches. Troubleshoot a single
+  warehouse locally when needed.
 - DuckDB portability is validated locally as needed rather than in GitHub CI.
 - Pull-request comment commands do not trigger CI and CI does not accept
   arbitrary dbt commands, selectors, or flags.
 - Automatic secrets-backed CI does not execute fork code. After reviewing an
   external pull request, a maintainer runs `External PR Snowflake CI` from the
-  Actions tab and supplies only the pull-request number. Version-changing pull
-  requests must use an internal branch so release CI can run.
-- Standalone packages validate in their own repositories. Routine Tuva Core CI
-  does not install standalone packages; release CI snapshots their `main`
-  branches to exact commits before building.
+  Actions tab and supplies only the pull-request number. External version
+  changes are rejected because release CI requires a same-repository branch.
+- Standalone packages validate in their own repositories. Routine Snowflake CI
+  does not install standalone packages; only manual release CI snapshots their
+  `main` branches to exact commits before building.
 - Parity comparisons are separate, manually initiated Snowflake validations.
 - Do not edit `.github/workflows/create-release.yml` unless the task explicitly
   targets release automation.

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -80,26 +80,37 @@ testing cross-package compatibility.
 
 ## Continuous Integration
 
-In-repository pull requests automatically run the Core build on Snowflake with
-the small synthetic dataset. If the pull request changes the top-level Tuva Core
-version, that run automatically switches to release validation: the exact pull
-request test-merge commit plus all eight accepted standalone package `main`
-branches run on Snowflake, BigQuery, Databricks, Fabric, and Redshift. Package
-branches are resolved once to exact commits so every warehouse tests the same
-source set. DuckDB remains available for local portability checks.
+`Tuva CI -- Snowflake` runs automatically for every in-repository pull request.
+It tests the exact pull-request merge commit on Snowflake using Tuva Core, the
+integration project, and the small synthetic dataset. A package version change
+does not change this automatic path.
 
-Release CI selects the integration project, Tuva Core, AHRQ Quality Indicators,
-CCSR, CMS Chronic Conditions, CMS HCC, FHIR Preprocessing, NYU ED
-Classification, Quality Measures, and Semantic Layer. It keeps the small
-synthetic dataset enabled and parity disabled, and retains each warehouse's dbt
-result summary and resolved source lock for 90 days. Raw logs and warehouse
-connection metadata are not included. There is no general-purpose manual
-warehouse dispatcher; troubleshoot individual warehouses locally.
+For the final release pull request, dispatch `Tuva CI -- All Warehouses` from
+the Actions tab and enter only its pull-request number. The workflow accepts an
+open, mergeable, same-repository pull request into `main` only when its exact
+test merge changes the Tuva Core package version. It resolves all eight
+standalone package `main` branches once to exact commits, then uses that single
+source lock for Snowflake, BigQuery, Databricks, Fabric, and Redshift.
+
+The manual release build selects the integration project, Tuva Core, AHRQ
+Quality Indicators, CCSR, CMS Chronic Conditions, CMS HCC, FHIR Preprocessing,
+NYU ED Classification, Quality Measures, and Semantic Layer. Before any
+warehouse job receives credentials, CI verifies that every Core asset declared
+by the release candidate exists under its future version in S3, GCS, and Azure
+and that `_release.json` is absent. The receipt is finalized against the merged
+`main` commit later; candidate payloads alone are sufficient for PR validation.
+
+Both workflows keep the small synthetic dataset enabled and parity disabled.
+The all-warehouse workflow retains each warehouse's sanitized dbt result
+summary and resolved source lock for 90 days; raw logs and warehouse connection
+metadata are not included. There is no individual-warehouse dispatcher.
+Troubleshoot individual warehouses locally, and use DuckDB locally for
+portability checks.
 
 Reviewed fork pull requests use the separate `External PR Snowflake CI`
 workflow. Its only input is the pull-request number. CI does not accept
-pull-request comment commands or arbitrary dbt commands. Version changes must
-come from an internal branch so the secrets-backed release matrix can run.
+pull-request comment commands or arbitrary dbt commands. External version
+changes are rejected because the release matrix requires an internal branch.
 
 ## Data Asset Loading
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -81,13 +81,25 @@ testing cross-package compatibility.
 ## Continuous Integration
 
 In-repository pull requests automatically run the Core build on Snowflake with
-the small synthetic dataset. From GitHub Actions, maintainers can run that same
-fixed build manually on Snowflake, BigQuery, Databricks, Fabric, Redshift, or
-all five warehouses. DuckDB remains available for local portability checks.
+the small synthetic dataset. If the pull request changes the top-level Tuva Core
+version, that run automatically switches to release validation: the exact pull
+request test-merge commit plus all eight accepted standalone package `main`
+branches run on Snowflake, BigQuery, Databricks, Fabric, and Redshift. Package
+branches are resolved once to exact commits so every warehouse tests the same
+source set. DuckDB remains available for local portability checks.
+
+Release CI selects the integration project, Tuva Core, AHRQ Quality Indicators,
+CCSR, CMS Chronic Conditions, CMS HCC, FHIR Preprocessing, NYU ED
+Classification, Quality Measures, and Semantic Layer. It keeps the small
+synthetic dataset enabled and parity disabled, and retains each warehouse's dbt
+result summary and resolved source lock for 90 days. Raw logs and warehouse
+connection metadata are not included. There is no general-purpose manual
+warehouse dispatcher; troubleshoot individual warehouses locally.
 
 Reviewed fork pull requests use the separate `External PR Snowflake CI`
 workflow. Its only input is the pull-request number. CI does not accept
-pull-request comment commands or arbitrary dbt commands.
+pull-request comment commands or arbitrary dbt commands. Version changes must
+come from an internal branch so the secrets-backed release matrix can run.
 
 ## Data Asset Loading
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -82,8 +82,9 @@ testing cross-package compatibility.
 
 `Tuva CI -- Snowflake` runs automatically for every in-repository pull request.
 It tests the exact pull-request merge commit on Snowflake using Tuva Core, the
-integration project, and the small synthetic dataset. A package version change
-does not change this automatic path.
+integration project, and the small synthetic dataset. Data Quality and its
+optional failure-key relation are enabled so the complete Core test surface
+runs. A package version change does not change this automatic path.
 
 For the final release pull request, dispatch `Tuva CI -- All Warehouses` from
 the Actions tab and enter only its pull-request number. The workflow accepts an
@@ -100,12 +101,12 @@ by the release candidate exists under its future version in S3, GCS, and Azure
 and that `_release.json` is absent. The receipt is finalized against the merged
 `main` commit later; candidate payloads alone are sufficient for PR validation.
 
-Both workflows keep the small synthetic dataset enabled and parity disabled.
-The all-warehouse workflow retains each warehouse's sanitized dbt result
-summary and resolved source lock for 90 days; raw logs and warehouse connection
-metadata are not included. There is no individual-warehouse dispatcher.
-Troubleshoot individual warehouses locally, and use DuckDB locally for
-portability checks.
+Both workflows keep the small synthetic dataset and Data Quality failure-key
+coverage enabled while parity remains disabled. The all-warehouse workflow
+retains each warehouse's sanitized dbt result summary and resolved source lock
+for 90 days; raw logs and warehouse connection metadata are not included. There
+is no individual-warehouse dispatcher. Troubleshoot individual warehouses
+locally, and use DuckDB locally for portability checks.
 
 Reviewed fork pull requests use the separate `External PR Snowflake CI`
 workflow. Its only input is the pull-request number. CI does not accept

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -118,6 +118,9 @@ clean-targets:
   - "target"
   - "dbt_packages"
 
+on-run-start:
+  - "{{ ensure_target_schema_for_unit_tests() }}"
+
 
 dispatch:
   - macro_namespace: 'dbt'

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -131,6 +131,17 @@ models:
     +materialized: table
     +schema: |
       {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_input_layer{%- else -%}input_layer{%- endif -%}
+  ccsr:
+    +schema: |
+      {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_ccsr{%- else -%}ccsr{%- endif -%}
+  semantic_layer:
+    +schema: |
+      {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_semantic_layer{%- else -%}semantic_layer{%- endif -%}
+
+seeds:
+  ccsr:
+    +schema: |
+      {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_ccsr{%- else -%}ccsr{%- endif -%}
 flags:
   require_generic_test_arguments_property: true
   require_ref_searches_node_package_before_root: true

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -120,6 +120,8 @@ clean-targets:
 
 
 dispatch:
+  - macro_namespace: 'dbt'
+    search_order: ['integration_tests', 'dbt']
   - macro_namespace: 'the_tuva_project'
     search_order: ['integration_tests', 'the_tuva_project']
   - macro_namespace: 'dbt_utils'

--- a/integration_tests/macros/bigquery_seed.sql
+++ b/integration_tests/macros/bigquery_seed.sql
@@ -1,0 +1,77 @@
+{#
+  dbt-bigquery does not create a relation for a header-only seed before it
+  applies table options. Tuva's committed seed files intentionally contain
+  only headers because their rows are loaded from versioned cloud assets in a
+  post-hook. Create the typed empty relation here so the normal materialization
+  can reach that post-hook.
+
+  Keep the nonempty branch aligned with dbt-bigquery's implementation so this
+  override remains safe if the integration project gains an inline seed.
+#}
+
+{% macro bigquery__load_csv_rows(model, agate_table) %}
+  {%- set column_override = model['config'].get('column_types', {}) -%}
+
+  {% if agate_table.rows | length == 0 %}
+    {%- set quote_seed_column = model['config'].get('quote_columns', none) -%}
+    {%- set missing_columns = [] -%}
+    {%- set extra_columns = [] -%}
+
+    {% for column_name in agate_table.column_names %}
+      {% if not column_override.get(column_name) %}
+        {% do missing_columns.append(column_name) %}
+      {% endif %}
+    {% endfor %}
+
+    {% for column_name in column_override %}
+      {% if column_name not in agate_table.column_names %}
+        {% do extra_columns.append(column_name) %}
+      {% endif %}
+    {% endfor %}
+
+    {% if missing_columns or extra_columns %}
+      {{ exceptions.raise_compiler_error(
+          "Header-only BigQuery seed " ~ model['name'] ~
+          " requires column_types that exactly match its CSV header. " ~
+          "Missing: " ~ (missing_columns | join(', ')) ~ "; extra: " ~
+          (extra_columns | join(', '))
+      ) }}
+    {% endif %}
+
+    {% set create_sql %}
+      create or replace table {{ this.render() }} (
+        {% for column_name in agate_table.column_names %}
+          {{ adapter.quote_seed_column(column_name | string, quote_seed_column) }}
+          {{ api.Column.translate_type(column_override[column_name]) }}
+          {%- if not loop.last %}, {% endif %}
+        {% endfor %}
+      )
+    {% endset %}
+
+    {% call statement('create_header_only_seed_relation') %}
+      {{ create_sql }}
+    {% endcall %}
+  {% else %}
+    {% do adapter.load_dataframe(
+        model['database'],
+        model['schema'],
+        model['alias'],
+        agate_table,
+        column_override,
+        model['config']['delimiter']
+    ) %}
+  {% endif %}
+
+  {% call statement() %}
+    alter table {{ this.render() }} set {{ bigquery_table_options(config, model) }}
+  {% endcall %}
+
+  {% if config.persist_relation_docs() and 'description' in model %}
+    {% do adapter.update_table_description(
+        model['database'],
+        model['schema'],
+        model['alias'],
+        model['description']
+    ) %}
+  {% endif %}
+{% endmacro %}

--- a/integration_tests/macros/bigquery_seed.sql
+++ b/integration_tests/macros/bigquery_seed.sql
@@ -1,22 +1,19 @@
 {#
-  dbt-bigquery does not create a relation for a header-only seed before it
-  applies table options. Tuva's committed seed files intentionally contain
-  only headers because their rows are loaded from versioned cloud assets in a
-  post-hook. Create the typed empty relation here so the normal materialization
-  can reach that post-hook.
-
-  Keep the nonempty branch aligned with dbt-bigquery's implementation so this
-  override remains safe if the integration project gains an inline seed.
+  dbt-bigquery treats table creation as a no-op and drops an existing table
+  during seed reset. That works when dbt subsequently uploads inline rows, but
+  dbt-core 1.10 skips row loading for Tuva's intentionally header-only seed
+  files. Create the typed empty relation in both paths so the normal Tuva
+  post-hook can replace it with the versioned cloud asset.
 #}
 
-{% macro bigquery__load_csv_rows(model, agate_table) %}
+{% macro bigquery_create_seed_relation(model, agate_table, relation) %}
   {%- set column_override = model['config'].get('column_types', {}) -%}
+  {%- set quote_seed_column = model['config'].get('quote_columns', none) -%}
+  {%- set missing_columns = [] -%}
+  {%- set extra_columns = [] -%}
+  {%- set column_definitions = [] -%}
 
   {% if agate_table.rows | length == 0 %}
-    {%- set quote_seed_column = model['config'].get('quote_columns', none) -%}
-    {%- set missing_columns = [] -%}
-    {%- set extra_columns = [] -%}
-
     {% for column_name in agate_table.column_names %}
       {% if not column_override.get(column_name) %}
         {% do missing_columns.append(column_name) %}
@@ -37,41 +34,39 @@
           (extra_columns | join(', '))
       ) }}
     {% endif %}
-
-    {% set create_sql %}
-      create or replace table {{ this.render() }} (
-        {% for column_name in agate_table.column_names %}
-          {{ adapter.quote_seed_column(column_name | string, quote_seed_column) }}
-          {{ api.Column.translate_type(column_override[column_name]) }}
-          {%- if not loop.last %}, {% endif %}
-        {% endfor %}
-      )
-    {% endset %}
-
-    {% call statement('create_header_only_seed_relation') %}
-      {{ create_sql }}
-    {% endcall %}
-  {% else %}
-    {% do adapter.load_dataframe(
-        model['database'],
-        model['schema'],
-        model['alias'],
-        agate_table,
-        column_override,
-        model['config']['delimiter']
-    ) %}
   {% endif %}
 
-  {% call statement() %}
-    alter table {{ this.render() }} set {{ bigquery_table_options(config, model) }}
+  {% for column_name in agate_table.column_names %}
+    {%- set configured_type = column_override.get(column_name) -%}
+    {%- set column_type = configured_type
+        if configured_type
+        else adapter.convert_type(agate_table, loop.index0) -%}
+    {% do column_definitions.append(
+        adapter.quote_seed_column(column_name | string, quote_seed_column) ~
+        " " ~ api.Column.translate_type(column_type)
+    ) %}
+  {% endfor %}
+
+  {% set create_sql %}
+    create or replace table {{ relation.render() }} (
+      {{ column_definitions | join(',\n      ') }}
+    )
+  {% endset %}
+
+  {% call statement('create_bigquery_seed_relation') %}
+    {{ create_sql }}
   {% endcall %}
 
-  {% if config.persist_relation_docs() and 'description' in model %}
-    {% do adapter.update_table_description(
-        model['database'],
-        model['schema'],
-        model['alias'],
-        model['description']
-    ) %}
-  {% endif %}
+  {{ return(create_sql) }}
+{% endmacro %}
+
+
+{% macro bigquery__create_csv_table(model, agate_table) %}
+  {{ return(bigquery_create_seed_relation(model, agate_table, this)) }}
+{% endmacro %}
+
+
+{% macro bigquery__reset_csv_table(model, full_refresh, old_relation, agate_table) %}
+  {% do adapter.drop_relation(old_relation) %}
+  {{ return(bigquery_create_seed_relation(model, agate_table, this)) }}
 {% endmacro %}

--- a/integration_tests/macros/ensure_target_schema_for_unit_tests.sql
+++ b/integration_tests/macros/ensure_target_schema_for_unit_tests.sql
@@ -1,0 +1,13 @@
+{#
+    dbt unit tests can use target.schema for temporary relations. Because every
+    integration-test node has a custom schema, dbt does not otherwise create it.
+#}
+{% macro ensure_target_schema_for_unit_tests() -%}
+    {%- if execute -%}
+        {%- set target_schema_relation = api.Relation.create(
+            database=target.database,
+            schema=target.schema
+        ) -%}
+        {%- do adapter.create_schema(target_schema_relation) -%}
+    {%- endif -%}
+{%- endmacro %}

--- a/integration_tests/packages.release.yml
+++ b/integration_tests/packages.release.yml
@@ -1,0 +1,18 @@
+packages:
+  - local: ../
+  - git: https://github.com/tuva-health/ahrq_quality_indicators.git
+    revision: "{{ env_var('TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA') }}"
+  - git: https://github.com/tuva-health/ccsr.git
+    revision: "{{ env_var('TUVA_CI_CCSR_SHA') }}"
+  - git: https://github.com/tuva-health/cms_chronic_conditions.git
+    revision: "{{ env_var('TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA') }}"
+  - git: https://github.com/tuva-health/cms_hcc.git
+    revision: "{{ env_var('TUVA_CI_CMS_HCC_SHA') }}"
+  - git: https://github.com/tuva-health/fhir_preprocessing.git
+    revision: "{{ env_var('TUVA_CI_FHIR_PREPROCESSING_SHA') }}"
+  - git: https://github.com/tuva-health/nyu_ed_classification.git
+    revision: "{{ env_var('TUVA_CI_NYU_ED_CLASSIFICATION_SHA') }}"
+  - git: https://github.com/tuva-health/quality_measures.git
+    revision: "{{ env_var('TUVA_CI_QUALITY_MEASURES_SHA') }}"
+  - git: https://github.com/tuva-health/semantic-layer.git
+    revision: "{{ env_var('TUVA_CI_SEMANTIC_LAYER_SHA') }}"

--- a/integration_tests/profiles/bigquery/profiles.yml
+++ b/integration_tests/profiles/bigquery/profiles.yml
@@ -6,7 +6,7 @@ default:
       method: service-account
       keyfile: ./creds.json
       project: "{{ env_var('DBT_BIGQUERY_CI_PROJECT') }}"
-      dataset: connector
+      dataset: "connector_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
       threads: 4
       timeout_seconds: 300
       location: US

--- a/integration_tests/profiles/databricks/profiles.yml
+++ b/integration_tests/profiles/databricks/profiles.yml
@@ -7,7 +7,7 @@ default:
         http_path: "{{ env_var('DBT_DATABRICKS_CI_HTTP_PATH') }}"
         token: "{{ env_var('DBT_DATABRICKS_CI_TOKEN') }}"
         catalog: "{{ env_var('DBT_DATABRICKS_CI_CATALOG') }}"
-        schema: default
+        schema: "default_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
         threads: 8
         connect_timeout: 60
         connect_retries: 3

--- a/integration_tests/profiles/fabric/profiles.yml
+++ b/integration_tests/profiles/fabric/profiles.yml
@@ -7,7 +7,7 @@ default:
       authentication: ActiveDirectoryServicePrincipal
       server: "{{ env_var('DBT_FABRIC_CI_SERVER') }}"
       database: "{{ env_var('DBT_FABRIC_CI_DATABASE') }}"
-      schema: "{{ env_var('DBT_FABRIC_CI_SCHEMA') }}"
+      schema: "{{ env_var('DBT_FABRIC_CI_SCHEMA') }}_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
       client_id: "{{ env_var('DBT_FABRIC_CI_CLIENT_ID') }}"
       client_secret: "{{ env_var('DBT_FABRIC_CI_CLIENT_SECRET') }}"
       tenant_id: "{{ env_var('DBT_FABRIC_CI_TENANT_ID') }}"

--- a/integration_tests/profiles/redshift/profiles.yml
+++ b/integration_tests/profiles/redshift/profiles.yml
@@ -7,6 +7,6 @@ default:
       user: "{{ env_var('DBT_REDSHIFT_CI_USER') }}"
       password: "{{ env_var('DBT_REDSHIFT_CI_PASSWORD') }}"
       dbname: "{{ env_var('DBT_REDSHIFT_CI_DATABASE') }}"
-      schema: public
+      schema: "public_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
       port: 5439
       threads: "{{ env_var('DBT_REDSHIFT_CI_THREADS', '4') | int }}"

--- a/integration_tests/profiles/snowflake/profiles.yml
+++ b/integration_tests/profiles/snowflake/profiles.yml
@@ -7,7 +7,7 @@
         warehouse: "{{ env_var('DBT_SNOWFLAKE_CI_WAREHOUSE') }}"
         database: "{{ env_var('DBT_SNOWFLAKE_CI_DATABASE') }}"
         role: "{{ env_var('DBT_SNOWFLAKE_CI_ROLE') }}"
-        schema: "{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}"
+        schema: "{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
         user: "{{ env_var('DBT_SNOWFLAKE_CI_USER') }}"
         password: "{{ env_var('DBT_SNOWFLAKE_CI_PASSWORD') }}"
         threads: 5

--- a/models/data_quality/logical/claims_logical_unit_tests.yml
+++ b/models/data_quality/logical/claims_logical_unit_tests.yml
@@ -433,7 +433,7 @@ unit_tests:
   - name: test_medical_claim_line_new_flags_are_tristate
     description: >
       Verifies fail, pass, and not-applicable behavior for medical claim-line
-      number, paid-date range, and paid-date sequencing checks.
+      number, ingest datetime, and paid-date presence and range checks.
     model: data_quality__medical_claim_line_flags
     config:
       enabled: "{{ (var('data_quality_enabled', false) and var('claims_enabled', false)) | as_bool }}"
@@ -449,12 +449,6 @@ unit_tests:
               select 'invalid_values', 0
               union all
               select 'valid_values', 1
-              union all
-              select 'before_claim_end', 1
-              union all
-              select 'same_as_claim_end', 1
-              union all
-              select 'missing_claim_end', 1
           )
           select
                 row_ids.claim_id
@@ -465,12 +459,7 @@ unit_tests:
               , 'payer' as payer
               , 'plan' as {{ plan_identifier }}
               , cast('2024-01-01' as date) as claim_start_date
-              , case
-                  when row_ids.claim_id = 'before_claim_end' then cast('2024-02-01' as date)
-                  when row_ids.claim_id = 'same_as_claim_end' then cast('2024-01-15' as date)
-                  when row_ids.claim_id = 'missing_claim_end' then cast(null as date)
-                  else cast('2024-01-01' as date)
-                end as claim_end_date
+              , cast('2024-01-01' as date) as claim_end_date
               , cast('2024-01-01' as date) as claim_line_start_date
               , cast('2024-01-01' as date) as claim_line_end_date
               , cast(null as date) as admission_date
@@ -586,6 +575,126 @@ unit_tests:
           paid_date_null: 0
           paid_date_out_of_reasonable_range: 0
           paid_date_before_claim_end_date: 0
+
+  - name: test_medical_claim_line_paid_date_sequence_is_tristate
+    description: >
+      Verifies fail, pass, and not-applicable behavior when the paid date is
+      before, equal to, or cannot be compared with the claim end date.
+    model: data_quality__medical_claim_line_flags
+    config:
+      enabled: "{{ (var('data_quality_enabled', false) and var('claims_enabled', false)) | as_bool }}"
+    given:
+      - input: ref('input_layer__medical_claim')
+        format: sql
+        rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          with row_ids as (
+              select 'before_claim_end' as claim_id, cast('2024-02-01' as date) as claim_end_date
+              union all
+              select 'same_as_claim_end', cast('2024-01-15' as date)
+              union all
+              select 'missing_claim_end', cast(null as date)
+          )
+          select
+                row_ids.claim_id
+              , 1 as claim_line_number
+              , 'undetermined' as claim_type
+              , 'person' as person_id
+              , 'member' as member_id
+              , 'payer' as payer
+              , 'plan' as {{ plan_identifier }}
+              , cast('2024-01-01' as date) as claim_start_date
+              , row_ids.claim_end_date
+              , cast('2024-01-01' as date) as claim_line_start_date
+              , cast('2024-01-01' as date) as claim_line_end_date
+              , cast(null as date) as admission_date
+              , cast(null as date) as discharge_date
+              , null as admit_source_code
+              , null as admit_type_code
+              , null as discharge_disposition_code
+              , null as place_of_service_code
+              , null as bill_type_code
+              , null as revenue_center_code
+              , null as hcpcs_code
+              , null as rendering_npi
+              , null as billing_npi
+              , null as facility_npi
+              , null as drg_code_type
+              , null as drg_code
+              , null as diagnosis_code_type
+              , null as procedure_code_type
+              , cast('2024-01-15' as date) as paid_date
+              , 1 as paid_amount
+              , 2 as allowed_amount
+              {% for index in range(1, 26) %}
+              , null as diagnosis_code_{{ index }}
+              {% endfor %}
+              {% for index in range(1, 26) %}
+              , null as procedure_code_{{ index }}
+              {% endfor %}
+              , cast(null as {{ timestamp_type }}) as ingest_datetime
+              , 'source' as data_source
+          from row_ids
+      - input: ref('input_layer__eligibility')
+        format: sql
+        rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          select 'person' as person_id, 'member' as member_id, 'payer' as payer, 'plan' as {{ plan_identifier }}, cast('2000-01-01' as date) as enrollment_start_date, cast('2030-12-31' as date) as enrollment_end_date, 'source' as data_source
+      - input: ref('terminology__admit_source')
+        format: sql
+        rows: |
+          select '__unused__' as admit_source_code
+      - input: ref('terminology__admit_type')
+        format: sql
+        rows: |
+          select '__unused__' as admit_type_code
+      - input: ref('terminology__discharge_disposition')
+        format: sql
+        rows: |
+          select '__unused__' as discharge_disposition_code
+      - input: ref('terminology__place_of_service')
+        format: sql
+        rows: |
+          select '__unused__' as place_of_service_code
+      - input: ref('terminology__bill_type')
+        format: sql
+        rows: |
+          select '__unused__' as bill_type_code
+      - input: ref('terminology__revenue_center')
+        format: sql
+        rows: |
+          select '__unused__' as revenue_center_code
+      - input: ref('provider_data__provider')
+        format: sql
+        rows: |
+          select '__unused__' as npi
+      - input: ref('terminology__ms_drg')
+        format: sql
+        rows: |
+          select '__unused__' as ms_drg_code
+      - input: ref('terminology__apr_drg')
+        format: sql
+        rows: |
+          select '__unused__' as apr_drg_code
+      - input: ref('terminology__icd_10_cm')
+        format: sql
+        rows: |
+          select '__unused__' as icd_10_cm
+      - input: ref('terminology__icd_9_cm')
+        format: sql
+        rows: |
+          select '__unused__' as icd_9_cm
+      - input: ref('terminology__icd_10_pcs')
+        format: sql
+        rows: |
+          select '__unused__' as icd_10_pcs
+      - input: ref('terminology__icd_9_pcs')
+        format: sql
+        rows: |
+          select '__unused__' as icd_9_pcs
+    expect:
+      rows:
         - claim_id: before_claim_end
           claim_line_number_not_positive: 0
           ingest_datetime_out_of_reasonable_range: null
@@ -936,13 +1045,12 @@ unit_tests:
 
   - name: test_medical_claim_header_consistency_flags_are_tristate
     description: >
-      Verifies every new header-consistency flag, including fail behavior for
-      conflicting or mixed null/populated values, pass behavior for repeated
-      values, and not-applicable behavior for single-line and all-null groups.
+      Verifies claim identity and date header-consistency flags for conflicting,
+      repeated, single-line, all-null, case-sensitive, and cross-source groups.
     model: data_quality__medical_claim_claim_flags
     config:
       enabled: "{{ (var('data_quality_enabled', false) and var('claims_enabled', false)) | as_bool }}"
-    given:
+    given: &medical_claim_header_consistency_given
       - input: ref('input_layer__medical_claim')
         format: sql
         rows: |
@@ -1040,6 +1148,67 @@ unit_tests:
           claim_start_date_has_multiple_values_per_claim: null
           claim_end_date_has_multiple_values_per_claim: null
           billing_npi_has_multiple_values_per_claim: null
+        - claim_id: same_values
+          member_id_has_multiple_values_per_claim: 0
+          payer_has_multiple_values_per_claim: 0
+          plan_has_multiple_values_per_claim: 0
+          claim_start_date_has_multiple_values_per_claim: 0
+          claim_end_date_has_multiple_values_per_claim: 0
+          billing_npi_has_multiple_values_per_claim: 0
+        - claim_id: mixed_values
+          member_id_has_multiple_values_per_claim: 1
+          payer_has_multiple_values_per_claim: 1
+          plan_has_multiple_values_per_claim: 1
+          claim_start_date_has_multiple_values_per_claim: 1
+          claim_end_date_has_multiple_values_per_claim: 1
+          billing_npi_has_multiple_values_per_claim: 1
+        - claim_id: all_null
+          member_id_has_multiple_values_per_claim: null
+          payer_has_multiple_values_per_claim: null
+          plan_has_multiple_values_per_claim: null
+          claim_start_date_has_multiple_values_per_claim: null
+          claim_end_date_has_multiple_values_per_claim: null
+          billing_npi_has_multiple_values_per_claim: null
+        - claim_id: case_conflict
+          member_id_has_multiple_values_per_claim: 0
+          payer_has_multiple_values_per_claim: 0
+          plan_has_multiple_values_per_claim: 0
+          claim_start_date_has_multiple_values_per_claim: 0
+          claim_end_date_has_multiple_values_per_claim: 0
+          billing_npi_has_multiple_values_per_claim: 0
+        - claim_id: uppercase_institutional
+          member_id_has_multiple_values_per_claim: 0
+          payer_has_multiple_values_per_claim: 0
+          plan_has_multiple_values_per_claim: 0
+          claim_start_date_has_multiple_values_per_claim: 0
+          claim_end_date_has_multiple_values_per_claim: 0
+          billing_npi_has_multiple_values_per_claim: 0
+        - claim_id: cross_source
+          member_id_has_multiple_values_per_claim: null
+          payer_has_multiple_values_per_claim: null
+          plan_has_multiple_values_per_claim: null
+          claim_start_date_has_multiple_values_per_claim: null
+          claim_end_date_has_multiple_values_per_claim: null
+          billing_npi_has_multiple_values_per_claim: null
+        - claim_id: cross_source
+          member_id_has_multiple_values_per_claim: null
+          payer_has_multiple_values_per_claim: null
+          plan_has_multiple_values_per_claim: null
+          claim_start_date_has_multiple_values_per_claim: null
+          claim_end_date_has_multiple_values_per_claim: null
+          billing_npi_has_multiple_values_per_claim: null
+
+  - name: test_medical_claim_header_code_consistency_flags_are_tristate
+    description: >
+      Verifies inpatient and code header-consistency flags for conflicting,
+      repeated, single-line, all-null, case-sensitive, and cross-source groups.
+    model: data_quality__medical_claim_claim_flags
+    config:
+      enabled: "{{ (var('data_quality_enabled', false) and var('claims_enabled', false)) | as_bool }}"
+    given: *medical_claim_header_consistency_given
+    expect:
+      rows:
+        - claim_id: single_line
           admit_source_code_has_multiple_values_per_inpatient_claim: null
           admit_type_code_has_multiple_values_per_inpatient_claim: null
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: null
@@ -1048,12 +1217,6 @@ unit_tests:
           procedure_code_type_has_multiple_values_per_claim: null
           diagnosis_code_count_gt_one_per_position_for_institutional_claim: null
         - claim_id: same_values
-          member_id_has_multiple_values_per_claim: 0
-          payer_has_multiple_values_per_claim: 0
-          plan_has_multiple_values_per_claim: 0
-          claim_start_date_has_multiple_values_per_claim: 0
-          claim_end_date_has_multiple_values_per_claim: 0
-          billing_npi_has_multiple_values_per_claim: 0
           admit_source_code_has_multiple_values_per_inpatient_claim: 0
           admit_type_code_has_multiple_values_per_inpatient_claim: 0
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: 0
@@ -1062,12 +1225,6 @@ unit_tests:
           procedure_code_type_has_multiple_values_per_claim: 0
           diagnosis_code_count_gt_one_per_position_for_institutional_claim: 0
         - claim_id: mixed_values
-          member_id_has_multiple_values_per_claim: 1
-          payer_has_multiple_values_per_claim: 1
-          plan_has_multiple_values_per_claim: 1
-          claim_start_date_has_multiple_values_per_claim: 1
-          claim_end_date_has_multiple_values_per_claim: 1
-          billing_npi_has_multiple_values_per_claim: 1
           admit_source_code_has_multiple_values_per_inpatient_claim: 1
           admit_type_code_has_multiple_values_per_inpatient_claim: 1
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: 1
@@ -1076,12 +1233,6 @@ unit_tests:
           procedure_code_type_has_multiple_values_per_claim: 1
           diagnosis_code_count_gt_one_per_position_for_institutional_claim: 1
         - claim_id: all_null
-          member_id_has_multiple_values_per_claim: null
-          payer_has_multiple_values_per_claim: null
-          plan_has_multiple_values_per_claim: null
-          claim_start_date_has_multiple_values_per_claim: null
-          claim_end_date_has_multiple_values_per_claim: null
-          billing_npi_has_multiple_values_per_claim: null
           admit_source_code_has_multiple_values_per_inpatient_claim: null
           admit_type_code_has_multiple_values_per_inpatient_claim: null
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: null
@@ -1090,12 +1241,6 @@ unit_tests:
           procedure_code_type_has_multiple_values_per_claim: null
           diagnosis_code_count_gt_one_per_position_for_institutional_claim: null
         - claim_id: case_conflict
-          member_id_has_multiple_values_per_claim: 0
-          payer_has_multiple_values_per_claim: 0
-          plan_has_multiple_values_per_claim: 0
-          claim_start_date_has_multiple_values_per_claim: 0
-          claim_end_date_has_multiple_values_per_claim: 0
-          billing_npi_has_multiple_values_per_claim: 0
           admit_source_code_has_multiple_values_per_inpatient_claim: 0
           admit_type_code_has_multiple_values_per_inpatient_claim: 0
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: 0
@@ -1104,12 +1249,6 @@ unit_tests:
           procedure_code_type_has_multiple_values_per_claim: 1
           diagnosis_code_count_gt_one_per_position_for_institutional_claim: 0
         - claim_id: uppercase_institutional
-          member_id_has_multiple_values_per_claim: 0
-          payer_has_multiple_values_per_claim: 0
-          plan_has_multiple_values_per_claim: 0
-          claim_start_date_has_multiple_values_per_claim: 0
-          claim_end_date_has_multiple_values_per_claim: 0
-          billing_npi_has_multiple_values_per_claim: 0
           admit_source_code_has_multiple_values_per_inpatient_claim: null
           admit_type_code_has_multiple_values_per_inpatient_claim: null
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: null
@@ -1118,12 +1257,6 @@ unit_tests:
           procedure_code_type_has_multiple_values_per_claim: 0
           diagnosis_code_count_gt_one_per_position_for_institutional_claim: null
         - claim_id: cross_source
-          member_id_has_multiple_values_per_claim: null
-          payer_has_multiple_values_per_claim: null
-          plan_has_multiple_values_per_claim: null
-          claim_start_date_has_multiple_values_per_claim: null
-          claim_end_date_has_multiple_values_per_claim: null
-          billing_npi_has_multiple_values_per_claim: null
           admit_source_code_has_multiple_values_per_inpatient_claim: null
           admit_type_code_has_multiple_values_per_inpatient_claim: null
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: null
@@ -1132,12 +1265,6 @@ unit_tests:
           procedure_code_type_has_multiple_values_per_claim: null
           diagnosis_code_count_gt_one_per_position_for_institutional_claim: null
         - claim_id: cross_source
-          member_id_has_multiple_values_per_claim: null
-          payer_has_multiple_values_per_claim: null
-          plan_has_multiple_values_per_claim: null
-          claim_start_date_has_multiple_values_per_claim: null
-          claim_end_date_has_multiple_values_per_claim: null
-          billing_npi_has_multiple_values_per_claim: null
           admit_source_code_has_multiple_values_per_inpatient_claim: null
           admit_type_code_has_multiple_values_per_inpatient_claim: null
           discharge_disposition_code_has_multiple_values_per_inpatient_claim: null

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -46,6 +46,16 @@ WAREHOUSES = (
     "redshift",
 )
 
+CI_DEPENDENCY_VERSIONS = {
+    "DBT_CORE_VERSION": "1.11.14",
+    "DBT_SNOWFLAKE_VERSION": "1.11.6",
+    "DBT_BIGQUERY_VERSION": "1.11.3",
+    "DBT_DATABRICKS_VERSION": "1.12.4",
+    "DBT_FABRIC_VERSION": "1.11.1",
+    "DBT_REDSHIFT_VERSION": "1.11.1",
+    "SQLPARSE_VERSION": "0.6.0",
+}
+
 RELEASE_PACKAGES = (
     (
         "ahrq_quality_indicators",
@@ -194,6 +204,34 @@ class CiContractTest(unittest.TestCase):
             {"snowflake:core", "all:all-packages"},
         )
         self.assertEqual(self.packages.strip(), "packages:\n  - local: ../")
+
+    def test_ci_dependency_set_is_pinned_and_verified(self):
+        env_block = self.workflow.split("\nenv:\n", 1)[1].split(
+            "\njobs:\n", 1
+        )[0]
+        for name, version in CI_DEPENDENCY_VERSIONS.items():
+            with self.subTest(name=name):
+                self.assertIn(f'{name}: "{version}"', env_block)
+
+        install_step = self.workflow.split(
+            "      - name: Install dbt adapter\n", 1
+        )[1].split("\n      - name:", 1)[0]
+        self.assertEqual(
+            install_step.count('"sqlparse==${SQLPARSE_VERSION}"'),
+            len(WAREHOUSES),
+        )
+        self.assertIn("python -m pip check", install_step)
+        self.assertIn("dbt --version", install_step)
+        self.assertIn("sqlparse.__version__", install_step)
+
+        self.assertIn(
+            '{"MAX_GROUPING_DEPTH": 100, "MAX_GROUPING_TOKENS": 100000}',
+            env_block,
+        )
+        self.assertEqual(
+            self.workflow.count('--sqlparse "$DBT_SQLPARSE_OPTIONS"'),
+            len(WAREHOUSES),
+        )
 
     def test_manual_release_dispatch_validates_an_internal_version_pr(self):
         resolver = self.all_warehouses_workflow

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
+import json
+import os
 import re
+import subprocess
+import sys
+import tempfile
+import textwrap
 import unittest
 from collections import Counter
 from pathlib import Path
@@ -87,6 +93,18 @@ def extract_javascript_array(text, name, terminator):
 
 def extract_action_uses(text):
     return re.findall(r"(?m)^\s*uses:\s+([^\s#]+)", text)
+
+
+def extract_embedded_python(text, step_name):
+    step_marker = f"      - name: {step_name}\n"
+    if step_marker not in text:
+        raise AssertionError(f"Could not find workflow step {step_name}")
+    step = text.split(step_marker, 1)[1].split("\n      - name:", 1)[0]
+    script_marker = "          python3 - <<'PY'\n"
+    if script_marker not in step or "\n          PY" not in step:
+        raise AssertionError(f"Could not find embedded Python in {step_name}")
+    script = step.split(script_marker, 1)[1].rsplit("\n          PY", 1)[0]
+    return textwrap.dedent(script)
 
 
 class CiContractTest(unittest.TestCase):
@@ -266,7 +284,16 @@ class CiContractTest(unittest.TestCase):
         )
         self.assertIn('exact_sha = re.compile(r"^[0-9a-f]{40}$")', build)
         self.assertIn('env_path = Path(os.environ["GITHUB_ENV"])', build)
-        self.assertIn('integration_dir / "packages.release.yml"', build)
+        self.assertIn(
+            'release_manifest = ["packages:", "  - local: ../"]', build
+        )
+        self.assertIn(
+            'f"  - git: https://github.com/{item[\'repository\']}.git"',
+            build,
+        )
+        self.assertIn('(integration_dir / "packages.yml").write_text(', build)
+        self.assertNotIn("shutil.copyfile", build)
+        self.assertNotIn('integration_dir / "packages.release.yml"', build)
         self.assertIn('integration_dir / "ci-source-lock.json"', build)
 
         self.assertIn("const expectedStandalonePackages = [", self.workflow)
@@ -280,6 +307,147 @@ class CiContractTest(unittest.TestCase):
                 self.assertIn(f'/{repository}"', build)
                 self.assertIn(f'"{dbt_package}"', build)
                 self.assertIn(f'"{env_var}"', build)
+
+    def test_locked_sources_generate_the_runtime_release_manifest(self):
+        packages = [
+            {
+                "repository": f"tuva-health/{repository}",
+                "dbt_package": dbt_package,
+                "branch": "main",
+                "revision": f"{index:x}" * 40,
+                "env_var": env_var,
+            }
+            for index, (repository, dbt_package, env_var) in enumerate(
+                RELEASE_PACKAGES,
+                start=1,
+            )
+        ]
+        source_lock = {"standalone_packages": packages}
+        script = extract_embedded_python(
+            self.workflow,
+            "Configure all-package sources",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            integration_dir = root / "integration_tests"
+            integration_dir.mkdir()
+            env_path = root / "github-env"
+            env_path.touch()
+            env = os.environ.copy()
+            env.update(
+                {
+                    "CI_SOURCE_LOCK": json.dumps(source_lock),
+                    "GITHUB_ENV": str(env_path),
+                    "GITHUB_REPOSITORY_OWNER": "tuva-health",
+                }
+            )
+            subprocess.run(
+                [sys.executable, "-c", script],
+                cwd=root,
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            expected_manifest = ["packages:", "  - local: ../"]
+            for package in packages:
+                expected_manifest.extend(
+                    [
+                        (
+                            "  - git: https://github.com/"
+                            f"{package['repository']}.git"
+                        ),
+                        (
+                            "    revision: \"{{ env_var('"
+                            f"{package['env_var']}"
+                            "') }}\""
+                        ),
+                    ]
+                )
+            self.assertEqual(
+                (integration_dir / "packages.yml").read_text(),
+                "\n".join(expected_manifest) + "\n",
+            )
+            self.assertEqual(
+                env_path.read_text().splitlines(),
+                [
+                    f"{package['env_var']}={package['revision']}"
+                    for package in packages
+                ],
+            )
+
+    def test_release_evidence_rejects_missing_required_package_nodes(self):
+        script = extract_embedded_python(
+            self.workflow,
+            "Prepare all-warehouse evidence",
+        )
+        required_packages = {
+            "integration_tests",
+            "the_tuva_project",
+            *(dbt_package for _, dbt_package, _ in RELEASE_PACKAGES),
+        }
+
+        for missing_package in (None, "semantic_layer"):
+            with self.subTest(missing_package=missing_package):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    root = Path(temp_dir)
+                    target_dir = root / "integration_tests" / "target"
+                    target_dir.mkdir(parents=True)
+                    manifest_packages = required_packages - {missing_package}
+                    manifest = {
+                        "metadata": {"dbt_version": "test"},
+                        "nodes": {
+                            f"model.{package}.fixture": {
+                                "package_name": package
+                            }
+                            for package in manifest_packages
+                        },
+                    }
+                    (target_dir / "manifest.json").write_text(
+                        json.dumps(manifest),
+                        encoding="utf-8",
+                    )
+                    (target_dir / "run_results.json").write_text(
+                        json.dumps({"elapsed_time": 1, "results": []}),
+                        encoding="utf-8",
+                    )
+                    env = os.environ.copy()
+                    env.update(
+                        {
+                            "CI_SOURCE_LOCK": json.dumps(
+                                {"standalone_packages": []}
+                            ),
+                            "CI_WAREHOUSE": "snowflake",
+                            "GITHUB_RUN_ID": "1",
+                            "GITHUB_RUN_ATTEMPT": "1",
+                        }
+                    )
+                    completed = subprocess.run(
+                        [sys.executable, "-c", script],
+                        cwd=root,
+                        env=env,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+                    evidence = json.loads(
+                        (
+                            root / "integration_tests" / "ci-evidence.json"
+                        ).read_text()
+                    )
+                    if missing_package is None:
+                        self.assertEqual(completed.returncode, 0)
+                        self.assertTrue(
+                            evidence["manifest"]["required_packages_present"]
+                        )
+                    else:
+                        self.assertNotEqual(completed.returncode, 0)
+                        self.assertIn(missing_package, completed.stderr)
+                        self.assertFalse(
+                            evidence["manifest"]["required_packages_present"]
+                        )
 
     def test_release_preflight_requires_payloads_but_no_receipt(self):
         preflight = self.workflow[
@@ -316,10 +484,20 @@ class CiContractTest(unittest.TestCase):
             self.workflow,
         )
 
-    def test_both_paths_use_small_synthetic_data_without_parity(self):
+    def test_both_paths_exercise_data_quality_with_small_data_without_parity(self):
         self.assertEqual(self.workflow.count('"use_synthetic_data": true'), 1)
         self.assertEqual(self.workflow.count('"synthetic_data_size": "small"'), 1)
         self.assertEqual(self.workflow.count('"parity_enabled": false'), 1)
+        self.assertEqual(self.workflow.count('"data_quality_enabled": true'), 1)
+        self.assertEqual(
+            self.workflow.count('"enable_data_quality_failure_keys": true'), 1
+        )
+        self.assertEqual(self.workflow.count('--vars "$CI_DBT_VARS"'), 5)
+        self.assertIn("data_quality_enabled: false", self.integration_project)
+        self.assertIn(
+            "enable_data_quality_failure_keys: false",
+            self.integration_project,
+        )
         self.assertIn("strategy:\n      fail-fast: false", self.workflow)
         self.assertEqual(self.workflow.count("dbt build --full-refresh"), 5)
         self.assertNotIn('"synthetic_data_size": "large"', self.workflow)
@@ -418,6 +596,13 @@ class CiContractTest(unittest.TestCase):
                 f'"{result_field}": result.get("{result_field}")',
                 prepare_block,
             )
+        self.assertIn(
+            '"required_packages_present": not missing_packages',
+            prepare_block,
+        )
+        self.assertIn("expected_dbt_packages = {", prepare_block)
+        self.assertIn("if coverage_error:", prepare_block)
+        self.assertIn("raise SystemExit(coverage_error)", prepare_block)
 
     def test_status_contexts_are_distinct_and_stale_safe(self):
         self.assertIn('"Tuva CI / Snowflake"', self.workflow)
@@ -446,6 +631,8 @@ class CiContractTest(unittest.TestCase):
         self.assertIn(
             "A standalone package main changed; rerun required", self.workflow
         )
+        self.assertIn('if (state === "error") {', self.workflow)
+        self.assertIn("core.setFailed(description);", self.workflow)
         self.assertIn("All-warehouse release CI passed", self.workflow)
         self.assertIn("Snowflake Core build passed", self.workflow)
 

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -605,6 +605,14 @@ class CiContractTest(unittest.TestCase):
         self.assertIn("raise SystemExit(coverage_error)", prepare_block)
 
     def test_status_contexts_are_distinct_and_stale_safe(self):
+        pending_status = self.workflow[
+            self.workflow.index("\n  mark_pending:") : self.workflow.index(
+                "\n  preflight_assets:"
+            )
+        ]
+        final_status = self.workflow[
+            self.workflow.index("\n  finalize_status:") :
+        ]
         self.assertIn('"Tuva CI / Snowflake"', self.workflow)
         self.assertIn('"Tuva CI / All Warehouses"', self.workflow)
         self.assertNotIn("Tuva CI / Required", self.workflow)
@@ -631,8 +639,10 @@ class CiContractTest(unittest.TestCase):
         self.assertIn(
             "A standalone package main changed; rerun required", self.workflow
         )
-        self.assertIn('if (state === "error") {', self.workflow)
-        self.assertIn("core.setFailed(description);", self.workflow)
+        self.assertNotIn('if (state === "error") {', pending_status)
+        self.assertNotIn("core.setFailed(description);", pending_status)
+        self.assertIn('if (state === "error") {', final_status)
+        self.assertIn("core.setFailed(description);", final_status)
         self.assertIn("All-warehouse release CI passed", self.workflow)
         self.assertIn("Snowflake Core build passed", self.workflow)
 

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -21,6 +21,12 @@ EXTERNAL_CI_PATH = ROOT / ".github" / "workflows" / "ci-external-pr.yml"
 PACKAGES_PATH = ROOT / "integration_tests" / "packages.yml"
 RELEASE_PACKAGES_PATH = ROOT / "integration_tests" / "packages.release.yml"
 INTEGRATION_PROJECT_PATH = ROOT / "integration_tests" / "dbt_project.yml"
+TARGET_SCHEMA_MACRO_PATH = (
+    ROOT
+    / "integration_tests"
+    / "macros"
+    / "ensure_target_schema_for_unit_tests.sql"
+)
 PROFILE_PATHS = {
     warehouse: ROOT / "integration_tests" / "profiles" / warehouse / "profiles.yml"
     for warehouse in (
@@ -118,6 +124,9 @@ class CiContractTest(unittest.TestCase):
         cls.packages = PACKAGES_PATH.read_text(encoding="utf-8")
         cls.release_packages = RELEASE_PACKAGES_PATH.read_text(encoding="utf-8")
         cls.integration_project = INTEGRATION_PROJECT_PATH.read_text(
+            encoding="utf-8"
+        )
+        cls.target_schema_macro = TARGET_SCHEMA_MACRO_PATH.read_text(
             encoding="utf-8"
         )
         cls.profiles = {
@@ -704,6 +713,18 @@ class CiContractTest(unittest.TestCase):
                 profile = self.profiles[warehouse]
                 self.assertIn(target_location, profile)
                 self.assertEqual(profile.count("TUVA_CI_SCHEMA_PREFIX"), 1)
+
+    def test_isolated_target_schema_is_created_for_dbt_unit_tests(self):
+        self.assertIn(
+            'on-run-start:\n  - "{{ ensure_target_schema_for_unit_tests() }}"',
+            self.integration_project,
+        )
+        self.assertIn("database=target.database", self.target_schema_macro)
+        self.assertIn("schema=target.schema", self.target_schema_macro)
+        self.assertIn(
+            "adapter.create_schema(target_schema_relation)",
+            self.target_schema_macro,
+        )
 
     def test_external_dispatch_is_core_snowflake_and_rejects_version_changes(self):
         self.assertRegex(self.external_workflow, r"(?m)^  workflow_dispatch:$")

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -258,7 +258,7 @@ class CiContractTest(unittest.TestCase):
             self.assertRegex(revision, r"^[0-9a-f]{40}$", use)
 
         expected_actions = {
-            "actions/github-script": "f28e40c7f34bde8b3046d885e986cb6290c5673b",
+            "actions/github-script": "3a2844b7e9c422d3c10d287c895573f7108da1b3",
             "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
             "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
             "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+EXTERNAL_CI_PATH = ROOT / ".github" / "workflows" / "ci-external-pr.yml"
+PACKAGES_PATH = ROOT / "integration_tests" / "packages.yml"
+RELEASE_PACKAGES_PATH = ROOT / "integration_tests" / "packages.release.yml"
+INTEGRATION_PROJECT_PATH = ROOT / "integration_tests" / "dbt_project.yml"
+PROFILE_PATHS = {
+    warehouse: ROOT / "integration_tests" / "profiles" / warehouse / "profiles.yml"
+    for warehouse in (
+        "snowflake",
+        "bigquery",
+        "databricks",
+        "fabric",
+        "redshift",
+    )
+}
+
+WAREHOUSES = (
+    "snowflake",
+    "bigquery",
+    "databricks",
+    "fabric",
+    "redshift",
+)
+
+RELEASE_PACKAGES = (
+    (
+        "ahrq_quality_indicators",
+        "ahrq_quality_indicators",
+        "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA",
+    ),
+    ("ccsr", "ccsr", "TUVA_CI_CCSR_SHA"),
+    (
+        "cms_chronic_conditions",
+        "cms_chronic_conditions",
+        "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA",
+    ),
+    ("cms_hcc", "cms_hcc", "TUVA_CI_CMS_HCC_SHA"),
+    (
+        "fhir_preprocessing",
+        "fhir_preprocessing",
+        "TUVA_CI_FHIR_PREPROCESSING_SHA",
+    ),
+    (
+        "nyu_ed_classification",
+        "nyu_ed_classification",
+        "TUVA_CI_NYU_ED_CLASSIFICATION_SHA",
+    ),
+    (
+        "quality_measures",
+        "quality_measures",
+        "TUVA_CI_QUALITY_MEASURES_SHA",
+    ),
+    ("semantic-layer", "semantic_layer", "TUVA_CI_SEMANTIC_LAYER_SHA"),
+)
+
+DEFAULT_SELECTOR = (
+    "package:integration_tests",
+    "package:the_tuva_project",
+)
+RELEASE_SELECTOR = DEFAULT_SELECTOR + tuple(
+    f"package:{dbt_package}" for _, dbt_package, _ in RELEASE_PACKAGES
+)
+
+
+def extract_javascript_array(text, name, terminator):
+    match = re.search(
+        rf"const {re.escape(name)} = \[(.*?)\]{terminator}",
+        text,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"Could not find JavaScript array {name}")
+    return tuple(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def extract_action_uses(text):
+    return re.findall(r"(?m)^\s*uses:\s+([^\s#]+)", text)
+
+
+class CiContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = CI_PATH.read_text(encoding="utf-8")
+        cls.external_workflow = EXTERNAL_CI_PATH.read_text(encoding="utf-8")
+        cls.packages = PACKAGES_PATH.read_text(encoding="utf-8")
+        cls.release_packages = RELEASE_PACKAGES_PATH.read_text(encoding="utf-8")
+        cls.integration_project = INTEGRATION_PROJECT_PATH.read_text(
+            encoding="utf-8"
+        )
+        cls.profiles = {
+            warehouse: path.read_text(encoding="utf-8")
+            for warehouse, path in PROFILE_PATHS.items()
+        }
+
+    def test_primary_ci_exposes_only_the_two_automatic_modes(self):
+        event_block = self.workflow.split("\npermissions:", 1)[0]
+        self.assertRegex(event_block, r"(?m)^  pull_request:$")
+        self.assertRegex(event_block, r"(?m)^  workflow_call:$")
+        self.assertNotRegex(event_block, r"(?m)^  workflow_dispatch:$")
+
+        default_selector_match = re.search(
+            r'const defaultSelector =\s*"([^"]+)";', self.workflow
+        )
+        self.assertIsNotNone(default_selector_match)
+        self.assertEqual(
+            tuple(default_selector_match.group(1).split()), DEFAULT_SELECTOR
+        )
+        self.assertEqual(
+            extract_javascript_array(
+                self.workflow, "releaseSelector", r'\.join\(" "\);'
+            ),
+            RELEASE_SELECTOR,
+        )
+
+        self.assertIn('let warehouse = "snowflake";', self.workflow)
+        self.assertIn('let mode = "default";', self.workflow)
+        self.assertIn("if (baseVersion !== mergeVersion) {", self.workflow)
+        self.assertIn('mode = "release";', self.workflow)
+        self.assertIn('warehouse = "all";', self.workflow)
+        self.assertIn("selector = releaseSelector;", self.workflow)
+        self.assertIn(
+            'if (isReusableCall && warehouse !== "snowflake")', self.workflow
+        )
+
+        # Routine CI installs only the checked-out Core package. Standalone
+        # package sources are exclusive to the version-gated release mode.
+        self.assertEqual(self.packages.strip(), "packages:\n  - local: ../")
+        self.assertIn("checkoutRef = context.sha;", self.workflow)
+        self.assertIn("mergeSha = context.sha;", self.workflow)
+        self.assertIn('source: "pull_request_test_merge"', self.workflow)
+
+    def test_release_warehouse_and_package_inventories_are_exact(self):
+        self.assertEqual(
+            extract_javascript_array(self.workflow, "supportedWarehouses", r";"),
+            WAREHOUSES,
+        )
+        self.assertIn(
+            'warehouse === "all" ? supportedWarehouses : [warehouse]',
+            self.workflow,
+        )
+
+        release_package_block = re.search(
+            r"const releasePackages = \[(.*?)\];\n\s*const exactSha",
+            self.workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(release_package_block)
+        package_definitions = tuple(
+            re.findall(
+                r"\{\s*repository: \"([^\"]+)\",\s*"
+                r"dbtPackage: \"([^\"]+)\",\s*"
+                r"envVar: \"([^\"]+)\"\s*\}",
+                release_package_block.group(1),
+                re.DOTALL,
+            )
+        )
+        self.assertEqual(package_definitions, RELEASE_PACKAGES)
+
+        manifest_sources = tuple(
+            re.findall(
+                r"(?m)^  - git: https://github\.com/tuva-health/([^/]+)\.git\n"
+                r"    revision: \"\{\{ env_var\('([^']+)'\) \}\}\"$",
+                self.release_packages,
+            )
+        )
+        expected_manifest_sources = tuple(
+            (repository, env_var)
+            for repository, _, env_var in RELEASE_PACKAGES
+        )
+        self.assertEqual(manifest_sources, expected_manifest_sources)
+        self.assertEqual(self.release_packages.count("  - local: ../"), 1)
+        self.assertNotRegex(self.release_packages, r"(?m)^\s*revision:\s*main\s*$")
+
+    def test_release_sources_are_resolved_once_and_locked_to_exact_commits(self):
+        resolver_start = self.workflow.index("const releasePackages = [")
+        build_start = self.workflow.index("\n  build:")
+        resolver = self.workflow[resolver_start:build_start]
+        build = self.workflow[build_start:]
+
+        self.assertIn("await Promise.all(", resolver)
+        self.assertIn("releasePackages.map(async (item) =>", resolver)
+        self.assertIn("github.rest.repos.getCommit({", resolver)
+        self.assertIn("repo: item.repository,", resolver)
+        self.assertIn('ref: "main"', resolver)
+        self.assertIn("revision: commit.sha.toLowerCase()", resolver)
+        self.assertIn("branch: \"main\"", resolver)
+        self.assertIn("const exactSha = /^[0-9a-f]{40}$/i;", resolver)
+        # The final status job re-resolves the PR merge ref to prevent a stale
+        # run from winning. It must not resolve standalone package branches a
+        # second time inside any matrix job.
+        self.assertNotIn("repo: item.repository,", build)
+        self.assertNotIn("releasePackages.map(async (item) =>", build)
+
+        self.assertIn("standalone_packages: standalonePackages", resolver)
+        self.assertIn("revision: mergeSha.toLowerCase()", resolver)
+        self.assertIn('core.setOutput("source_lock", sourceLock);', resolver)
+        self.assertIn(
+            "packages = source_lock.get(\"standalone_packages\")", build
+        )
+        self.assertIn(
+            'if not isinstance(packages, list) or len(packages) != 8:', build
+        )
+        self.assertIn(
+            'exact_sha = re.compile(r"^[0-9a-f]{40}$")', build
+        )
+        self.assertIn('env_path = Path(os.environ["GITHUB_ENV"])', build)
+        self.assertIn(
+            "integration_dir / \"packages.release.yml\"", build
+        )
+        self.assertIn(
+            'integration_dir / "ci-source-lock.json"', build
+        )
+
+        expected_env_vars = {env_var for _, _, env_var in RELEASE_PACKAGES}
+        configured_env_vars_match = re.search(
+            r"expected_env_vars = \{(.*?)\n\s*\}", build, re.DOTALL
+        )
+        self.assertIsNotNone(configured_env_vars_match)
+        self.assertEqual(
+            set(re.findall(r'"(TUVA_CI_[A-Z0-9_]+_SHA)"', configured_env_vars_match.group(1))),
+            expected_env_vars,
+        )
+
+    def test_both_modes_use_small_synthetic_data_without_parity(self):
+        self.assertEqual(
+            self.workflow.count('"use_synthetic_data": true'), 1
+        )
+        self.assertEqual(
+            self.workflow.count('"synthetic_data_size": "small"'), 1
+        )
+        self.assertEqual(self.workflow.count('"parity_enabled": false'), 1)
+        self.assertIn("strategy:\n      fail-fast: false", self.workflow)
+        self.assertEqual(self.workflow.count("dbt build --full-refresh"), 5)
+        self.assertNotIn('"synthetic_data_size": "large"', self.workflow)
+
+    def test_ci_actions_are_immutable_and_release_evidence_is_retained(self):
+        action_uses = extract_action_uses(self.workflow) + extract_action_uses(
+            self.external_workflow
+        )
+        local_uses = [use for use in action_uses if use.startswith("./")]
+        external_uses = [use for use in action_uses if not use.startswith("./")]
+
+        self.assertEqual(local_uses, ["./.github/workflows/ci.yml"])
+        self.assertTrue(external_uses)
+        for use in external_uses:
+            action, separator, revision = use.rpartition("@")
+            self.assertTrue(separator, use)
+            self.assertTrue(action, use)
+            self.assertRegex(revision, r"^[0-9a-f]{40}$", use)
+
+        expected_actions = {
+            "actions/github-script": "f28e40c7f34bde8b3046d885e986cb6290c5673b",
+            "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
+            "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
+            "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+        }
+        observed = Counter(external_uses)
+        self.assertEqual(
+            set(observed),
+            {f"{action}@{revision}" for action, revision in expected_actions.items()},
+        )
+        self.assertEqual(
+            observed[
+                "actions/upload-artifact@"
+                "ea165f8d65b6e75b540449e92b4886f43607fa02"
+            ],
+            1,
+        )
+
+        artifact_match = re.search(
+            r"- name: Upload release evidence(.*?)retention-days: 90",
+            self.workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(artifact_match)
+        artifact_block = artifact_match.group(1)
+        self.assertIn("if: always() && env.CI_MODE == 'release'", artifact_block)
+        self.assertIn("if-no-files-found: warn", artifact_block)
+        artifact_paths = tuple(
+            re.findall(r"(?m)^\s+(integration_tests/\S+)$", artifact_block)
+        )
+        self.assertEqual(
+            artifact_paths,
+            (
+                "integration_tests/ci-evidence.json",
+                "integration_tests/package-lock.yml",
+                "integration_tests/packages.yml",
+                "integration_tests/ci-source-lock.json",
+            ),
+        )
+        for raw_artifact in (
+            "integration_tests/target/manifest.json",
+            "integration_tests/target/run_results.json",
+            "integration_tests/logs/dbt.log",
+        ):
+            self.assertNotIn(raw_artifact, artifact_block)
+
+        prepare_match = re.search(
+            r"- name: Prepare release evidence(.*?)"
+            r"\n\s*- name: Upload release evidence",
+            self.workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(prepare_match)
+        prepare_block = prepare_match.group(1)
+        self.assertIn("target_dir / \"manifest.json\"", prepare_block)
+        self.assertIn("target_dir / \"run_results.json\"", prepare_block)
+        for result_field in (
+            "unique_id",
+            "status",
+            "execution_time",
+            "failures",
+        ):
+            self.assertIn(
+                f'"{result_field}": result.get("{result_field}")',
+                prepare_block,
+            )
+        self.assertIn(
+            'for result in run_results.get("results", [])', prepare_block
+        )
+        self.assertIn(
+            'integration_dir / "ci-evidence.json"', prepare_block
+        )
+
+    def test_required_status_context_is_stable_across_both_modes(self):
+        status_contexts = re.findall(
+            r'(?:context:\s*|status\.context === )"([^"]+)"', self.workflow
+        )
+        self.assertGreaterEqual(len(status_contexts), 3)
+        self.assertEqual(set(status_contexts), {"Tuva CI / Required"})
+        self.assertNotIn("Tuva CI / Snowflake", self.workflow)
+        self.assertIn(
+            "[process.env.HEAD_SHA, process.env.MERGE_SHA].map((sha)",
+            self.workflow,
+        )
+        self.assertIn(
+            "const statusRefs = [expectedHead, expectedMerge];", self.workflow
+        )
+        self.assertIn("Full release compatibility matrix passed", self.workflow)
+        self.assertIn("Snowflake Core build passed", self.workflow)
+
+    def test_unscoped_package_resources_have_run_specific_schema_overrides(self):
+        models = self.integration_project.split("\nmodels:\n", 1)[1].split(
+            "\nseeds:\n", 1
+        )[0]
+        seeds = self.integration_project.split("\nseeds:\n", 1)[1].split(
+            "\nflags:\n", 1
+        )[0]
+
+        for package_name, suffix in (
+            ("ccsr", "ccsr"),
+            ("semantic_layer", "semantic_layer"),
+        ):
+            self.assertRegex(
+                models,
+                rf"(?ms)^  {package_name}:\n    \+schema: \|\n"
+                rf"      .*var\('tuva_schema_prefix'\).*"
+                rf"\}}\}}_{suffix}.*else.*{suffix}",
+            )
+        self.assertRegex(
+            seeds,
+            r"(?ms)^  ccsr:\n    \+schema: \|\n"
+            r"      .*var\('tuva_schema_prefix'\).*\}\}_ccsr.*else.*ccsr",
+        )
+        self.assertIn(
+            '"tuva_schema_prefix": "${{ needs.resolve.outputs.schema_prefix }}"',
+            self.workflow,
+        )
+
+    def test_every_warehouse_target_appends_the_run_specific_schema_prefix(self):
+        self.assertIn(
+            "TUVA_CI_SCHEMA_PREFIX: "
+            "${{ needs.resolve.outputs.schema_prefix }}",
+            self.workflow,
+        )
+        expected_target_locations = {
+            "snowflake": (
+                "schema: \"{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "bigquery": (
+                "dataset: \"connector_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "databricks": (
+                "schema: \"default_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "fabric": (
+                "schema: \"{{ env_var('DBT_FABRIC_CI_SCHEMA') }}_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "redshift": (
+                "schema: \"public_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+        }
+        self.assertEqual(set(self.profiles), set(WAREHOUSES))
+        for warehouse, target_location in expected_target_locations.items():
+            with self.subTest(warehouse=warehouse):
+                profile = self.profiles[warehouse]
+                self.assertIn(target_location, profile)
+                self.assertEqual(profile.count("TUVA_CI_SCHEMA_PREFIX"), 1)
+
+    def test_external_dispatch_rejects_version_changing_pull_requests(self):
+        self.assertRegex(
+            self.external_workflow, r"(?m)^  workflow_dispatch:$"
+        )
+        self.assertIn("projectVersion(pr.base.sha)", self.external_workflow)
+        self.assertIn(
+            "projectVersion(mergeCommit.sha)", self.external_workflow
+        )
+        rejection = "if (baseVersion !== mergeVersion) {"
+        rejection_message = (
+            "Version-changing pull requests must use an internal branch so the "
+        )
+        self.assertIn(rejection, self.external_workflow)
+        self.assertIn(rejection_message, self.external_workflow)
+        self.assertLess(
+            self.external_workflow.index(rejection),
+            self.external_workflow.index('core.setOutput("pr_number"'),
+        )
+        self.assertIn("warehouse: snowflake", self.external_workflow)
+        self.assertNotIn("warehouse: all", self.external_workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+ALL_WAREHOUSES_CI_PATH = (
+    ROOT / ".github" / "workflows" / "ci-all-warehouses.yml"
+)
 EXTERNAL_CI_PATH = ROOT / ".github" / "workflows" / "ci-external-pr.yml"
 PACKAGES_PATH = ROOT / "integration_tests" / "packages.yml"
 RELEASE_PACKAGES_PATH = ROOT / "integration_tests" / "packages.release.yml"
@@ -62,11 +65,11 @@ RELEASE_PACKAGES = (
     ("semantic-layer", "semantic_layer", "TUVA_CI_SEMANTIC_LAYER_SHA"),
 )
 
-DEFAULT_SELECTOR = (
+CORE_SELECTOR = (
     "package:integration_tests",
     "package:the_tuva_project",
 )
-RELEASE_SELECTOR = DEFAULT_SELECTOR + tuple(
+ALL_PACKAGES_SELECTOR = CORE_SELECTOR + tuple(
     f"package:{dbt_package}" for _, dbt_package, _ in RELEASE_PACKAGES
 )
 
@@ -90,6 +93,9 @@ class CiContractTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.workflow = CI_PATH.read_text(encoding="utf-8")
+        cls.all_warehouses_workflow = ALL_WAREHOUSES_CI_PATH.read_text(
+            encoding="utf-8"
+        )
         cls.external_workflow = EXTERNAL_CI_PATH.read_text(encoding="utf-8")
         cls.packages = PACKAGES_PATH.read_text(encoding="utf-8")
         cls.release_packages = RELEASE_PACKAGES_PATH.read_text(encoding="utf-8")
@@ -101,42 +107,96 @@ class CiContractTest(unittest.TestCase):
             for warehouse, path in PROFILE_PATHS.items()
         }
 
-    def test_primary_ci_exposes_only_the_two_automatic_modes(self):
-        event_block = self.workflow.split("\npermissions:", 1)[0]
-        self.assertRegex(event_block, r"(?m)^  pull_request:$")
-        self.assertRegex(event_block, r"(?m)^  workflow_call:$")
-        self.assertNotRegex(event_block, r"(?m)^  workflow_dispatch:$")
+    def test_public_ci_surface_is_two_simple_workflows(self):
+        self.assertTrue(self.workflow.startswith("name: Tuva CI -- Snowflake\n"))
+        primary_events = self.workflow.split("\npermissions:", 1)[0]
+        self.assertRegex(primary_events, r"(?m)^  pull_request:$")
+        self.assertRegex(primary_events, r"(?m)^  workflow_call:$")
+        self.assertNotRegex(primary_events, r"(?m)^  workflow_dispatch:$")
 
-        default_selector_match = re.search(
-            r'const defaultSelector =\s*"([^"]+)";', self.workflow
+        self.assertTrue(
+            self.all_warehouses_workflow.startswith(
+                "name: Tuva CI -- All Warehouses\n"
+            )
         )
-        self.assertIsNotNone(default_selector_match)
+        all_events = self.all_warehouses_workflow.split("\npermissions:", 1)[0]
+        self.assertRegex(all_events, r"(?m)^  workflow_dispatch:$")
         self.assertEqual(
-            tuple(default_selector_match.group(1).split()), DEFAULT_SELECTOR
+            re.findall(r"(?m)^      ([a-z_]+):$", all_events),
+            ["pr_number"],
+        )
+        self.assertNotIn("warehouse:", all_events)
+        self.assertNotIn("selector:", all_events)
+        self.assertNotIn("command:", all_events)
+
+    def test_automatic_pull_requests_are_always_core_on_snowflake(self):
+        core_selector_match = re.search(
+            r'const coreSelector =\s*"([^"]+)";', self.workflow
+        )
+        self.assertIsNotNone(core_selector_match)
+        self.assertEqual(
+            tuple(core_selector_match.group(1).split()), CORE_SELECTOR
         )
         self.assertEqual(
             extract_javascript_array(
-                self.workflow, "releaseSelector", r'\.join\(" "\);'
+                self.workflow, "allPackagesSelector", r'\.join\(" "\);'
             ),
-            RELEASE_SELECTOR,
+            ALL_PACKAGES_SELECTOR,
         )
 
-        self.assertIn('let warehouse = "snowflake";', self.workflow)
-        self.assertIn('let mode = "default";', self.workflow)
-        self.assertIn("if (baseVersion !== mergeVersion) {", self.workflow)
-        self.assertIn('mode = "release";', self.workflow)
-        self.assertIn('warehouse = "all";', self.workflow)
-        self.assertIn("selector = releaseSelector;", self.workflow)
-        self.assertIn(
-            'if (isReusableCall && warehouse !== "snowflake")', self.workflow
-        )
+        pull_request_branch = self.workflow[
+            self.workflow.index(
+                '} else if (context.eventName === "pull_request") {'
+            ) : self.workflow.index("const supportedRequests = new Set")
+        ]
+        self.assertIn('warehouse = "snowflake";', pull_request_branch)
+        self.assertIn('scope = "core";', pull_request_branch)
+        self.assertIn("checkoutRef = context.sha;", pull_request_branch)
+        self.assertIn("mergeSha = context.sha;", pull_request_branch)
+        self.assertNotIn("projectVersion", pull_request_branch)
+        self.assertNotIn("all-packages", pull_request_branch)
 
-        # Routine CI installs only the checked-out Core package. Standalone
-        # package sources are exclusive to the version-gated release mode.
+        supported_request_match = re.search(
+            r"const supportedRequests = new Set\(\[(.*?)\]\);",
+            self.workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(supported_request_match)
+        self.assertEqual(
+            set(re.findall(r'"([^"]+)"', supported_request_match.group(1))),
+            {"snowflake:core", "all:all-packages"},
+        )
         self.assertEqual(self.packages.strip(), "packages:\n  - local: ../")
-        self.assertIn("checkoutRef = context.sha;", self.workflow)
-        self.assertIn("mergeSha = context.sha;", self.workflow)
-        self.assertIn('source: "pull_request_test_merge"', self.workflow)
+
+    def test_manual_release_dispatch_validates_an_internal_version_pr(self):
+        resolver = self.all_warehouses_workflow
+        self.assertIn('context.ref !== "refs/heads/main"', resolver)
+        self.assertIn('pr.state !== "open"', resolver)
+        self.assertIn('pr.base.ref !== "main"', resolver)
+        self.assertIn("headRepository !== baseRepository", resolver)
+        self.assertIn("pr.mergeable !== true", resolver)
+        self.assertIn('ref: `refs/pull/${prNumber}/merge`', resolver)
+        self.assertIn("parentShas[0] !== pr.base.sha", resolver)
+        self.assertIn("parentShas[1] !== pr.head.sha", resolver)
+        self.assertIn("projectVersion(pr.base.sha)", resolver)
+        self.assertIn("projectVersion(mergeCommit.sha)", resolver)
+        self.assertIn("function parseSemver(version)", resolver)
+        self.assertIn("function compareSemverPrecedence(", resolver)
+        self.assertIn(
+            "compareSemverPrecedence(releaseVersion, baseVersion) <= 0",
+            resolver,
+        )
+
+        self.assertGreaterEqual(resolver.count("await getPullRequest()"), 2)
+        self.assertGreaterEqual(resolver.count("await getTestMerge("), 2)
+        self.assertIn("currentMerge.sha !== mergeCommit.sha", resolver)
+
+        self.assertIn("warehouse: all", resolver)
+        self.assertIn("scope: all-packages", resolver)
+        self.assertIn(
+            "source_lock: ${{ needs.resolve.outputs.source_lock }}", resolver
+        )
+        self.assertIn("publish_status: true", resolver)
 
     def test_release_warehouse_and_package_inventories_are_exact(self):
         self.assertEqual(
@@ -149,8 +209,8 @@ class CiContractTest(unittest.TestCase):
         )
 
         release_package_block = re.search(
-            r"const releasePackages = \[(.*?)\];\n\s*const exactSha",
-            self.workflow,
+            r"const releasePackages = \[(.*?)\];\n\s*async function getPullRequest",
+            self.all_warehouses_workflow,
             re.DOTALL,
         )
         self.assertIsNotNone(release_package_block)
@@ -180,76 +240,104 @@ class CiContractTest(unittest.TestCase):
         self.assertEqual(self.release_packages.count("  - local: ../"), 1)
         self.assertNotRegex(self.release_packages, r"(?m)^\s*revision:\s*main\s*$")
 
-    def test_release_sources_are_resolved_once_and_locked_to_exact_commits(self):
-        resolver_start = self.workflow.index("const releasePackages = [")
-        build_start = self.workflow.index("\n  build:")
-        resolver = self.workflow[resolver_start:build_start]
-        build = self.workflow[build_start:]
+    def test_release_sources_are_resolved_once_and_shared_by_every_job(self):
+        resolver = self.all_warehouses_workflow
+        build = self.workflow[self.workflow.index("\n  build:") :]
 
-        self.assertIn("await Promise.all(", resolver)
         self.assertIn("releasePackages.map(async (item) =>", resolver)
         self.assertIn("github.rest.repos.getCommit({", resolver)
         self.assertIn("repo: item.repository,", resolver)
         self.assertIn('ref: "main"', resolver)
         self.assertIn("revision: commit.sha.toLowerCase()", resolver)
-        self.assertIn("branch: \"main\"", resolver)
-        self.assertIn("const exactSha = /^[0-9a-f]{40}$/i;", resolver)
-        # The final status job re-resolves the PR merge ref to prevent a stale
-        # run from winning. It must not resolve standalone package branches a
-        # second time inside any matrix job.
+        self.assertIn('branch: "main"', resolver)
+        self.assertIn("standalone_packages: standalonePackages", resolver)
+        self.assertIn("revision: mergeCommit.sha.toLowerCase()", resolver)
+        self.assertIn(
+            'core.setOutput("source_lock", JSON.stringify(sourceLock));', resolver
+        )
+
         self.assertNotIn("repo: item.repository,", build)
         self.assertNotIn("releasePackages.map(async (item) =>", build)
-
-        self.assertIn("standalone_packages: standalonePackages", resolver)
-        self.assertIn("revision: mergeSha.toLowerCase()", resolver)
-        self.assertIn('core.setOutput("source_lock", sourceLock);', resolver)
         self.assertIn(
-            "packages = source_lock.get(\"standalone_packages\")", build
+            'packages = source_lock.get("standalone_packages")', build
         )
         self.assertIn(
             'if not isinstance(packages, list) or len(packages) != 8:', build
         )
-        self.assertIn(
-            'exact_sha = re.compile(r"^[0-9a-f]{40}$")', build
-        )
+        self.assertIn('exact_sha = re.compile(r"^[0-9a-f]{40}$")', build)
         self.assertIn('env_path = Path(os.environ["GITHUB_ENV"])', build)
+        self.assertIn('integration_dir / "packages.release.yml"', build)
+        self.assertIn('integration_dir / "ci-source-lock.json"', build)
+
+        self.assertIn("const expectedStandalonePackages = [", self.workflow)
+        self.assertIn("expected_packages = {", build)
+        self.assertIn("actual_packages = {", build)
+        for repository, dbt_package, env_var in RELEASE_PACKAGES:
+            with self.subTest(repository=repository):
+                self.assertIn(f"/{repository}`", self.workflow)
+                self.assertIn(f'"{dbt_package}"', self.workflow)
+                self.assertIn(f'"{env_var}"', self.workflow)
+                self.assertIn(f'/{repository}"', build)
+                self.assertIn(f'"{dbt_package}"', build)
+                self.assertIn(f'"{env_var}"', build)
+
+    def test_release_preflight_requires_payloads_but_no_receipt(self):
+        preflight = self.workflow[
+            self.workflow.index("\n  preflight_assets:") : self.workflow.index(
+                "\n  build:"
+            )
+        ]
+        self.assertIn("needs.resolve.outputs.scope == 'all-packages'", preflight)
         self.assertIn(
-            "integration_dir / \"packages.release.yml\"", build
+            'source_lock.get("release_version") != package_version', preflight
         )
+        self.assertIn('Path("data_assets.yml")', preflight)
+        self.assertIn('r"^    path: (\\S+)$"', preflight)
+        self.assertIn("declared_path_keys != len(asset_paths)", preflight)
+        self.assertIn("declared_seed_keys != len(canonical_seeds)", preflight)
+        self.assertIn("len(canonical_seeds) != len(asset_paths)", preflight)
         self.assertIn(
-            'integration_dir / "ci-source-lock.json"', build
+            "release preflight refuses to skip unrecognized YAML declarations",
+            preflight,
+        )
+        for provider_url in (
+            "https://tuva-public-resources.s3.amazonaws.com",
+            "https://storage.googleapis.com/tuva-public-resources",
+            "https://tuvapublicresources.blob.core.windows.net/",
+        ):
+            self.assertIn(provider_url, preflight)
+        self.assertIn("/tuva-core/{version_component}/", preflight)
+        self.assertIn("/_release.json", preflight)
+        self.assertIn("if status != 404:", preflight)
+        self.assertIn("- preflight_assets", self.workflow)
+        self.assertIn(
+            "needs.preflight_assets.result == 'success' || "
+            "needs.preflight_assets.result == 'skipped'",
+            self.workflow,
         )
 
-        expected_env_vars = {env_var for _, _, env_var in RELEASE_PACKAGES}
-        configured_env_vars_match = re.search(
-            r"expected_env_vars = \{(.*?)\n\s*\}", build, re.DOTALL
-        )
-        self.assertIsNotNone(configured_env_vars_match)
-        self.assertEqual(
-            set(re.findall(r'"(TUVA_CI_[A-Z0-9_]+_SHA)"', configured_env_vars_match.group(1))),
-            expected_env_vars,
-        )
-
-    def test_both_modes_use_small_synthetic_data_without_parity(self):
-        self.assertEqual(
-            self.workflow.count('"use_synthetic_data": true'), 1
-        )
-        self.assertEqual(
-            self.workflow.count('"synthetic_data_size": "small"'), 1
-        )
+    def test_both_paths_use_small_synthetic_data_without_parity(self):
+        self.assertEqual(self.workflow.count('"use_synthetic_data": true'), 1)
+        self.assertEqual(self.workflow.count('"synthetic_data_size": "small"'), 1)
         self.assertEqual(self.workflow.count('"parity_enabled": false'), 1)
         self.assertIn("strategy:\n      fail-fast: false", self.workflow)
         self.assertEqual(self.workflow.count("dbt build --full-refresh"), 5)
         self.assertNotIn('"synthetic_data_size": "large"', self.workflow)
 
     def test_ci_actions_are_immutable_and_release_evidence_is_retained(self):
-        action_uses = extract_action_uses(self.workflow) + extract_action_uses(
-            self.external_workflow
+        workflows = (
+            self.workflow,
+            self.all_warehouses_workflow,
+            self.external_workflow,
         )
+        action_uses = sum((extract_action_uses(text) for text in workflows), [])
         local_uses = [use for use in action_uses if use.startswith("./")]
         external_uses = [use for use in action_uses if not use.startswith("./")]
 
-        self.assertEqual(local_uses, ["./.github/workflows/ci.yml"])
+        self.assertEqual(
+            local_uses,
+            ["./.github/workflows/ci.yml", "./.github/workflows/ci.yml"],
+        )
         self.assertTrue(external_uses)
         for use in external_uses:
             action, separator, revision = use.rpartition("@")
@@ -277,13 +365,15 @@ class CiContractTest(unittest.TestCase):
         )
 
         artifact_match = re.search(
-            r"- name: Upload release evidence(.*?)retention-days: 90",
+            r"- name: Upload all-warehouse evidence(.*?)retention-days: 90",
             self.workflow,
             re.DOTALL,
         )
         self.assertIsNotNone(artifact_match)
         artifact_block = artifact_match.group(1)
-        self.assertIn("if: always() && env.CI_MODE == 'release'", artifact_block)
+        self.assertIn(
+            "if: always() && env.CI_SCOPE == 'all-packages'", artifact_block
+        )
         self.assertIn("if-no-files-found: warn", artifact_block)
         artifact_paths = tuple(
             re.findall(r"(?m)^\s+(integration_tests/\S+)$", artifact_block)
@@ -305,15 +395,19 @@ class CiContractTest(unittest.TestCase):
             self.assertNotIn(raw_artifact, artifact_block)
 
         prepare_match = re.search(
-            r"- name: Prepare release evidence(.*?)"
-            r"\n\s*- name: Upload release evidence",
+            r"- name: Prepare all-warehouse evidence(.*?)"
+            r"\n\s*- name: Upload all-warehouse evidence",
             self.workflow,
             re.DOTALL,
         )
         self.assertIsNotNone(prepare_match)
         prepare_block = prepare_match.group(1)
-        self.assertIn("target_dir / \"manifest.json\"", prepare_block)
-        self.assertIn("target_dir / \"run_results.json\"", prepare_block)
+        self.assertIn(
+            '"github_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"]',
+            prepare_block,
+        )
+        self.assertIn('target_dir / "manifest.json"', prepare_block)
+        self.assertIn('target_dir / "run_results.json"', prepare_block)
         for result_field in (
             "unique_id",
             "status",
@@ -324,38 +418,51 @@ class CiContractTest(unittest.TestCase):
                 f'"{result_field}": result.get("{result_field}")',
                 prepare_block,
             )
-        self.assertIn(
-            'for result in run_results.get("results", [])', prepare_block
-        )
-        self.assertIn(
-            'integration_dir / "ci-evidence.json"', prepare_block
-        )
 
-    def test_required_status_context_is_stable_across_both_modes(self):
-        status_contexts = re.findall(
-            r'(?:context:\s*|status\.context === )"([^"]+)"', self.workflow
-        )
-        self.assertGreaterEqual(len(status_contexts), 3)
-        self.assertEqual(set(status_contexts), {"Tuva CI / Required"})
-        self.assertNotIn("Tuva CI / Snowflake", self.workflow)
+    def test_status_contexts_are_distinct_and_stale_safe(self):
+        self.assertIn('"Tuva CI / Snowflake"', self.workflow)
+        self.assertIn('"Tuva CI / All Warehouses"', self.workflow)
+        self.assertNotIn("Tuva CI / Required", self.workflow)
         self.assertIn(
-            "[process.env.HEAD_SHA, process.env.MERGE_SHA].map((sha)",
+            "const statusRefs = [process.env.HEAD_SHA, process.env.MERGE_SHA]",
             self.workflow,
         )
         self.assertIn(
             "const statusRefs = [expectedHead, expectedMerge];", self.workflow
         )
-        self.assertIn("Full release compatibility matrix passed", self.workflow)
+        self.assertIn("status.context === statusContext", self.workflow)
+        self.assertIn("currentMerge.sha === expectedMerge", self.workflow)
+        self.assertIn(
+            "changed before CI could publish pending status", self.workflow
+        )
+        self.assertIn("newerRunOwnsStatus", self.workflow)
+        self.assertIn(
+            "JSON.parse(sourceLock).standalone_packages", self.workflow
+        )
+        self.assertIn(
+            'ref: "main"',
+            self.workflow[self.workflow.index("\n  finalize_status:") :],
+        )
+        self.assertIn(
+            "A standalone package main changed; rerun required", self.workflow
+        )
+        self.assertIn("All-warehouse release CI passed", self.workflow)
         self.assertIn("Snowflake Core build passed", self.workflow)
 
-    def test_unscoped_package_resources_have_run_specific_schema_overrides(self):
+    def test_every_run_gets_isolated_cross_package_schemas(self):
+        self.assertIn("${schemaBase}_r${runId}_a${runAttempt}", self.workflow)
+        self.assertIn(
+            "TUVA_CI_SCHEMA_PREFIX: "
+            "${{ needs.resolve.outputs.schema_prefix }}",
+            self.workflow,
+        )
+
         models = self.integration_project.split("\nmodels:\n", 1)[1].split(
             "\nseeds:\n", 1
         )[0]
         seeds = self.integration_project.split("\nseeds:\n", 1)[1].split(
             "\nflags:\n", 1
         )[0]
-
         for package_name, suffix in (
             ("ccsr", "ccsr"),
             ("semantic_layer", "semantic_layer"),
@@ -371,17 +478,7 @@ class CiContractTest(unittest.TestCase):
             r"(?ms)^  ccsr:\n    \+schema: \|\n"
             r"      .*var\('tuva_schema_prefix'\).*\}\}_ccsr.*else.*ccsr",
         )
-        self.assertIn(
-            '"tuva_schema_prefix": "${{ needs.resolve.outputs.schema_prefix }}"',
-            self.workflow,
-        )
 
-    def test_every_warehouse_target_appends_the_run_specific_schema_prefix(self):
-        self.assertIn(
-            "TUVA_CI_SCHEMA_PREFIX: "
-            "${{ needs.resolve.outputs.schema_prefix }}",
-            self.workflow,
-        )
         expected_target_locations = {
             "snowflake": (
                 "schema: \"{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}_"
@@ -411,25 +508,23 @@ class CiContractTest(unittest.TestCase):
                 self.assertIn(target_location, profile)
                 self.assertEqual(profile.count("TUVA_CI_SCHEMA_PREFIX"), 1)
 
-    def test_external_dispatch_rejects_version_changing_pull_requests(self):
-        self.assertRegex(
-            self.external_workflow, r"(?m)^  workflow_dispatch:$"
-        )
+    def test_external_dispatch_is_core_snowflake_and_rejects_version_changes(self):
+        self.assertRegex(self.external_workflow, r"(?m)^  workflow_dispatch:$")
         self.assertIn("projectVersion(pr.base.sha)", self.external_workflow)
-        self.assertIn(
-            "projectVersion(mergeCommit.sha)", self.external_workflow
-        )
+        self.assertIn("projectVersion(mergeCommit.sha)", self.external_workflow)
         rejection = "if (baseVersion !== mergeVersion) {"
-        rejection_message = (
-            "Version-changing pull requests must use an internal branch so the "
-        )
         self.assertIn(rejection, self.external_workflow)
-        self.assertIn(rejection_message, self.external_workflow)
+        self.assertIn(
+            "Version-changing pull requests must use an internal branch",
+            self.external_workflow,
+        )
         self.assertLess(
             self.external_workflow.index(rejection),
             self.external_workflow.index('core.setOutput("pr_number"'),
         )
         self.assertIn("warehouse: snowflake", self.external_workflow)
+        self.assertIn("scope: core", self.external_workflow)
+        self.assertIn('source_lock: ""', self.external_workflow)
         self.assertNotIn("warehouse: all", self.external_workflow)
 
 

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -217,14 +217,22 @@ class DataAssetContractTest(unittest.TestCase):
             ROOT / "integration_tests" / "dbt_project.yml"
         ).read_text()
 
-        self.assertIn("macro bigquery__load_csv_rows(model, agate_table)", macro)
+        self.assertIn(
+            "macro bigquery_create_seed_relation(model, agate_table, relation)",
+            macro,
+        )
+        self.assertIn("macro bigquery__create_csv_table(model, agate_table)", macro)
+        self.assertIn(
+            "macro bigquery__reset_csv_table(model, full_refresh, old_relation, agate_table)",
+            macro,
+        )
         self.assertIn("agate_table.rows | length == 0", macro)
         self.assertIn("for column_name in agate_table.column_names", macro)
         self.assertIn("column_types that exactly match its CSV header", macro)
-        self.assertIn("api.Column.translate_type(column_override[column_name])", macro)
-        self.assertIn("create or replace table {{ this.render() }}", macro)
-        self.assertIn("adapter.load_dataframe(", macro)
-        self.assertIn("bigquery_table_options(config, model)", macro)
+        self.assertIn("api.Column.translate_type(column_type)", macro)
+        self.assertIn("create or replace table {{ relation.render() }}", macro)
+        self.assertIn("adapter.drop_relation(old_relation)", macro)
+        self.assertNotIn("macro bigquery__load_csv_rows", macro)
         self.assertIn("macro_namespace: 'dbt'", integration_project)
         self.assertIn("search_order: ['integration_tests', 'dbt']", integration_project)
 

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -209,6 +209,20 @@ class DataAssetContractTest(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, load_macro)
 
+    def test_bigquery_header_only_seed_materialization_contract(self):
+        macro = (
+            ROOT / "integration_tests" / "macros" / "bigquery_seed.sql"
+        ).read_text()
+
+        self.assertIn("macro bigquery__load_csv_rows(model, agate_table)", macro)
+        self.assertIn("agate_table.rows | length == 0", macro)
+        self.assertIn("for column_name in agate_table.column_names", macro)
+        self.assertIn("column_types that exactly match its CSV header", macro)
+        self.assertIn("api.Column.translate_type(column_override[column_name])", macro)
+        self.assertIn("create or replace table {{ this.render() }}", macro)
+        self.assertIn("adapter.load_dataframe(", macro)
+        self.assertIn("bigquery_table_options(config, model)", macro)
+
     def test_release_requires_all_cloud_receipts_before_tagging(self):
         workflow = (ROOT / ".github" / "workflows" / "create-release.yml").read_text()
         receipt_step = workflow.index("- name: Verify data asset release receipts")

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -213,6 +213,9 @@ class DataAssetContractTest(unittest.TestCase):
         macro = (
             ROOT / "integration_tests" / "macros" / "bigquery_seed.sql"
         ).read_text()
+        integration_project = (
+            ROOT / "integration_tests" / "dbt_project.yml"
+        ).read_text()
 
         self.assertIn("macro bigquery__load_csv_rows(model, agate_table)", macro)
         self.assertIn("agate_table.rows | length == 0", macro)
@@ -222,6 +225,8 @@ class DataAssetContractTest(unittest.TestCase):
         self.assertIn("create or replace table {{ this.render() }}", macro)
         self.assertIn("adapter.load_dataframe(", macro)
         self.assertIn("bigquery_table_options(config, model)", macro)
+        self.assertIn("macro_namespace: 'dbt'", integration_project)
+        self.assertIn("search_order: ['integration_tests', 'dbt']", integration_project)
 
     def test_release_requires_all_cloud_receipts_before_tagging(self):
         workflow = (ROOT / ".github" / "workflows" / "create-release.yml").read_text()


### PR DESCRIPTION
## Summary

- make `Tuva CI -- Snowflake` the only automatic internal-PR path: exact PR test merge, Tuva Core plus the integration project, Snowflake, and the small synthetic dataset
- add `Tuva CI -- All Warehouses` as a manual release workflow with one input: the final internal, version-increasing pull request number
- resolve the exact PR test merge and all eight standalone package `main` revisions once, then use that immutable source lock for Snowflake, BigQuery, Databricks, Fabric, and Redshift
- enable Data Quality and optional logical failure-key coverage in the shared CI worker while keeping parity disabled
- pin the newest mutually compatible dbt compiler/adapter set across the five warehouses, require security-fixed `sqlparse 0.6.0`, and retain a bounded 100,000-token grouping guard for Tuva's large unit-test SQL
- preflight every future-version Core payload in S3, GCS, and Azure while requiring completion receipts to remain absent before merge
- retain isolated schemas, stale-run protection, distinct commit statuses, sanitized 90-day evidence, external-fork safeguards, and the integration-only BigQuery header-seed fix
- generate the release package manifest from the trusted source lock and require enabled nodes from Core, integration tests, and all eight standalone packages
- remove the public individual-warehouse dispatcher and arbitrary dbt command, selector, and flag inputs

## Validation

- `python3 -m unittest discover -s tests/unit -p 'test_*.py' -v` — 28 passed
- `actionlint` 1.7.12 across all GitHub workflows
- Node syntax checks for all five embedded GitHub Script programs
- Python compilation checks for all five embedded workflow programs
- `scripts/dbt-local deps`
- DQ-enabled `scripts/dbt-local parse --no-partial-parse` — passed
- DQ-enabled selection includes the previously omitted Data Quality models and unit tests; the two Snowflake statements that exceeded the 10,000-token limit are split without changing their assertions
- focused Snowflake-dev and DuckDB runs of all four split DQ unit tests — passed
- all five pinned dbt adapter dependency sets resolve with `dbt-core 1.11.14` and `sqlparse 0.6.0`; `pip check` is enforced in CI
- exact compiler dependencies parsed a 42,000-token statement under the bounded CI options, covering the 13,741- and 22,199-token DQ statements that exposed the prior transitive-dependency failure
- isolated-schema startup hook exercised on DuckDB; the target schema was created before unit-test fixture setup and the affected CodeRx unit test passed
- [data-asset publication run 33039894197](https://github.com/tuva-health/tuva-maintenance/actions/runs/33039894197) — passed validation and publication to S3, GCS, and Azure; all three clouds now serve the required assignment payload and identical completion receipt
- [Snowflake run 33041871576](https://github.com/tuva-health/tuva-core/actions/runs/33041871576) cleared the asset and isolated-schema failures and executed 789/791 resources; its only two failures identified the now-fixed `dbt-core 1.10.15` / `sqlparse 0.5.5` compiler-limit regression
- [Snowflake run 33043410772](https://github.com/tuva-health/tuva-core/actions/runs/33043410772) — passed against the exact PR merge on current `main`: `PASS=792 WARN=0 ERROR=0 SKIP=0 TOTAL=792`
- the other seven standalone package mains resolve and parse together against this branch with DQ enabled
- the complete ten-package graph resolves and parses when semantic-layer's existing CodeRx migration commit is used

## Known release blockers surfaced by the matrix

- [`semantic-layer@main`](https://github.com/tuva-health/semantic-layer/commit/4c64f140430030e8b39434cf1f519c2b26030153) still references three terminology seeds removed by Core #1398. The prepared [CodeRx migration](https://github.com/tuva-health/semantic-layer/commit/ef29890e44d2109d41e2d557cd0d32b6dbcbf75f) parses cleanly but still needs its own review and merge.
- BigQuery Data Quality portability remains tracked in #1390. The disposable matrix also exposed standalone CCSR/CMS HCC SQL issues and unreachable Databricks/Fabric/Redshift CI endpoints. The release workflow should remain red for real compatibility or infrastructure failures.
- the manual workflow becomes available in the Actions UI only after this workflow reaches `main`; its first successful release run therefore belongs to the next version-changing release PR.

## Release notes

`ignore-for-release`

Closes #1382

Addresses #1389
