### PR TITLE
DO NOT MERGE: exercise version-gated release CI

### DIFF
--- a/.github/workflows/ci-external-pr.yml
+++ b/.github/workflows/ci-external-pr.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Pin the reviewed pull request revision
         id: resolve
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
         with:

--- a/.github/workflows/ci-external-pr.yml
+++ b/.github/workflows/ci-external-pr.yml
@@ -97,6 +97,49 @@ jobs:
               return;
             }
 
+            async function projectVersion(ref) {
+              const { data } = await github.rest.repos.getContent({
+                ...context.repo,
+                path: "dbt_project.yml",
+                ref
+              });
+              if (Array.isArray(data) || data.type !== "file" || !data.content) {
+                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
+              }
+              const text = Buffer.from(
+                data.content.replace(/\n/g, ""),
+                data.encoding || "base64"
+              ).toString("utf8");
+              const versionPattern =
+                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
+              const matches = [...text.matchAll(versionPattern)];
+              if (matches.length !== 1) {
+                throw new Error(
+                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
+                );
+              }
+              return matches[0][2];
+            }
+
+            let baseVersion;
+            let mergeVersion;
+            try {
+              [baseVersion, mergeVersion] = await Promise.all([
+                projectVersion(pr.base.sha),
+                projectVersion(mergeCommit.sha)
+              ]);
+            } catch (error) {
+              core.setFailed(`Could not inspect PR #${prNumber}'s version: ${error.message}`);
+              return;
+            }
+            if (baseVersion !== mergeVersion) {
+              core.setFailed(
+                "Version-changing pull requests must use an internal branch so the " +
+                "automatic full release matrix can run safely."
+              );
+              return;
+            }
+
             core.setOutput("pr_number", String(prNumber));
             core.setOutput("base_sha", pr.base.sha);
             core.setOutput("head_sha", pr.head.sha);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,8 @@ jobs:
                   projectVersion(baseSha),
                   projectVersion(mergeSha)
                 ]);
-                if (baseVersion !== mergeVersion) {
+                const forceReleaseForLiveTest = true; // TEMPORARY: DO NOT MERGE
+                if (baseVersion !== mergeVersion || forceReleaseForLiveTest) {
                   mode = "release";
                   warehouse = "all";
                   selector = releaseSelector;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     steps:
       - name: Normalize request
         id: resolve
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref || '' }}
           INPUT_WAREHOUSE: ${{ inputs.warehouse || '' }}
@@ -423,7 +423,7 @@ jobs:
       statuses: write
     steps:
       - name: Mark the tested pull request revision as pending
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
@@ -782,7 +782,7 @@ jobs:
       statuses: write
     steps:
       - name: Publish result for the tested pull request revision
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
           EXPECTED_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-  workflow_dispatch:
-    inputs:
-      warehouse:
-        description: Warehouse to validate
-        required: true
-        type: choice
-        default: snowflake
-        options:
-          - snowflake
-          - bigquery
-          - databricks
-          - fabric
-          - redshift
-          - all
   workflow_call:
     inputs:
       checkout_ref:
@@ -121,7 +107,7 @@ concurrency:
     tuva-ci-${{
       github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) ||
       inputs.concurrency_key ||
-      format('manual-{0}', github.run_id)
+      format('run-{0}', github.run_id)
     }}
   cancel-in-progress: true
 
@@ -138,6 +124,8 @@ jobs:
   resolve:
     name: Resolve request
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}
       adapter_matrix: ${{ steps.resolve.outputs.adapter_matrix }}
@@ -145,6 +133,9 @@ jobs:
       schema_prefix: ${{ steps.resolve.outputs.schema_prefix }}
       concurrency_key: ${{ steps.resolve.outputs.concurrency_key }}
       publish_status: ${{ steps.resolve.outputs.publish_status }}
+      mode: ${{ steps.resolve.outputs.mode }}
+      selector: ${{ steps.resolve.outputs.selector }}
+      source_lock: ${{ steps.resolve.outputs.source_lock }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       base_sha: ${{ steps.resolve.outputs.base_sha }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
@@ -172,20 +163,111 @@ jobs:
               "fabric",
               "redshift"
             ];
+            const defaultSelector =
+              "package:integration_tests package:the_tuva_project";
+            const releaseSelector = [
+              "package:integration_tests",
+              "package:the_tuva_project",
+              "package:ahrq_quality_indicators",
+              "package:ccsr",
+              "package:cms_chronic_conditions",
+              "package:cms_hcc",
+              "package:fhir_preprocessing",
+              "package:nyu_ed_classification",
+              "package:quality_measures",
+              "package:semantic_layer"
+            ].join(" ");
+            const releasePackages = [
+              {
+                repository: "ahrq_quality_indicators",
+                dbtPackage: "ahrq_quality_indicators",
+                envVar: "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA"
+              },
+              {
+                repository: "ccsr",
+                dbtPackage: "ccsr",
+                envVar: "TUVA_CI_CCSR_SHA"
+              },
+              {
+                repository: "cms_chronic_conditions",
+                dbtPackage: "cms_chronic_conditions",
+                envVar: "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA"
+              },
+              {
+                repository: "cms_hcc",
+                dbtPackage: "cms_hcc",
+                envVar: "TUVA_CI_CMS_HCC_SHA"
+              },
+              {
+                repository: "fhir_preprocessing",
+                dbtPackage: "fhir_preprocessing",
+                envVar: "TUVA_CI_FHIR_PREPROCESSING_SHA"
+              },
+              {
+                repository: "nyu_ed_classification",
+                dbtPackage: "nyu_ed_classification",
+                envVar: "TUVA_CI_NYU_ED_CLASSIFICATION_SHA"
+              },
+              {
+                repository: "quality_measures",
+                dbtPackage: "quality_measures",
+                envVar: "TUVA_CI_QUALITY_MEASURES_SHA"
+              },
+              {
+                repository: "semantic-layer",
+                dbtPackage: "semantic_layer",
+                envVar: "TUVA_CI_SEMANTIC_LAYER_SHA"
+              }
+            ];
+            const exactSha = /^[0-9a-f]{40}$/i;
+
+            async function projectVersion(ref) {
+              const { data } = await github.rest.repos.getContent({
+                ...context.repo,
+                path: "dbt_project.yml",
+                ref
+              });
+              if (Array.isArray(data) || data.type !== "file" || !data.content) {
+                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
+              }
+              const text = Buffer.from(
+                data.content.replace(/\n/g, ""),
+                data.encoding || "base64"
+              ).toString("utf8");
+              const versionPattern =
+                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
+              const matches = [...text.matchAll(versionPattern)];
+              if (matches.length !== 1) {
+                throw new Error(
+                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
+                );
+              }
+              return matches[0][2];
+            }
 
             const calledCheckoutRef = process.env.INPUT_CHECKOUT_REF.trim();
             const isReusableCall = calledCheckoutRef !== "";
 
             let shouldRun = true;
-            let warehouse;
-            let checkoutRef;
-            let schemaPrefix;
-            let concurrencyKey;
+            let warehouse = "snowflake";
+            let checkoutRef = "";
+            let schemaPrefix = "";
+            let concurrencyKey = "";
             let publishStatus = false;
+            let mode = "default";
+            let selector = defaultSelector;
+            let sourceLock = "";
             let prNumber = "";
             let baseSha = "";
             let headSha = "";
             let mergeSha = "";
+            let resolutionError = "";
+
+            function fail(message) {
+              if (!resolutionError) {
+                resolutionError = message;
+              }
+            }
 
             if (isReusableCall) {
               warehouse = process.env.INPUT_WAREHOUSE.trim();
@@ -220,54 +302,92 @@ jobs:
               headSha = pr.head.sha;
               mergeSha = context.sha;
             } else {
-              warehouse = String(context.payload.inputs?.warehouse || "snowflake").trim();
-              checkoutRef = context.sha;
-              schemaPrefix = `ci_manual_${process.env.GITHUB_RUN_ID}`;
-              concurrencyKey = `manual-${process.env.GITHUB_RUN_ID}`;
+              shouldRun = false;
+              fail(`Unsupported event: ${context.eventName}`);
+            }
+
+            if (shouldRun && !isReusableCall) {
+              try {
+                const [baseVersion, mergeVersion] = await Promise.all([
+                  projectVersion(baseSha),
+                  projectVersion(mergeSha)
+                ]);
+                if (baseVersion !== mergeVersion) {
+                  mode = "release";
+                  warehouse = "all";
+                  selector = releaseSelector;
+
+                  const standalonePackages = await Promise.all(
+                    releasePackages.map(async (item) => {
+                      const { data: commit } = await github.rest.repos.getCommit({
+                        owner: context.repo.owner,
+                        repo: item.repository,
+                        ref: "main"
+                      });
+                      if (!exactSha.test(commit.sha)) {
+                        throw new Error(
+                          `Could not resolve ${item.repository} main to an exact commit`
+                        );
+                      }
+                      return {
+                        repository: `${context.repo.owner}/${item.repository}`,
+                        dbt_package: item.dbtPackage,
+                        branch: "main",
+                        revision: commit.sha.toLowerCase(),
+                        env_var: item.envVar
+                      };
+                    })
+                  );
+                  sourceLock = JSON.stringify({
+                    core: {
+                      repository: `${context.repo.owner}/${context.repo.repo}`,
+                      source: "pull_request_test_merge",
+                      revision: mergeSha.toLowerCase()
+                    },
+                    base_version: baseVersion,
+                    release_version: mergeVersion,
+                    standalone_packages: standalonePackages
+                  });
+                  core.notice(
+                    `Release CI selected for version ${baseVersion} -> ${mergeVersion}`
+                  );
+                } else {
+                  core.notice(`Default CI selected; version remains ${mergeVersion}`);
+                }
+              } catch (error) {
+                fail(`Could not resolve CI mode: ${error.message}`);
+              }
             }
 
             if (![...supportedWarehouses, "all"].includes(warehouse)) {
-              core.setFailed(`Unsupported warehouse: ${warehouse}`);
-              return;
+              fail(`Unsupported warehouse: ${warehouse}`);
             }
             if (isReusableCall && warehouse !== "snowflake") {
-              core.setFailed("Reusable CI calls are restricted to Snowflake.");
-              return;
+              fail("Reusable CI calls are restricted to default Snowflake CI.");
             }
             if (shouldRun && !checkoutRef) {
-              core.setFailed("checkout_ref is required.");
-              return;
+              fail("checkout_ref is required.");
             }
-            if (shouldRun && !/^[0-9a-f]{40}$/i.test(checkoutRef)) {
-              core.setFailed("checkout_ref must be an exact 40-character commit SHA.");
-              return;
+            if (shouldRun && !exactSha.test(checkoutRef)) {
+              fail("checkout_ref must be an exact 40-character commit SHA.");
             }
             if (shouldRun && !/^[a-z0-9_]+$/.test(schemaPrefix)) {
-              core.setFailed(`Invalid schema prefix: ${schemaPrefix}`);
-              return;
+              fail(`Invalid schema prefix: ${schemaPrefix}`);
             }
             if (shouldRun && !concurrencyKey) {
-              core.setFailed("concurrency_key is required.");
-              return;
+              fail("concurrency_key is required.");
             }
             if (publishStatus) {
-              if (warehouse !== "snowflake") {
-                core.setFailed("The required status may be published only by a Snowflake build.");
-                return;
-              }
-              const exactSha = /^[0-9a-f]{40}$/i;
               if (
                 !/^\d+$/.test(prNumber) ||
                 !exactSha.test(baseSha) ||
                 !exactSha.test(headSha) ||
                 !exactSha.test(mergeSha)
               ) {
-                core.setFailed("PR number and exact base, head, and merge commits are required.");
-                return;
+                fail("PR number and exact base, head, and merge commits are required.");
               }
               if (checkoutRef !== mergeSha) {
-                core.setFailed("The required status must describe the exact test-merge commit being built.");
-                return;
+                fail("The required status must describe the exact test-merge commit being built.");
               }
             }
 
@@ -278,15 +398,23 @@ jobs:
             core.setOutput("schema_prefix", schemaPrefix || "");
             core.setOutput("concurrency_key", concurrencyKey || "");
             core.setOutput("publish_status", String(publishStatus));
+            core.setOutput("mode", mode);
+            core.setOutput("selector", selector);
+            core.setOutput("source_lock", sourceLock);
             core.setOutput("pr_number", prNumber);
             core.setOutput("base_sha", baseSha);
             core.setOutput("head_sha", headSha);
             core.setOutput("merge_sha", mergeSha);
 
+            if (resolutionError) {
+              core.setFailed(resolutionError);
+            }
+
   mark_pending:
     name: Publish pending status
     needs: resolve
     if: >-
+      always() &&
       needs.resolve.outputs.should_run == 'true' &&
       needs.resolve.outputs.publish_status == 'true'
     runs-on: ubuntu-latest
@@ -298,18 +426,22 @@ jobs:
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
+          CI_MODE: ${{ needs.resolve.outputs.mode }}
         with:
           script: |
             const targetUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const description = process.env.CI_MODE === "release"
+              ? "Full release compatibility matrix is running"
+              : "Required Snowflake Core build is running";
             await Promise.all(
               [process.env.HEAD_SHA, process.env.MERGE_SHA].map((sha) =>
                 github.rest.repos.createCommitStatus({
                   ...context.repo,
                   sha,
                   state: "pending",
-                  context: "Tuva CI / Snowflake",
-                  description: "Snowflake dbt build is running",
+                  context: "Tuva CI / Required",
+                  description,
                   target_url: targetUrl
                 })
               )
@@ -322,6 +454,7 @@ jobs:
       - mark_pending
     if: >-
       always() &&
+      needs.resolve.result == 'success' &&
       needs.resolve.outputs.should_run == 'true' &&
       (needs.mark_pending.result == 'success' || needs.mark_pending.result == 'skipped')
     runs-on: ubuntu-latest
@@ -332,6 +465,9 @@ jobs:
       matrix:
         warehouse: ${{ fromJson(needs.resolve.outputs.adapter_matrix) }}
     env:
+      CI_MODE: ${{ needs.resolve.outputs.mode }}
+      CI_DBT_SELECTOR: ${{ needs.resolve.outputs.selector }}
+      TUVA_CI_SCHEMA_PREFIX: ${{ needs.resolve.outputs.schema_prefix }}
       CI_DBT_VARS: >-
         {"use_synthetic_data": true, "synthetic_data_size": "small",
         "parity_enabled": false,
@@ -382,9 +518,88 @@ jobs:
               ;;
           esac
 
+      - name: Configure release package sources
+        if: env.CI_MODE == 'release'
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import shutil
+          from pathlib import Path
+
+          source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
+          packages = source_lock.get("standalone_packages")
+          if not isinstance(packages, list) or len(packages) != 8:
+              raise SystemExit("release source lock must contain eight standalone packages")
+
+          exact_sha = re.compile(r"^[0-9a-f]{40}$")
+          expected_env_vars = {
+              "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA",
+              "TUVA_CI_CCSR_SHA",
+              "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA",
+              "TUVA_CI_CMS_HCC_SHA",
+              "TUVA_CI_FHIR_PREPROCESSING_SHA",
+              "TUVA_CI_NYU_ED_CLASSIFICATION_SHA",
+              "TUVA_CI_QUALITY_MEASURES_SHA",
+              "TUVA_CI_SEMANTIC_LAYER_SHA",
+          }
+          actual_env_vars = {item.get("env_var") for item in packages}
+          if actual_env_vars != expected_env_vars:
+              raise SystemExit("release source lock package inventory is invalid")
+
+          env_path = Path(os.environ["GITHUB_ENV"])
+          with env_path.open("a", encoding="utf-8") as env_file:
+              for item in packages:
+                  revision = item.get("revision", "")
+                  if not exact_sha.fullmatch(revision):
+                      raise SystemExit(
+                          f"invalid revision for {item.get('repository', 'unknown')}"
+                      )
+                  env_file.write(f"{item['env_var']}={revision}\n")
+
+          integration_dir = Path("integration_tests")
+          shutil.copyfile(
+              integration_dir / "packages.release.yml",
+              integration_dir / "packages.yml",
+          )
+          (integration_dir / "ci-source-lock.json").write_text(
+              json.dumps(source_lock, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Summarize release sources
+        if: env.CI_MODE == 'release'
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
+          lines = [
+              "## Release CI source lock",
+              "",
+              f"- Tuva Core test merge: `{source_lock['core']['revision']}`",
+          ]
+          for package in source_lock["standalone_packages"]:
+              lines.append(
+                  f"- {package['repository']} `main`: `{package['revision']}`"
+              )
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open(
+              "a", encoding="utf-8"
+          ) as summary:
+              summary.write("\n".join(lines) + "\n")
+          PY
+
       - name: Install dbt dependencies
         run: >-
-          dbt deps
+          dbt deps --upgrade
           --project-dir ./integration_tests
           --profiles-dir ./integration_tests/profiles/${{ matrix.warehouse }}
 
@@ -399,11 +614,12 @@ jobs:
           DBT_SNOWFLAKE_CI_USER: ${{ secrets.DBT_SNOWFLAKE_CI_USER }}
           DBT_SNOWFLAKE_CI_PASSWORD: ${{ secrets.DBT_SNOWFLAKE_CI_PASSWORD }}
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/snowflake
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/snowflake \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on BigQuery
@@ -414,11 +630,12 @@ jobs:
         run: |
           trap 'rm -f ./creds.json' EXIT
           printf '%s' "$DBT_BIGQUERY_CI_TOKEN" | base64 --decode > ./creds.json
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/bigquery
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/bigquery \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on Databricks
@@ -429,11 +646,12 @@ jobs:
           DBT_DATABRICKS_CI_TOKEN: ${{ secrets.DBT_DATABRICKS_CI_TOKEN }}
           DBT_DATABRICKS_CI_CATALOG: ${{ secrets.DBT_DATABRICKS_CI_CATALOG }}
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/databricks
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/databricks \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on Fabric
@@ -446,11 +664,12 @@ jobs:
           DBT_FABRIC_CI_CLIENT_SECRET: ${{ secrets.DBT_FABRIC_CI_CLIENT_SECRET }}
           DBT_FABRIC_CI_TENANT_ID: ${{ secrets.DBT_FABRIC_CI_TENANT_ID }}
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/fabric
           dbt build --full-refresh --cache-selected-only \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/fabric \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
       - name: Build on Redshift
@@ -463,12 +682,87 @@ jobs:
           DBT_REDSHIFT_CI_THREADS: "4"
           DBT_REDSHIFT_CI_SEED_BATCH_SIZE: "2000"
         run: |
+          read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/redshift
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/redshift \
-            --select package:integration_tests package:the_tuva_project \
+            --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
+
+      - name: Prepare release evidence
+        if: always() && env.CI_MODE == 'release'
+        env:
+          CI_WAREHOUSE: ${{ matrix.warehouse }}
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from collections import Counter
+          from pathlib import Path
+
+          integration_dir = Path("integration_tests")
+          target_dir = integration_dir / "target"
+          evidence = {
+              "warehouse": os.environ["CI_WAREHOUSE"],
+              "github_run_id": os.environ["GITHUB_RUN_ID"],
+              "source_lock": json.loads(os.environ["CI_SOURCE_LOCK"]),
+              "manifest": None,
+              "run_results": None,
+          }
+
+          manifest_path = target_dir / "manifest.json"
+          if manifest_path.exists():
+              manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+              nodes = manifest.get("nodes", {})
+              evidence["manifest"] = {
+                  "dbt_version": manifest.get("metadata", {}).get("dbt_version"),
+                  "node_count": len(nodes),
+                  "nodes_by_package": dict(
+                      sorted(
+                          Counter(
+                              node.get("package_name", "unknown")
+                              for node in nodes.values()
+                          ).items()
+                      )
+                  ),
+              }
+
+          results_path = target_dir / "run_results.json"
+          if results_path.exists():
+              run_results = json.loads(results_path.read_text(encoding="utf-8"))
+              evidence["run_results"] = {
+                  "elapsed_time": run_results.get("elapsed_time"),
+                  "results": [
+                      {
+                          "unique_id": result.get("unique_id"),
+                          "status": result.get("status"),
+                          "execution_time": result.get("execution_time"),
+                          "failures": result.get("failures"),
+                      }
+                      for result in run_results.get("results", [])
+                  ],
+              }
+
+          (integration_dir / "ci-evidence.json").write_text(
+              json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload release evidence
+        if: always() && env.CI_MODE == 'release'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tuva-release-ci-${{ matrix.warehouse }}-${{ github.run_id }}
+          path: |
+            integration_tests/ci-evidence.json
+            integration_tests/package-lock.yml
+            integration_tests/packages.yml
+            integration_tests/ci-source-lock.json
+          if-no-files-found: warn
+          retention-days: 90
 
   finalize_status:
     name: Publish final status
@@ -493,6 +787,8 @@ jobs:
           EXPECTED_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
           EXPECTED_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           EXPECTED_MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
+          CI_MODE: ${{ needs.resolve.outputs.mode }}
+          RESOLVE_RESULT: ${{ needs.resolve.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           PENDING_RESULT: ${{ needs.mark_pending.result }}
         with:
@@ -501,13 +797,15 @@ jobs:
             const expectedBase = process.env.EXPECTED_BASE_SHA;
             const expectedHead = process.env.EXPECTED_HEAD_SHA;
             const expectedMerge = process.env.EXPECTED_MERGE_SHA;
+            const mode = process.env.CI_MODE;
+            const resolveResult = process.env.RESOLVE_RESULT;
             const buildResult = process.env.BUILD_RESULT;
             const pendingResult = process.env.PENDING_RESULT;
             const runUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let state = "error";
-            let description = `Snowflake dbt build ended with ${buildResult}`;
+            let description = `Required CI ended with ${buildResult}`;
 
             try {
               const { data: pr } = await github.rest.pulls.get({
@@ -527,21 +825,27 @@ jobs:
                 currentMerge.sha === expectedMerge;
 
               if (!requestIsCurrent) {
-                description = "PR changed while Snowflake CI was running; rerun required";
+                description = "PR changed while CI was running; rerun required";
               } else if (pendingResult !== "success") {
-                description = "Snowflake CI could not publish its pending status";
+                description = "CI could not publish its pending status";
+              } else if (resolveResult !== "success") {
+                description = "CI request resolution failed";
               } else if (buildResult === "success") {
                 state = "success";
-                description = "Snowflake dbt build passed";
+                description = mode === "release"
+                  ? "Full release compatibility matrix passed"
+                  : "Snowflake Core build passed";
               } else if (buildResult === "failure") {
                 state = "failure";
-                description = "Snowflake dbt build failed";
+                description = mode === "release"
+                  ? "Full release compatibility matrix failed"
+                  : "Snowflake Core build failed";
               } else {
-                description = `Snowflake dbt build ended with ${buildResult}`;
+                description = `Required CI ended with ${buildResult}`;
               }
             } catch (error) {
               core.warning(`Could not revalidate PR #${prNumber}: ${error.message}`);
-              description = "Snowflake CI could not revalidate the pull request";
+              description = "CI could not revalidate the pull request";
             }
 
             const statusRefs = [expectedHead, expectedMerge];
@@ -554,7 +858,7 @@ jobs:
                     per_page: 100
                   });
                 return statuses.find(
-                  (status) => status.context === "Tuva CI / Snowflake"
+                  (status) => status.context === "Tuva CI / Required"
                 );
               })
             );
@@ -564,7 +868,7 @@ jobs:
               )
             ) {
               core.notice(
-                "A newer Snowflake CI run owns the required status; " +
+                "A newer CI run owns the required status; " +
                 "this run will not overwrite it."
               );
               return;
@@ -576,7 +880,7 @@ jobs:
                   ...context.repo,
                   sha,
                   state,
-                  context: "Tuva CI / Snowflake",
+                  context: "Tuva CI / Required",
                   description,
                   target_url: runUrl
                 })

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,17 +169,23 @@ content is loaded from public object storage.
   `dbt build --full-refresh` against the small synthetic dataset. The build
   selects Tuva Core plus the integration-test project and runs unit and data
   tests. Parity remains disabled.
-- Additional warehouse validation is manually initiated from GitHub Actions.
-  Choose Snowflake, BigQuery, Databricks, Fabric, Redshift, or `all`; every
-  target runs the same fixed Core build.
+- A pull request that changes the top-level Tuva Core version automatically
+  switches to release CI. It builds the exact pull-request test-merge commit
+  plus all eight accepted standalone package `main` branches on Snowflake,
+  BigQuery, Databricks, Fabric, and Redshift with the small synthetic dataset.
+  Each package branch is resolved once to an exact commit shared by all jobs.
+- Individual warehouse troubleshooting is local; GitHub CI has no general
+  manual warehouse dispatcher.
 - DuckDB portability is validated locally as needed rather than in GitHub CI.
 - Pull-request comment commands do not trigger CI and CI does not accept
   arbitrary dbt commands, selectors, or flags.
 - Automatic secrets-backed CI does not execute fork code. After reviewing an
   external pull request, a maintainer runs `External PR Snowflake CI` from the
-  Actions tab and supplies only the pull-request number.
+  Actions tab and supplies only the pull-request number. Version-changing pull
+  requests must use an internal branch so release CI can run.
 - Standalone packages validate in their own repositories. Routine Tuva Core CI
-  does not install mutable standalone-package branches.
+  does not install standalone packages; release CI snapshots their `main`
+  branches to exact commits before building.
 - Parity comparisons are separate, manually initiated Snowflake validations.
 - Do not edit `.github/workflows/create-release.yml` unless the task explicitly
   targets release automation.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'the_tuva_project'
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 require-dbt-version: ">=1.10.0"
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'the_tuva_project'
-version: '1.0.1'
+version: '1.0.0'
 config-version: 2
 require-dbt-version: ">=1.10.0"
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -81,13 +81,25 @@ testing cross-package compatibility.
 ## Continuous Integration
 
 In-repository pull requests automatically run the Core build on Snowflake with
-the small synthetic dataset. From GitHub Actions, maintainers can run that same
-fixed build manually on Snowflake, BigQuery, Databricks, Fabric, Redshift, or
-all five warehouses. DuckDB remains available for local portability checks.
+the small synthetic dataset. If the pull request changes the top-level Tuva Core
+version, that run automatically switches to release validation: the exact pull
+request test-merge commit plus all eight accepted standalone package `main`
+branches run on Snowflake, BigQuery, Databricks, Fabric, and Redshift. Package
+branches are resolved once to exact commits so every warehouse tests the same
+source set. DuckDB remains available for local portability checks.
+
+Release CI selects the integration project, Tuva Core, AHRQ Quality Indicators,
+CCSR, CMS Chronic Conditions, CMS HCC, FHIR Preprocessing, NYU ED
+Classification, Quality Measures, and Semantic Layer. It keeps the small
+synthetic dataset enabled and parity disabled, and retains each warehouse's dbt
+result summary and resolved source lock for 90 days. Raw logs and warehouse
+connection metadata are not included. There is no general-purpose manual
+warehouse dispatcher; troubleshoot individual warehouses locally.
 
 Reviewed fork pull requests use the separate `External PR Snowflake CI`
 workflow. Its only input is the pull-request number. CI does not accept
-pull-request comment commands or arbitrary dbt commands.
+pull-request comment commands or arbitrary dbt commands. Version changes must
+come from an internal branch so the secrets-backed release matrix can run.
 
 ## Data Asset Loading
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -114,6 +114,8 @@ clean-targets:
 
 
 dispatch:
+  - macro_namespace: 'dbt'
+    search_order: ['integration_tests', 'dbt']
   - macro_namespace: 'the_tuva_project'
     search_order: ['integration_tests', 'the_tuva_project']
   - macro_namespace: 'dbt_utils'

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -125,6 +125,17 @@ models:
     +materialized: table
     +schema: |
       {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_input_layer{%- else -%}input_layer{%- endif -%}
+  ccsr:
+    +schema: |
+      {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_ccsr{%- else -%}ccsr{%- endif -%}
+  semantic_layer:
+    +schema: |
+      {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_semantic_layer{%- else -%}semantic_layer{%- endif -%}
+
+seeds:
+  ccsr:
+    +schema: |
+      {%- if var('tuva_schema_prefix', none) is not none and var('tuva_schema_prefix', none) | trim != '' -%}{{ var('tuva_schema_prefix') }}_ccsr{%- else -%}ccsr{%- endif -%}
 flags:
   require_generic_test_arguments_property: true
   require_ref_searches_node_package_before_root: true

--- a/integration_tests/macros/bigquery_seed.sql
+++ b/integration_tests/macros/bigquery_seed.sql
@@ -11,6 +11,11 @@
 
 {% macro bigquery__load_csv_rows(model, agate_table) %}
   {%- set column_override = model['config'].get('column_types', {}) -%}
+  {{ log(
+      "TEMP BigQuery seed override selected for " ~ model['name'] ~
+      " with " ~ (agate_table.rows | length) ~ " inline rows",
+      true
+  ) }}
 
   {% if agate_table.rows | length == 0 %}
     {%- set quote_seed_column = model['config'].get('quote_columns', none) -%}

--- a/integration_tests/macros/bigquery_seed.sql
+++ b/integration_tests/macros/bigquery_seed.sql
@@ -1,27 +1,24 @@
 {#
-  dbt-bigquery does not create a relation for a header-only seed before it
-  applies table options. Tuva's committed seed files intentionally contain
-  only headers because their rows are loaded from versioned cloud assets in a
-  post-hook. Create the typed empty relation here so the normal materialization
-  can reach that post-hook.
-
-  Keep the nonempty branch aligned with dbt-bigquery's implementation so this
-  override remains safe if the integration project gains an inline seed.
+  dbt-bigquery treats table creation as a no-op and drops an existing table
+  during seed reset. That works when dbt subsequently uploads inline rows, but
+  dbt-core 1.10 skips row loading for Tuva's intentionally header-only seed
+  files. Create the typed empty relation in both paths so the normal Tuva
+  post-hook can replace it with the versioned cloud asset.
 #}
 
-{% macro bigquery__load_csv_rows(model, agate_table) %}
+{% macro bigquery_create_seed_relation(model, agate_table, relation) %}
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {{ log(
-      "TEMP BigQuery seed override selected for " ~ model['name'] ~
+      "TEMP BigQuery seed relation override selected for " ~ model['name'] ~
       " with " ~ (agate_table.rows | length) ~ " inline rows",
       true
   ) }}
+  {%- set quote_seed_column = model['config'].get('quote_columns', none) -%}
+  {%- set missing_columns = [] -%}
+  {%- set extra_columns = [] -%}
+  {%- set column_definitions = [] -%}
 
   {% if agate_table.rows | length == 0 %}
-    {%- set quote_seed_column = model['config'].get('quote_columns', none) -%}
-    {%- set missing_columns = [] -%}
-    {%- set extra_columns = [] -%}
-
     {% for column_name in agate_table.column_names %}
       {% if not column_override.get(column_name) %}
         {% do missing_columns.append(column_name) %}
@@ -42,41 +39,39 @@
           (extra_columns | join(', '))
       ) }}
     {% endif %}
-
-    {% set create_sql %}
-      create or replace table {{ this.render() }} (
-        {% for column_name in agate_table.column_names %}
-          {{ adapter.quote_seed_column(column_name | string, quote_seed_column) }}
-          {{ api.Column.translate_type(column_override[column_name]) }}
-          {%- if not loop.last %}, {% endif %}
-        {% endfor %}
-      )
-    {% endset %}
-
-    {% call statement('create_header_only_seed_relation') %}
-      {{ create_sql }}
-    {% endcall %}
-  {% else %}
-    {% do adapter.load_dataframe(
-        model['database'],
-        model['schema'],
-        model['alias'],
-        agate_table,
-        column_override,
-        model['config']['delimiter']
-    ) %}
   {% endif %}
 
-  {% call statement() %}
-    alter table {{ this.render() }} set {{ bigquery_table_options(config, model) }}
+  {% for column_name in agate_table.column_names %}
+    {%- set configured_type = column_override.get(column_name) -%}
+    {%- set column_type = configured_type
+        if configured_type
+        else adapter.convert_type(agate_table, loop.index0) -%}
+    {% do column_definitions.append(
+        adapter.quote_seed_column(column_name | string, quote_seed_column) ~
+        " " ~ api.Column.translate_type(column_type)
+    ) %}
+  {% endfor %}
+
+  {% set create_sql %}
+    create or replace table {{ relation.render() }} (
+      {{ column_definitions | join(',\n      ') }}
+    )
+  {% endset %}
+
+  {% call statement('create_bigquery_seed_relation') %}
+    {{ create_sql }}
   {% endcall %}
 
-  {% if config.persist_relation_docs() and 'description' in model %}
-    {% do adapter.update_table_description(
-        model['database'],
-        model['schema'],
-        model['alias'],
-        model['description']
-    ) %}
-  {% endif %}
+  {{ return(create_sql) }}
+{% endmacro %}
+
+
+{% macro bigquery__create_csv_table(model, agate_table) %}
+  {{ return(bigquery_create_seed_relation(model, agate_table, this)) }}
+{% endmacro %}
+
+
+{% macro bigquery__reset_csv_table(model, full_refresh, old_relation, agate_table) %}
+  {% do adapter.drop_relation(old_relation) %}
+  {{ return(bigquery_create_seed_relation(model, agate_table, this)) }}
 {% endmacro %}

--- a/integration_tests/macros/bigquery_seed.sql
+++ b/integration_tests/macros/bigquery_seed.sql
@@ -1,0 +1,77 @@
+{#
+  dbt-bigquery does not create a relation for a header-only seed before it
+  applies table options. Tuva's committed seed files intentionally contain
+  only headers because their rows are loaded from versioned cloud assets in a
+  post-hook. Create the typed empty relation here so the normal materialization
+  can reach that post-hook.
+
+  Keep the nonempty branch aligned with dbt-bigquery's implementation so this
+  override remains safe if the integration project gains an inline seed.
+#}
+
+{% macro bigquery__load_csv_rows(model, agate_table) %}
+  {%- set column_override = model['config'].get('column_types', {}) -%}
+
+  {% if agate_table.rows | length == 0 %}
+    {%- set quote_seed_column = model['config'].get('quote_columns', none) -%}
+    {%- set missing_columns = [] -%}
+    {%- set extra_columns = [] -%}
+
+    {% for column_name in agate_table.column_names %}
+      {% if not column_override.get(column_name) %}
+        {% do missing_columns.append(column_name) %}
+      {% endif %}
+    {% endfor %}
+
+    {% for column_name in column_override %}
+      {% if column_name not in agate_table.column_names %}
+        {% do extra_columns.append(column_name) %}
+      {% endif %}
+    {% endfor %}
+
+    {% if missing_columns or extra_columns %}
+      {{ exceptions.raise_compiler_error(
+          "Header-only BigQuery seed " ~ model['name'] ~
+          " requires column_types that exactly match its CSV header. " ~
+          "Missing: " ~ (missing_columns | join(', ')) ~ "; extra: " ~
+          (extra_columns | join(', '))
+      ) }}
+    {% endif %}
+
+    {% set create_sql %}
+      create or replace table {{ this.render() }} (
+        {% for column_name in agate_table.column_names %}
+          {{ adapter.quote_seed_column(column_name | string, quote_seed_column) }}
+          {{ api.Column.translate_type(column_override[column_name]) }}
+          {%- if not loop.last %}, {% endif %}
+        {% endfor %}
+      )
+    {% endset %}
+
+    {% call statement('create_header_only_seed_relation') %}
+      {{ create_sql }}
+    {% endcall %}
+  {% else %}
+    {% do adapter.load_dataframe(
+        model['database'],
+        model['schema'],
+        model['alias'],
+        agate_table,
+        column_override,
+        model['config']['delimiter']
+    ) %}
+  {% endif %}
+
+  {% call statement() %}
+    alter table {{ this.render() }} set {{ bigquery_table_options(config, model) }}
+  {% endcall %}
+
+  {% if config.persist_relation_docs() and 'description' in model %}
+    {% do adapter.update_table_description(
+        model['database'],
+        model['schema'],
+        model['alias'],
+        model['description']
+    ) %}
+  {% endif %}
+{% endmacro %}

--- a/integration_tests/packages.release.yml
+++ b/integration_tests/packages.release.yml
@@ -1,0 +1,18 @@
+packages:
+  - local: ../
+  - git: https://github.com/tuva-health/ahrq_quality_indicators.git
+    revision: "{{ env_var('TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA') }}"
+  - git: https://github.com/tuva-health/ccsr.git
+    revision: "{{ env_var('TUVA_CI_CCSR_SHA') }}"
+  - git: https://github.com/tuva-health/cms_chronic_conditions.git
+    revision: "{{ env_var('TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA') }}"
+  - git: https://github.com/tuva-health/cms_hcc.git
+    revision: "{{ env_var('TUVA_CI_CMS_HCC_SHA') }}"
+  - git: https://github.com/tuva-health/fhir_preprocessing.git
+    revision: "{{ env_var('TUVA_CI_FHIR_PREPROCESSING_SHA') }}"
+  - git: https://github.com/tuva-health/nyu_ed_classification.git
+    revision: "{{ env_var('TUVA_CI_NYU_ED_CLASSIFICATION_SHA') }}"
+  - git: https://github.com/tuva-health/quality_measures.git
+    revision: "{{ env_var('TUVA_CI_QUALITY_MEASURES_SHA') }}"
+  - git: https://github.com/tuva-health/semantic-layer.git
+    revision: "{{ env_var('TUVA_CI_SEMANTIC_LAYER_SHA') }}"

--- a/integration_tests/profiles/bigquery/profiles.yml
+++ b/integration_tests/profiles/bigquery/profiles.yml
@@ -6,7 +6,7 @@ default:
       method: service-account
       keyfile: ./creds.json
       project: "{{ env_var('DBT_BIGQUERY_CI_PROJECT') }}"
-      dataset: connector
+      dataset: "connector_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
       threads: 4
       timeout_seconds: 300
       location: US

--- a/integration_tests/profiles/databricks/profiles.yml
+++ b/integration_tests/profiles/databricks/profiles.yml
@@ -7,7 +7,7 @@ default:
         http_path: "{{ env_var('DBT_DATABRICKS_CI_HTTP_PATH') }}"
         token: "{{ env_var('DBT_DATABRICKS_CI_TOKEN') }}"
         catalog: "{{ env_var('DBT_DATABRICKS_CI_CATALOG') }}"
-        schema: default
+        schema: "default_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
         threads: 8
         connect_timeout: 60
         connect_retries: 3

--- a/integration_tests/profiles/fabric/profiles.yml
+++ b/integration_tests/profiles/fabric/profiles.yml
@@ -7,7 +7,7 @@ default:
       authentication: ActiveDirectoryServicePrincipal
       server: "{{ env_var('DBT_FABRIC_CI_SERVER') }}"
       database: "{{ env_var('DBT_FABRIC_CI_DATABASE') }}"
-      schema: "{{ env_var('DBT_FABRIC_CI_SCHEMA') }}"
+      schema: "{{ env_var('DBT_FABRIC_CI_SCHEMA') }}_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
       client_id: "{{ env_var('DBT_FABRIC_CI_CLIENT_ID') }}"
       client_secret: "{{ env_var('DBT_FABRIC_CI_CLIENT_SECRET') }}"
       tenant_id: "{{ env_var('DBT_FABRIC_CI_TENANT_ID') }}"

--- a/integration_tests/profiles/redshift/profiles.yml
+++ b/integration_tests/profiles/redshift/profiles.yml
@@ -7,6 +7,6 @@ default:
       user: "{{ env_var('DBT_REDSHIFT_CI_USER') }}"
       password: "{{ env_var('DBT_REDSHIFT_CI_PASSWORD') }}"
       dbname: "{{ env_var('DBT_REDSHIFT_CI_DATABASE') }}"
-      schema: public
+      schema: "public_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
       port: 5439
       threads: "{{ env_var('DBT_REDSHIFT_CI_THREADS', '4') | int }}"

--- a/integration_tests/profiles/snowflake/profiles.yml
+++ b/integration_tests/profiles/snowflake/profiles.yml
@@ -7,7 +7,7 @@
         warehouse: "{{ env_var('DBT_SNOWFLAKE_CI_WAREHOUSE') }}"
         database: "{{ env_var('DBT_SNOWFLAKE_CI_DATABASE') }}"
         role: "{{ env_var('DBT_SNOWFLAKE_CI_ROLE') }}"
-        schema: "{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}"
+        schema: "{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}_{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}"
         user: "{{ env_var('DBT_SNOWFLAKE_CI_USER') }}"
         password: "{{ env_var('DBT_SNOWFLAKE_CI_PASSWORD') }}"
         threads: 5

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -258,7 +258,7 @@ class CiContractTest(unittest.TestCase):
             self.assertRegex(revision, r"^[0-9a-f]{40}$", use)
 
         expected_actions = {
-            "actions/github-script": "f28e40c7f34bde8b3046d885e986cb6290c5673b",
+            "actions/github-script": "3a2844b7e9c422d3c10d287c895573f7108da1b3",
             "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
             "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
             "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",

--- a/tests/unit/test_ci_contract.py
+++ b/tests/unit/test_ci_contract.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+EXTERNAL_CI_PATH = ROOT / ".github" / "workflows" / "ci-external-pr.yml"
+PACKAGES_PATH = ROOT / "integration_tests" / "packages.yml"
+RELEASE_PACKAGES_PATH = ROOT / "integration_tests" / "packages.release.yml"
+INTEGRATION_PROJECT_PATH = ROOT / "integration_tests" / "dbt_project.yml"
+PROFILE_PATHS = {
+    warehouse: ROOT / "integration_tests" / "profiles" / warehouse / "profiles.yml"
+    for warehouse in (
+        "snowflake",
+        "bigquery",
+        "databricks",
+        "fabric",
+        "redshift",
+    )
+}
+
+WAREHOUSES = (
+    "snowflake",
+    "bigquery",
+    "databricks",
+    "fabric",
+    "redshift",
+)
+
+RELEASE_PACKAGES = (
+    (
+        "ahrq_quality_indicators",
+        "ahrq_quality_indicators",
+        "TUVA_CI_AHRQ_QUALITY_INDICATORS_SHA",
+    ),
+    ("ccsr", "ccsr", "TUVA_CI_CCSR_SHA"),
+    (
+        "cms_chronic_conditions",
+        "cms_chronic_conditions",
+        "TUVA_CI_CMS_CHRONIC_CONDITIONS_SHA",
+    ),
+    ("cms_hcc", "cms_hcc", "TUVA_CI_CMS_HCC_SHA"),
+    (
+        "fhir_preprocessing",
+        "fhir_preprocessing",
+        "TUVA_CI_FHIR_PREPROCESSING_SHA",
+    ),
+    (
+        "nyu_ed_classification",
+        "nyu_ed_classification",
+        "TUVA_CI_NYU_ED_CLASSIFICATION_SHA",
+    ),
+    (
+        "quality_measures",
+        "quality_measures",
+        "TUVA_CI_QUALITY_MEASURES_SHA",
+    ),
+    ("semantic-layer", "semantic_layer", "TUVA_CI_SEMANTIC_LAYER_SHA"),
+)
+
+DEFAULT_SELECTOR = (
+    "package:integration_tests",
+    "package:the_tuva_project",
+)
+RELEASE_SELECTOR = DEFAULT_SELECTOR + tuple(
+    f"package:{dbt_package}" for _, dbt_package, _ in RELEASE_PACKAGES
+)
+
+
+def extract_javascript_array(text, name, terminator):
+    match = re.search(
+        rf"const {re.escape(name)} = \[(.*?)\]{terminator}",
+        text,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"Could not find JavaScript array {name}")
+    return tuple(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def extract_action_uses(text):
+    return re.findall(r"(?m)^\s*uses:\s+([^\s#]+)", text)
+
+
+class CiContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = CI_PATH.read_text(encoding="utf-8")
+        cls.external_workflow = EXTERNAL_CI_PATH.read_text(encoding="utf-8")
+        cls.packages = PACKAGES_PATH.read_text(encoding="utf-8")
+        cls.release_packages = RELEASE_PACKAGES_PATH.read_text(encoding="utf-8")
+        cls.integration_project = INTEGRATION_PROJECT_PATH.read_text(
+            encoding="utf-8"
+        )
+        cls.profiles = {
+            warehouse: path.read_text(encoding="utf-8")
+            for warehouse, path in PROFILE_PATHS.items()
+        }
+
+    def test_primary_ci_exposes_only_the_two_automatic_modes(self):
+        event_block = self.workflow.split("\npermissions:", 1)[0]
+        self.assertRegex(event_block, r"(?m)^  pull_request:$")
+        self.assertRegex(event_block, r"(?m)^  workflow_call:$")
+        self.assertNotRegex(event_block, r"(?m)^  workflow_dispatch:$")
+
+        default_selector_match = re.search(
+            r'const defaultSelector =\s*"([^"]+)";', self.workflow
+        )
+        self.assertIsNotNone(default_selector_match)
+        self.assertEqual(
+            tuple(default_selector_match.group(1).split()), DEFAULT_SELECTOR
+        )
+        self.assertEqual(
+            extract_javascript_array(
+                self.workflow, "releaseSelector", r'\.join\(" "\);'
+            ),
+            RELEASE_SELECTOR,
+        )
+
+        self.assertIn('let warehouse = "snowflake";', self.workflow)
+        self.assertIn('let mode = "default";', self.workflow)
+        self.assertIn("if (baseVersion !== mergeVersion) {", self.workflow)
+        self.assertIn('mode = "release";', self.workflow)
+        self.assertIn('warehouse = "all";', self.workflow)
+        self.assertIn("selector = releaseSelector;", self.workflow)
+        self.assertIn(
+            'if (isReusableCall && warehouse !== "snowflake")', self.workflow
+        )
+
+        # Routine CI installs only the checked-out Core package. Standalone
+        # package sources are exclusive to the version-gated release mode.
+        self.assertEqual(self.packages.strip(), "packages:\n  - local: ../")
+        self.assertIn("checkoutRef = context.sha;", self.workflow)
+        self.assertIn("mergeSha = context.sha;", self.workflow)
+        self.assertIn('source: "pull_request_test_merge"', self.workflow)
+
+    def test_release_warehouse_and_package_inventories_are_exact(self):
+        self.assertEqual(
+            extract_javascript_array(self.workflow, "supportedWarehouses", r";"),
+            WAREHOUSES,
+        )
+        self.assertIn(
+            'warehouse === "all" ? supportedWarehouses : [warehouse]',
+            self.workflow,
+        )
+
+        release_package_block = re.search(
+            r"const releasePackages = \[(.*?)\];\n\s*const exactSha",
+            self.workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(release_package_block)
+        package_definitions = tuple(
+            re.findall(
+                r"\{\s*repository: \"([^\"]+)\",\s*"
+                r"dbtPackage: \"([^\"]+)\",\s*"
+                r"envVar: \"([^\"]+)\"\s*\}",
+                release_package_block.group(1),
+                re.DOTALL,
+            )
+        )
+        self.assertEqual(package_definitions, RELEASE_PACKAGES)
+
+        manifest_sources = tuple(
+            re.findall(
+                r"(?m)^  - git: https://github\.com/tuva-health/([^/]+)\.git\n"
+                r"    revision: \"\{\{ env_var\('([^']+)'\) \}\}\"$",
+                self.release_packages,
+            )
+        )
+        expected_manifest_sources = tuple(
+            (repository, env_var)
+            for repository, _, env_var in RELEASE_PACKAGES
+        )
+        self.assertEqual(manifest_sources, expected_manifest_sources)
+        self.assertEqual(self.release_packages.count("  - local: ../"), 1)
+        self.assertNotRegex(self.release_packages, r"(?m)^\s*revision:\s*main\s*$")
+
+    def test_release_sources_are_resolved_once_and_locked_to_exact_commits(self):
+        resolver_start = self.workflow.index("const releasePackages = [")
+        build_start = self.workflow.index("\n  build:")
+        resolver = self.workflow[resolver_start:build_start]
+        build = self.workflow[build_start:]
+
+        self.assertIn("await Promise.all(", resolver)
+        self.assertIn("releasePackages.map(async (item) =>", resolver)
+        self.assertIn("github.rest.repos.getCommit({", resolver)
+        self.assertIn("repo: item.repository,", resolver)
+        self.assertIn('ref: "main"', resolver)
+        self.assertIn("revision: commit.sha.toLowerCase()", resolver)
+        self.assertIn("branch: \"main\"", resolver)
+        self.assertIn("const exactSha = /^[0-9a-f]{40}$/i;", resolver)
+        # The final status job re-resolves the PR merge ref to prevent a stale
+        # run from winning. It must not resolve standalone package branches a
+        # second time inside any matrix job.
+        self.assertNotIn("repo: item.repository,", build)
+        self.assertNotIn("releasePackages.map(async (item) =>", build)
+
+        self.assertIn("standalone_packages: standalonePackages", resolver)
+        self.assertIn("revision: mergeSha.toLowerCase()", resolver)
+        self.assertIn('core.setOutput("source_lock", sourceLock);', resolver)
+        self.assertIn(
+            "packages = source_lock.get(\"standalone_packages\")", build
+        )
+        self.assertIn(
+            'if not isinstance(packages, list) or len(packages) != 8:', build
+        )
+        self.assertIn(
+            'exact_sha = re.compile(r"^[0-9a-f]{40}$")', build
+        )
+        self.assertIn('env_path = Path(os.environ["GITHUB_ENV"])', build)
+        self.assertIn(
+            "integration_dir / \"packages.release.yml\"", build
+        )
+        self.assertIn(
+            'integration_dir / "ci-source-lock.json"', build
+        )
+
+        expected_env_vars = {env_var for _, _, env_var in RELEASE_PACKAGES}
+        configured_env_vars_match = re.search(
+            r"expected_env_vars = \{(.*?)\n\s*\}", build, re.DOTALL
+        )
+        self.assertIsNotNone(configured_env_vars_match)
+        self.assertEqual(
+            set(re.findall(r'"(TUVA_CI_[A-Z0-9_]+_SHA)"', configured_env_vars_match.group(1))),
+            expected_env_vars,
+        )
+
+    def test_both_modes_use_small_synthetic_data_without_parity(self):
+        self.assertEqual(
+            self.workflow.count('"use_synthetic_data": true'), 1
+        )
+        self.assertEqual(
+            self.workflow.count('"synthetic_data_size": "small"'), 1
+        )
+        self.assertEqual(self.workflow.count('"parity_enabled": false'), 1)
+        self.assertIn("strategy:\n      fail-fast: false", self.workflow)
+        self.assertEqual(self.workflow.count("dbt build --full-refresh"), 5)
+        self.assertNotIn('"synthetic_data_size": "large"', self.workflow)
+
+    def test_ci_actions_are_immutable_and_release_evidence_is_retained(self):
+        action_uses = extract_action_uses(self.workflow) + extract_action_uses(
+            self.external_workflow
+        )
+        local_uses = [use for use in action_uses if use.startswith("./")]
+        external_uses = [use for use in action_uses if not use.startswith("./")]
+
+        self.assertEqual(local_uses, ["./.github/workflows/ci.yml"])
+        self.assertTrue(external_uses)
+        for use in external_uses:
+            action, separator, revision = use.rpartition("@")
+            self.assertTrue(separator, use)
+            self.assertTrue(action, use)
+            self.assertRegex(revision, r"^[0-9a-f]{40}$", use)
+
+        expected_actions = {
+            "actions/github-script": "f28e40c7f34bde8b3046d885e986cb6290c5673b",
+            "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
+            "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
+            "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+        }
+        observed = Counter(external_uses)
+        self.assertEqual(
+            set(observed),
+            {f"{action}@{revision}" for action, revision in expected_actions.items()},
+        )
+        self.assertEqual(
+            observed[
+                "actions/upload-artifact@"
+                "ea165f8d65b6e75b540449e92b4886f43607fa02"
+            ],
+            1,
+        )
+
+        artifact_match = re.search(
+            r"- name: Upload release evidence(.*?)retention-days: 90",
+            self.workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(artifact_match)
+        artifact_block = artifact_match.group(1)
+        self.assertIn("if: always() && env.CI_MODE == 'release'", artifact_block)
+        self.assertIn("if-no-files-found: warn", artifact_block)
+        artifact_paths = tuple(
+            re.findall(r"(?m)^\s+(integration_tests/\S+)$", artifact_block)
+        )
+        self.assertEqual(
+            artifact_paths,
+            (
+                "integration_tests/ci-evidence.json",
+                "integration_tests/package-lock.yml",
+                "integration_tests/packages.yml",
+                "integration_tests/ci-source-lock.json",
+            ),
+        )
+        for raw_artifact in (
+            "integration_tests/target/manifest.json",
+            "integration_tests/target/run_results.json",
+            "integration_tests/logs/dbt.log",
+        ):
+            self.assertNotIn(raw_artifact, artifact_block)
+
+        prepare_match = re.search(
+            r"- name: Prepare release evidence(.*?)"
+            r"\n\s*- name: Upload release evidence",
+            self.workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(prepare_match)
+        prepare_block = prepare_match.group(1)
+        self.assertIn("target_dir / \"manifest.json\"", prepare_block)
+        self.assertIn("target_dir / \"run_results.json\"", prepare_block)
+        for result_field in (
+            "unique_id",
+            "status",
+            "execution_time",
+            "failures",
+        ):
+            self.assertIn(
+                f'"{result_field}": result.get("{result_field}")',
+                prepare_block,
+            )
+        self.assertIn(
+            'for result in run_results.get("results", [])', prepare_block
+        )
+        self.assertIn(
+            'integration_dir / "ci-evidence.json"', prepare_block
+        )
+
+    def test_required_status_context_is_stable_across_both_modes(self):
+        status_contexts = re.findall(
+            r'(?:context:\s*|status\.context === )"([^"]+)"', self.workflow
+        )
+        self.assertGreaterEqual(len(status_contexts), 3)
+        self.assertEqual(set(status_contexts), {"Tuva CI / Required"})
+        self.assertNotIn("Tuva CI / Snowflake", self.workflow)
+        self.assertIn(
+            "[process.env.HEAD_SHA, process.env.MERGE_SHA].map((sha)",
+            self.workflow,
+        )
+        self.assertIn(
+            "const statusRefs = [expectedHead, expectedMerge];", self.workflow
+        )
+        self.assertIn("Full release compatibility matrix passed", self.workflow)
+        self.assertIn("Snowflake Core build passed", self.workflow)
+
+    def test_unscoped_package_resources_have_run_specific_schema_overrides(self):
+        models = self.integration_project.split("\nmodels:\n", 1)[1].split(
+            "\nseeds:\n", 1
+        )[0]
+        seeds = self.integration_project.split("\nseeds:\n", 1)[1].split(
+            "\nflags:\n", 1
+        )[0]
+
+        for package_name, suffix in (
+            ("ccsr", "ccsr"),
+            ("semantic_layer", "semantic_layer"),
+        ):
+            self.assertRegex(
+                models,
+                rf"(?ms)^  {package_name}:\n    \+schema: \|\n"
+                rf"      .*var\('tuva_schema_prefix'\).*"
+                rf"\}}\}}_{suffix}.*else.*{suffix}",
+            )
+        self.assertRegex(
+            seeds,
+            r"(?ms)^  ccsr:\n    \+schema: \|\n"
+            r"      .*var\('tuva_schema_prefix'\).*\}\}_ccsr.*else.*ccsr",
+        )
+        self.assertIn(
+            '"tuva_schema_prefix": "${{ needs.resolve.outputs.schema_prefix }}"',
+            self.workflow,
+        )
+
+    def test_every_warehouse_target_appends_the_run_specific_schema_prefix(self):
+        self.assertIn(
+            "TUVA_CI_SCHEMA_PREFIX: "
+            "${{ needs.resolve.outputs.schema_prefix }}",
+            self.workflow,
+        )
+        expected_target_locations = {
+            "snowflake": (
+                "schema: \"{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "bigquery": (
+                "dataset: \"connector_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "databricks": (
+                "schema: \"default_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "fabric": (
+                "schema: \"{{ env_var('DBT_FABRIC_CI_SCHEMA') }}_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+            "redshift": (
+                "schema: \"public_"
+                "{{ env_var('TUVA_CI_SCHEMA_PREFIX') }}\""
+            ),
+        }
+        self.assertEqual(set(self.profiles), set(WAREHOUSES))
+        for warehouse, target_location in expected_target_locations.items():
+            with self.subTest(warehouse=warehouse):
+                profile = self.profiles[warehouse]
+                self.assertIn(target_location, profile)
+                self.assertEqual(profile.count("TUVA_CI_SCHEMA_PREFIX"), 1)
+
+    def test_external_dispatch_rejects_version_changing_pull_requests(self):
+        self.assertRegex(
+            self.external_workflow, r"(?m)^  workflow_dispatch:$"
+        )
+        self.assertIn("projectVersion(pr.base.sha)", self.external_workflow)
+        self.assertIn(
+            "projectVersion(mergeCommit.sha)", self.external_workflow
+        )
+        rejection = "if (baseVersion !== mergeVersion) {"
+        rejection_message = (
+            "Version-changing pull requests must use an internal branch so the "
+        )
+        self.assertIn(rejection, self.external_workflow)
+        self.assertIn(rejection_message, self.external_workflow)
+        self.assertLess(
+            self.external_workflow.index(rejection),
+            self.external_workflow.index('core.setOutput("pr_number"'),
+        )
+        self.assertIn("warehouse: snowflake", self.external_workflow)
+        self.assertNotIn("warehouse: all", self.external_workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -217,14 +217,22 @@ class DataAssetContractTest(unittest.TestCase):
             ROOT / "integration_tests" / "dbt_project.yml"
         ).read_text()
 
-        self.assertIn("macro bigquery__load_csv_rows(model, agate_table)", macro)
+        self.assertIn(
+            "macro bigquery_create_seed_relation(model, agate_table, relation)",
+            macro,
+        )
+        self.assertIn("macro bigquery__create_csv_table(model, agate_table)", macro)
+        self.assertIn(
+            "macro bigquery__reset_csv_table(model, full_refresh, old_relation, agate_table)",
+            macro,
+        )
         self.assertIn("agate_table.rows | length == 0", macro)
         self.assertIn("for column_name in agate_table.column_names", macro)
         self.assertIn("column_types that exactly match its CSV header", macro)
-        self.assertIn("api.Column.translate_type(column_override[column_name])", macro)
-        self.assertIn("create or replace table {{ this.render() }}", macro)
-        self.assertIn("adapter.load_dataframe(", macro)
-        self.assertIn("bigquery_table_options(config, model)", macro)
+        self.assertIn("api.Column.translate_type(column_type)", macro)
+        self.assertIn("create or replace table {{ relation.render() }}", macro)
+        self.assertIn("adapter.drop_relation(old_relation)", macro)
+        self.assertNotIn("macro bigquery__load_csv_rows", macro)
         self.assertIn("macro_namespace: 'dbt'", integration_project)
         self.assertIn("search_order: ['integration_tests', 'dbt']", integration_project)
 

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -209,6 +209,20 @@ class DataAssetContractTest(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, load_macro)
 
+    def test_bigquery_header_only_seed_materialization_contract(self):
+        macro = (
+            ROOT / "integration_tests" / "macros" / "bigquery_seed.sql"
+        ).read_text()
+
+        self.assertIn("macro bigquery__load_csv_rows(model, agate_table)", macro)
+        self.assertIn("agate_table.rows | length == 0", macro)
+        self.assertIn("for column_name in agate_table.column_names", macro)
+        self.assertIn("column_types that exactly match its CSV header", macro)
+        self.assertIn("api.Column.translate_type(column_override[column_name])", macro)
+        self.assertIn("create or replace table {{ this.render() }}", macro)
+        self.assertIn("adapter.load_dataframe(", macro)
+        self.assertIn("bigquery_table_options(config, model)", macro)
+
     def test_release_requires_all_cloud_receipts_before_tagging(self):
         workflow = (ROOT / ".github" / "workflows" / "create-release.yml").read_text()
         receipt_step = workflow.index("- name: Verify data asset release receipts")

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -213,6 +213,9 @@ class DataAssetContractTest(unittest.TestCase):
         macro = (
             ROOT / "integration_tests" / "macros" / "bigquery_seed.sql"
         ).read_text()
+        integration_project = (
+            ROOT / "integration_tests" / "dbt_project.yml"
+        ).read_text()
 
         self.assertIn("macro bigquery__load_csv_rows(model, agate_table)", macro)
         self.assertIn("agate_table.rows | length == 0", macro)
@@ -222,6 +225,8 @@ class DataAssetContractTest(unittest.TestCase):
         self.assertIn("create or replace table {{ this.render() }}", macro)
         self.assertIn("adapter.load_dataframe(", macro)
         self.assertIn("bigquery_table_options(config, model)", macro)
+        self.assertIn("macro_namespace: 'dbt'", integration_project)
+        self.assertIn("search_order: ['integration_tests', 'dbt']", integration_project)
 
     def test_release_requires_all_cloud_receipts_before_tagging(self):
         workflow = (ROOT / ".github" / "workflows" / "create-release.yml").read_text()


### PR DESCRIPTION
## Purpose

Temporary live test for the CI implementation in #1383. This PR must not be merged.

The first revision changes the package version only to prove that the real version detector selects release mode. It will be cancelled before dbt execution because 1.0.1 data assets are intentionally unpublished. A follow-up test-only revision will restore 1.0.0 and force the already-selected release path so the complete five-warehouse matrix can use published assets.

## Release notes

`ignore-for-release`

Related to #1382 and #1383.