### PR TITLE
Finalize the Structural Data Quality readiness contract

### DIFF
--- a/macros/data_quality/dq_summary_helpers.sql
+++ b/macros/data_quality/dq_summary_helpers.sql
@@ -1,35 +1,77 @@
-{% macro dq_enabled_input_layer_model_names() %}
-    {% set model_names = [] %}
+{% macro dq_enabled_input_layer_model_domains() %}
+    {% set domains = [] %}
 
     {% if var('clinical_enabled', false) | as_bool %}
-        {% do model_names.extend([
-            'input_layer__appointment',
-            'input_layer__condition',
-            'input_layer__encounter',
-            'input_layer__immunization',
-            'input_layer__lab_result',
-            'input_layer__location',
-            'input_layer__medication',
-            'input_layer__observation',
-            'input_layer__patient',
-            'input_layer__practitioner',
-            'input_layer__procedure'
-        ]) %}
+        {% do domains.append({
+            'name': 'clinical',
+            'model_names': [
+                'input_layer__appointment',
+                'input_layer__condition',
+                'input_layer__encounter',
+                'input_layer__immunization',
+                'input_layer__lab_result',
+                'input_layer__location',
+                'input_layer__medication',
+                'input_layer__observation',
+                'input_layer__patient',
+                'input_layer__practitioner',
+                'input_layer__procedure'
+            ]
+        }) %}
     {% endif %}
 
     {% if var('claims_enabled', false) | as_bool %}
-        {% do model_names.extend([
+        {% set claims_model_names = [
             'input_layer__eligibility',
             'input_layer__medical_claim',
             'input_layer__pharmacy_claim'
-        ]) %}
+        ] %}
+
+        {% if var('provider_attribution_enabled', false) | as_bool %}
+            {% do claims_model_names.append('input_layer__provider_attribution') %}
+        {% endif %}
+
+        {% do domains.append({
+            'name': 'claims',
+            'model_names': claims_model_names
+        }) %}
     {% endif %}
 
-    {% if (var('provider_attribution_enabled', false) and var('claims_enabled', false)) | as_bool %}
-        {% do model_names.append('input_layer__provider_attribution') %}
-    {% endif %}
+    {{ return(domains) }}
+{% endmacro %}
+
+{% macro dq_enabled_input_layer_model_names() %}
+    {% set model_names = [] %}
+
+    {% for domain in dq_enabled_input_layer_model_domains() %}
+        {% do model_names.extend(domain['model_names']) %}
+    {% endfor %}
 
     {{ return(model_names) }}
+{% endmacro %}
+
+{% macro dq_enabled_input_layer_model_names_for_domain(domain_name) %}
+    {% for domain in dq_enabled_input_layer_model_domains() %}
+        {% if domain['name'] == domain_name %}
+            {{ return(domain['model_names']) }}
+        {% endif %}
+    {% endfor %}
+
+    {{ return([]) }}
+{% endmacro %}
+
+{% macro dq_input_layer_domain_name(model_name) %}
+    {% for domain in dq_enabled_input_layer_model_domains() %}
+        {% if model_name in domain['model_names'] %}
+            {{ return(domain['name']) }}
+        {% endif %}
+    {% endfor %}
+
+    {{ exceptions.raise_compiler_error(
+        "Structural Data Quality could not determine the Input Layer domain for enabled Wrapper '"
+        ~ model_name
+        ~ "'. Add the Wrapper to dq_enabled_input_layer_model_domains()."
+    ) }}
 {% endmacro %}
 
 {% macro dq_expected_input_layer_models() %}
@@ -77,6 +119,20 @@
     ) }}
 {% endmacro %}
 
+{% macro dq_required_actual_relation(node) %}
+    {% set relation = dq_actual_relation(node) %}
+
+    {% if relation is none %}
+        {{ exceptions.raise_compiler_error(
+            "Structural Data Quality could not locate the Warehouse Table or View for Input Layer Wrapper '"
+            ~ node.name
+            ~ "'. Build the enabled Input Layer Models and Input Layer Wrappers before running Structural Data Quality."
+        ) }}
+    {% endif %}
+
+    {{ return(relation) }}
+{% endmacro %}
+
 {% macro dq_actual_columns(relation) %}
     {% if relation is none %}
         {{ return([]) }}
@@ -95,20 +151,106 @@
     {{ return(false) }}
 {% endmacro %}
 
+{% macro dq_actual_column(columns, column_name, relation_name='Warehouse Table or View') %}
+    {% set requested_name = column_name | lower %}
+    {% set matches = [] %}
+
+    {% for column in columns %}
+        {% if column.name | lower == requested_name %}
+            {% do matches.append(column) %}
+        {% endif %}
+    {% endfor %}
+
+    {% if matches | length > 1 %}
+        {{ exceptions.raise_compiler_error(
+            "Structural Data Quality found more than one physical column in "
+            ~ relation_name
+            ~ " that normalizes to '"
+            ~ requested_name
+            ~ "'. Rename the ambiguous columns before running Structural Data Quality."
+        ) }}
+    {% endif %}
+
+    {{ return(matches[0] if matches | length == 1 else none) }}
+{% endmacro %}
+
+{% macro dq_supported_type_families() %}
+    {{ return(['string', 'integer', 'numeric', 'boolean', 'date', 'timestamp']) }}
+{% endmacro %}
+
 {% macro dq_expected_columns(node) %}
     {% set expected_columns = [] %}
+    {% set normalized_names = [] %}
+    {% set duplicate_names = [] %}
+    {% set missing_data_types = [] %}
+    {% set unsupported_data_types = [] %}
+    {% set primary_key_columns = [] %}
+    {% set data_source_count = namespace(value=0) %}
 
     {% for column in node.columns.values() %}
         {% set meta = column.config.meta if column.config is not none and column.config.meta is not none else {} %}
+        {% set normalized_name = column.name | lower %}
+        {% set expected_type = meta.get('data_type') %}
+        {% set is_primary_key = meta.get('is_primary_key', false) | as_bool %}
+
+        {% if normalized_name in normalized_names %}
+            {% do duplicate_names.append(normalized_name) %}
+        {% else %}
+            {% do normalized_names.append(normalized_name) %}
+        {% endif %}
+
+        {% if expected_type is none or expected_type | trim == '' %}
+            {% do missing_data_types.append(normalized_name) %}
+        {% elif dq_type_family(expected_type) not in dq_supported_type_families() %}
+            {% do unsupported_data_types.append(normalized_name ~ '=' ~ expected_type) %}
+        {% endif %}
+
+        {% if is_primary_key %}
+            {% do primary_key_columns.append(normalized_name) %}
+        {% endif %}
+
+        {% if normalized_name == 'data_source' %}
+            {% set data_source_count.value = data_source_count.value + 1 %}
+        {% endif %}
+
         {% do expected_columns.append(
             {
-                'name': column.name | lower,
-                'data_type': meta.get('data_type'),
-                'is_primary_key': meta.get('is_primary_key', false),
+                'name': normalized_name,
+                'data_type': expected_type,
+                'is_primary_key': is_primary_key,
                 'column_order': loop.index
             }
         ) %}
     {% endfor %}
+
+    {% set contract_errors = [] %}
+    {% if duplicate_names | length > 0 %}
+        {% do contract_errors.append('duplicate case-normalized columns: ' ~ (duplicate_names | unique | list | join(', '))) %}
+    {% endif %}
+    {% if missing_data_types | length > 0 %}
+        {% do contract_errors.append('columns missing meta.data_type: ' ~ (missing_data_types | join(', '))) %}
+    {% endif %}
+    {% if unsupported_data_types | length > 0 %}
+        {% do contract_errors.append('unsupported portable data types: ' ~ (unsupported_data_types | join(', '))) %}
+    {% endif %}
+    {% if primary_key_columns | length == 0 %}
+        {% do contract_errors.append('no columns are marked meta.is_primary_key') %}
+    {% endif %}
+    {% if data_source_count.value != 1 %}
+        {% do contract_errors.append('expected exactly one data_source column but found ' ~ data_source_count.value) %}
+    {% elif 'data_source' not in primary_key_columns %}
+        {% do contract_errors.append('data_source is not marked meta.is_primary_key') %}
+    {% endif %}
+
+    {% if contract_errors | length > 0 %}
+        {{ exceptions.raise_compiler_error(
+            "Invalid Structural Data Quality contract for Input Layer Wrapper '"
+            ~ node.name
+            ~ "': "
+            ~ (contract_errors | join('; '))
+            ~ ". Correct Tuva Core's Input Layer YAML metadata."
+        ) }}
+    {% endif %}
 
     {{ return(expected_columns) }}
 {% endmacro %}
@@ -143,6 +285,31 @@
     {{ return('__dq_null__') }}
 {% endmacro %}
 
+{% macro dq_structural_null_source_key() %}
+    {{ return('__dq_structural_null__') }}
+{% endmacro %}
+
+{% macro dq_structural_source_value_prefix() %}
+    {{ return('__dq_structural_value__:') }}
+{% endmacro %}
+
+{% macro dq_structural_source_key_sql(data_source_expression) %}
+    {% set non_null_key = dbt.concat([
+        "'" ~ dq_structural_source_value_prefix() ~ "'",
+        "cast(" ~ data_source_expression ~ " as " ~ dbt.type_string() ~ ")"
+    ]) %}
+
+    {{ return(
+        "case when "
+        ~ data_source_expression
+        ~ " is null then '"
+        ~ dq_structural_null_source_key()
+        ~ "' else "
+        ~ non_null_key
+        ~ " end"
+    ) }}
+{% endmacro %}
+
 {% macro dq_empty_row_sql() %}
     select 1 as _dq_empty_row
 {% endmacro %}
@@ -152,66 +319,6 @@
         {{ dq_empty_row_sql() }}
     ) as dq_empty_row
     where 1 = 0
-{% endmacro %}
-
-{% macro dq_source_row_count_sql(relation) %}
-    {% set actual_columns = dq_actual_columns(relation) %}
-
-    select
-          {% if dq_has_column(actual_columns, 'data_source') %}
-          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
-          {% else %}
-          '{{ dq_source_key_sentinel() }}'
-          {% endif %} as data_source_key
-        , cast(count(*) as {{ dbt.type_numeric() }}) as row_count
-    from {{ relation }}
-    {% if dq_has_column(actual_columns, 'data_source') %}
-    group by coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
-    {% endif %}
-{% endmacro %}
-
-{% macro dq_source_dimension_sql(relation) %}
-    {% set actual_columns = dq_actual_columns(relation) %}
-
-    {% if dq_has_column(actual_columns, 'data_source') %}
-        select distinct
-              coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
-            , cast(data_source as {{ dbt.type_string() }}) as data_source
-        from {{ relation }}
-
-        union all
-
-        select
-              '{{ dq_source_key_sentinel() }}' as data_source_key
-            , cast(null as {{ dbt.type_string() }}) as data_source
-        from (
-            {{ dq_empty_row_sql() }}
-        ) as dq_empty_source
-        where not exists (
-            select 1
-            from {{ relation }}
-        )
-    {% else %}
-        select
-              '{{ dq_source_key_sentinel() }}' as data_source_key
-            , cast(null as {{ dbt.type_string() }}) as data_source
-    {% endif %}
-{% endmacro %}
-
-{% macro dq_missing_source_dimension_sql() %}
-    select
-          '{{ dq_source_key_sentinel() }}' as data_source_key
-        , cast(null as {{ dbt.type_string() }}) as data_source
-{% endmacro %}
-
-{% macro dq_source_key_expression_sql(relation, relation_alias='source_rows') %}
-    {% set actual_columns = dq_actual_columns(relation) %}
-
-    {% if dq_has_column(actual_columns, 'data_source') %}
-        {{ return("coalesce(cast(" ~ relation_alias ~ ".data_source as " ~ dbt.type_string() ~ "), '" ~ dq_source_key_sentinel() ~ "')") }}
-    {% else %}
-        {{ return("'" ~ dq_source_key_sentinel() ~ "'") }}
-    {% endif %}
 {% endmacro %}
 
 {% macro dq_base_type_family(type_string) %}
@@ -263,7 +370,7 @@
     {% if normalized == 'bool' %}
         {{ return('boolean') }}
     {% elif normalized == 'bytes' %}
-        {{ return('string') }}
+        {{ return('binary') }}
     {% else %}
         {{ return(dq_base_type_family(normalized)) }}
     {% endif %}

--- a/models/data_quality/data_quality_models.yml
+++ b/models/data_quality/data_quality_models.yml
@@ -2,8 +2,9 @@ version: 2
 
 models:
   - name: data_quality__structural
-    description: One row per data source and input-layer table with structural pass/fail results for table existence, population, expected columns, data types, and primary keys.
+    description: One row per data source and enabled Input Layer Model with four structural readiness results for required columns, data types, population, and primary keys.
     config:
+      access: public
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
         {% else %}data_quality{%- endif -%}
@@ -11,18 +12,48 @@ models:
       tags:
         - data_quality
       materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - data_source
+              - input_table_name
     columns:
       - name: data_source
-      - name: table_name
-      - name: table_exists
-      - name: table_populated
+        description: Source identifier evaluated independently within its Input Layer domain. Null identifies records whose data_source is null, or the fallback used when an enabled domain has no non-null source values.
+      - name: input_table_name
+        description: Connector-owned Input Layer Model evaluated by this row.
+        tests:
+          - not_null
       - name: columns_exist
-      - name: data_types
-      - name: primary_keys
+        description: Pass when every column required by the Input Layer contract exists, fail when at least one is missing, or not evaluated when the check cannot run.
+        tests: &structural_result_tests
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - pass
+                  - fail
+                  - not evaluated
+      - name: data_types_correct
+        description: Pass when every required column uses a compatible portable data type, fail when at least one present column is incompatible, or not evaluated when a required column is missing.
+        tests: *structural_result_tests
+      - name: table_populated
+        description: Pass when at least one record exists for this Input Layer Model and data source, fail when the count is zero, or not evaluated when data_source cannot be evaluated.
+        tests: *structural_result_tests
+      - name: primary_key_correct
+        description: Pass when the source-scoped composite key is non-null and unique, fail when null or duplicate key records exist, or not evaluated when a prerequisite is missing or the population is empty.
+        tests: *structural_result_tests
       - name: row_count
+        description: Number of records in this Input Layer Model for this data source. Zero is retained for domain-roster sources absent from the Model.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
 
   - name: data_quality__structural_expected_columns
-    description: One row per enabled Input Layer column expected by the Tuva contract, generated from Input Layer YAML metadata.
+    description: Internal implementation relation with one row per enabled Input Layer column expected by the Tuva contract, generated from Input Layer YAML metadata. This is not a stable public consumer contract.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
@@ -31,17 +62,45 @@ models:
       tags:
         - data_quality
       materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - model_name
+              - column_name
     columns:
+      - name: input_layer_domain
+        tests:
+          - not_null
       - name: table_name
+        tests:
+          - not_null
       - name: model_name
+        tests:
+          - not_null
       - name: column_name
+        tests:
+          - not_null
       - name: expected_data_type
+        tests:
+          - not_null
       - name: expected_type_family
+        tests:
+          - not_null
       - name: is_primary_key
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - "yes"
+                  - "no"
       - name: column_order
+        tests:
+          - not_null
 
   - name: data_quality__structural_actual_columns
-    description: One row per actual warehouse column and data source for enabled Input Layer tables, generated through dbt adapter metadata APIs.
+    description: Internal implementation relation with one row per actual warehouse column for each enabled Input Layer Model. It preserves the adapter-reported physical identifier and normalized type metadata, and is not a stable public consumer contract.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
@@ -50,19 +109,136 @@ models:
       tags:
         - data_quality
       materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - model_name
+              - column_name
     columns:
+      - name: input_layer_domain
+        tests:
+          - not_null
+      - name: table_name
+        tests:
+          - not_null
+      - name: model_name
+        tests:
+          - not_null
+      - name: column_name
+        tests:
+          - not_null
+      - name: actual_column_name
+        tests:
+          - not_null
+      - name: actual_data_type
+        tests:
+          - not_null
+      - name: actual_type_family
+        tests:
+          - not_null
+
+  - name: data_quality__structural_source_populations
+    description: Internal implementation relation with one row per enabled Input Layer Model and actual or fallback data source, including its record count. This is not a stable public consumer contract.
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_source_populations
+      tags:
+        - data_quality
+      materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - model_name
+              - data_source_key
+    columns:
+      - name: input_layer_domain
+        tests:
+          - not_null
       - name: data_source
       - name: data_source_key
+        tests:
+          - not_null
       - name: table_name
+        tests:
+          - not_null
       - name: model_name
-      - name: column_name
-      - name: actual_data_type
-      - name: actual_type_family
-      - name: table_exists
+        tests:
+          - not_null
       - name: row_count
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+  - name: data_quality__structural_data_sources
+    description: Internal implementation relation with the shared non-null data-source roster for each enabled Input Layer domain, or one null fallback when the domain has no non-null source. This is not a stable public consumer contract.
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_data_sources
+      tags:
+        - data_quality
+      materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - input_layer_domain
+              - data_source_key
+    columns:
+      - name: input_layer_domain
+        tests:
+          - not_null
+      - name: data_source
+      - name: data_source_key
+        tests:
+          - not_null
+
+  - name: data_quality__structural_evaluation_scope
+    description: Internal implementation relation containing the complete domain-scoped set of Input Layer Model and data-source combinations Structural Data Quality evaluates, including zero-count combinations and actual null-source populations. This is not a stable public consumer contract.
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_evaluation_scope
+      tags:
+        - data_quality
+      materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - input_table_name
+              - data_source_key
+    columns:
+      - name: input_layer_domain
+        tests:
+          - not_null
+      - name: input_table_name
+        tests:
+          - not_null
+      - name: model_name
+        tests:
+          - not_null
+      - name: data_source
+      - name: data_source_key
+        tests:
+          - not_null
+      - name: row_count
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
 
   - name: data_quality__structural_column_details
-    description: One row per data source, input-layer table, and expected column with expected-vs-actual column metadata and structural pass/fail results.
+    description: Internal implementation relation with one source-neutral row per enabled Input Layer Model and required column, containing expected-versus-actual metadata used to calculate column-presence and data-type results. This is not a stable public consumer contract.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
@@ -71,21 +247,54 @@ models:
       tags:
         - data_quality
       materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - input_table_name
+              - column_name
     columns:
-      - name: data_source
-      - name: table
-      - name: column
+      - name: input_table_name
+        tests:
+          - not_null
+      - name: column_name
+        tests:
+          - not_null
       - name: expected_data_type
+        tests:
+          - not_null
+      - name: actual_column_name
       - name: actual_data_type
       - name: is_primary_key
-      - name: table_exists
-      - name: row_count
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - "yes"
+                  - "no"
       - name: column_exists
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - "yes"
+                  - "no"
       - name: data_type_correct
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - "yes"
+                  - "no"
       - name: column_order
+        tests:
+          - not_null
 
   - name: data_quality__structural_primary_key_tests
-    description: One row per primary-key test result for each data source and input-layer table.
+    description: Internal implementation relation containing primary-key subcheck counts for each data source and enabled Input Layer Model. Null test_result values identify blocked subchecks; duplicate counts include every record in a non-unique key group rather than only records beyond the first. This is not a stable public consumer contract.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
@@ -94,12 +303,148 @@ models:
       tags:
         - data_quality
       materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - data_source
+              - input_table_name
+              - column_name
+              - test
     columns:
       - name: data_source
-      - name: table
-      - name: column
+      - name: input_table_name
+        tests:
+          - not_null
+      - name: column_name
+        tests:
+          - not_null
       - name: test
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - not null
+                  - duplicate value
       - name: test_result
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+
+  - name: data_quality__structural_missing_columns
+    description: Failure-only detail with one row for each required column missing from an enabled Input Layer Model's Warehouse Table or View. Schema evidence is source-neutral because every data source in a Model shares the same columns.
+    config:
+      access: public
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_missing_columns
+      tags:
+        - data_quality
+      materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - input_table_name
+              - column_name
+    columns:
+      - name: input_table_name
+        description: Input Layer Model with the missing required column.
+        tests:
+          - not_null
+      - name: column_name
+        description: Required column that is absent from the Warehouse Table or View.
+        tests:
+          - not_null
+      - name: expected_data_type
+        description: Portable data type declared for the missing column in Tuva's Input Layer contract.
+        tests:
+          - not_null
+
+  - name: data_quality__structural_data_type_mismatches
+    description: Failure-only detail with one row for each present required column whose actual warehouse data type does not satisfy Tuva's expected type. Known mismatches remain visible when another required column is missing; missing columns themselves are reported by structural_missing_columns.
+    config:
+      access: public
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_data_type_mismatches
+      tags:
+        - data_quality
+      materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - input_table_name
+              - column_name
+    columns:
+      - name: input_table_name
+        description: Input Layer Model with the incompatible column type.
+        tests:
+          - not_null
+      - name: column_name
+        description: Required column whose actual warehouse type is incompatible.
+        tests:
+          - not_null
+      - name: expected_data_type
+        description: Portable data type required by Tuva's Input Layer contract.
+        tests:
+          - not_null
+      - name: actual_data_type
+        description: Warehouse-specific data type reported for the physical column.
+        tests:
+          - not_null
+
+  - name: data_quality__structural_primary_key_failure_counts
+    description: Failure-only primary-key detail with null-value counts by key column and duplicate-record counts for the complete source-scoped composite key.
+    config:
+      access: public
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_primary_key_failure_counts
+      tags:
+        - data_quality
+      materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - data_source
+              - input_table_name
+              - failure_type
+              - primary_key_columns
+    columns:
+      - name: data_source
+        description: Source identifier for the failed source-scoped primary-key check. Null represents records whose data_source value is null.
+      - name: input_table_name
+        description: Input Layer Model containing the primary-key failure.
+        tests:
+          - not_null
+      - name: failure_type
+        description: null_value for a single primary-key column or duplicate_value for the complete source-scoped composite key.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - null_value
+                  - duplicate_value
+      - name: primary_key_columns
+        description: One key column for a null_value failure, or the full comma-separated composite key in contract order for duplicate_value.
+        tests:
+          - not_null
+      - name: failed_record_count
+        description: Number of records with a null value in the named key column, or number of records belonging to duplicate key groups. Null and duplicate counts can overlap and must not be added together.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
 
   - name: data_quality__logical
     description: Aggregated logical data quality results derived by summing persisted native-grain flag columns from the logical flag tables.

--- a/models/data_quality/rollups/data_quality__component_quality_results.sql
+++ b/models/data_quality/rollups/data_quality__component_quality_results.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = (var('data_quality_enabled', false) | as_bool)
+       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__component_table_quality_results.sql
+++ b/models/data_quality/rollups/data_quality__component_table_quality_results.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = (var('data_quality_enabled', false) | as_bool)
+       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__component_test_quality_results.sql
+++ b/models/data_quality/rollups/data_quality__component_test_quality_results.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = (var('data_quality_enabled', false) | as_bool)
+       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__data_source_catalog.sql
+++ b/models/data_quality/rollups/data_quality__data_source_catalog.sql
@@ -14,17 +14,17 @@
 with source_tables as (
 
     select distinct
-          actual.data_source
+          populations.data_source
         , catalog.input_table_type as data_source_type
-        , actual.table_name as input_table_name
-        , cast(max(actual.row_count) as {{ dbt.type_int() }}) as row_count
-    from {{ ref('data_quality__structural_actual_columns') }} as actual
+        , populations.table_name as input_table_name
+        , cast(max(populations.row_count) as {{ dbt.type_bigint() }}) as row_count
+    from {{ ref('data_quality__structural_source_populations') }} as populations
     inner join {{ ref('data_quality__input_layer_catalog') }} as catalog
-        on actual.table_name = catalog.input_table_name
+        on populations.table_name = catalog.input_table_name
     group by
-          actual.data_source
+          populations.data_source
         , catalog.input_table_type
-        , actual.table_name
+        , populations.table_name
 
 )
 
@@ -32,7 +32,7 @@ select
       data_source
     , data_source_type
     , cast(count(*) as {{ dbt.type_int() }}) as input_table_count
-    , cast(sum(coalesce(row_count, 0)) as {{ dbt.type_int() }}) as row_count
+    , cast(sum(coalesce(row_count, 0)) as {{ dbt.type_bigint() }}) as row_count
 from source_tables
 where coalesce(row_count, 0) > 0
 group by

--- a/models/data_quality/rollups/data_quality__source_quality_overview.sql
+++ b/models/data_quality/rollups/data_quality__source_quality_overview.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = (var('data_quality_enabled', false) | as_bool)
+       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__structural_test_results.sql
+++ b/models/data_quality/rollups/data_quality__structural_test_results.sql
@@ -6,7 +6,7 @@
        else 'data_quality'
      ),
      alias = 'structural_test_results',
-     tags = ['data_quality', 'dq', 'dq1', 'dq_rollup'],
+     tags = ['data_quality', 'dq', 'dq1', 'dq_rollup', 'dq_structural'],
      materialized = 'table'
    )
 }}
@@ -22,23 +22,10 @@ with structural as (
 
     select
           data_source
-        , table_name as input_table_name
-        , 'structural__table_exists' as test_name
-        , 'table does not exist' as display_name
-        , 'Checks whether the expected Input Layer table is missing for the data source.' as description
-        , 'table_presence' as test_type
-        , table_exists as test_status
-        , row_count
-    from structural
-
-    union all
-
-    select
-          data_source
-        , table_name as input_table_name
+        , input_table_name
         , 'structural__table_populated' as test_name
         , 'table is not populated' as display_name
-        , 'Checks whether the Input Layer table contains no records for the data source.' as description
+        , 'Checks whether the Warehouse Table or View contains records for the data source.' as description
         , 'row_population' as test_type
         , table_populated as test_status
         , row_count
@@ -48,10 +35,10 @@ with structural as (
 
     select
           data_source
-        , table_name as input_table_name
+        , input_table_name
         , 'structural__columns_exist' as test_name
         , 'columns do not exist' as display_name
-        , 'Checks whether one or more expected Input Layer columns are missing.' as description
+        , 'Checks whether one or more columns required by the Input Layer contract are missing.' as description
         , 'column_presence' as test_type
         , columns_exist as test_status
         , row_count
@@ -61,12 +48,12 @@ with structural as (
 
     select
           data_source
-        , table_name as input_table_name
-        , 'structural__data_types' as test_name
+        , input_table_name
+        , 'structural__data_types_correct' as test_name
         , 'data types mismatch' as display_name
         , 'Checks whether one or more Input Layer columns use an unexpected data type.' as description
         , 'data_type' as test_type
-        , data_types as test_status
+        , data_types_correct as test_status
         , row_count
     from structural
 
@@ -74,12 +61,12 @@ with structural as (
 
     select
           data_source
-        , table_name as input_table_name
-        , 'structural__primary_keys' as test_name
+        , input_table_name
+        , 'structural__primary_key_correct' as test_name
         , 'primary keys fail' as display_name
         , 'Checks whether the configured Input Layer primary key is null or not unique.' as description
         , 'primary_key' as test_type
-        , primary_keys as test_status
+        , primary_key_correct as test_status
         , row_count
     from structural
 
@@ -94,10 +81,10 @@ select
     , 'structural' as grain
     , test_type
     , 'structural' as check_category
-    , cast(1 as {{ dbt.type_int() }}) as severity
-    , cast(coalesce(row_count, 0) as {{ dbt.type_int() }}) as total_row_count
-    , cast(case when test_status = 'n/a' then 0 else 1 end as {{ dbt.type_int() }}) as tested_count
+    , cast(case when test_status = 'fail' then 1 else null end as {{ dbt.type_int() }}) as severity
+    , cast(coalesce(row_count, 0) as {{ dbt.type_bigint() }}) as total_row_count
+    , cast(case when test_status = 'not evaluated' then 0 else 1 end as {{ dbt.type_int() }}) as tested_count
     , cast(case when test_status = 'fail' then 1 else 0 end as {{ dbt.type_int() }}) as failed_count
     , cast(case when test_status = 'pass' then 1 else 0 end as {{ dbt.type_int() }}) as passed_count
-    , cast(case when test_status = 'n/a' then 1 else 0 end as {{ dbt.type_int() }}) as not_applicable_count
+    , cast(case when test_status = 'not evaluated' then 1 else 0 end as {{ dbt.type_int() }}) as not_evaluated_count
 from unpivoted

--- a/models/data_quality/rollups/data_quality_rollup_models.yml
+++ b/models/data_quality/rollups/data_quality_rollup_models.yml
@@ -231,8 +231,9 @@ models:
       - name: not_applicable_count
 
   - name: data_quality__structural_test_results
-    description: Normalized structural data quality results at data source, input table, and structural test grain.
+    description: Four normalized structural readiness results for each data source and enabled Input Layer Model.
     config:
+      access: public
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
         {% else %}data_quality{%- endif -%}
@@ -240,17 +241,56 @@ models:
       tags:
         - data_quality
         - dq_rollup
+        - dq_structural
       materialized: table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - data_source
+              - input_table_name
+              - test_name
     columns:
       - name: data_source
+        description: Source identifier evaluated by the normalized structural check. Null retains the structural matrix's null-source semantics.
       - name: input_table_name
+        description: Connector-owned Input Layer Model evaluated by the check.
+        tests:
+          - not_null
       - name: test_name
+        description: Stable identifier for one of the four structural checks.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - structural__columns_exist
+                  - structural__data_types_correct
+                  - structural__table_populated
+                  - structural__primary_key_correct
       - name: severity
+        description: Integer 1 for an active structural failure and null for pass or not evaluated.
+        tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - 1
+                quote: false
       - name: display_name
       - name: description
+      - name: grain
       - name: test_type
+      - name: check_category
+      - name: total_row_count
+        description: Number of Input Layer records represented by this Model and data-source result.
       - name: tested_count
+        description: One when the check was evaluated and zero when it was not evaluated.
       - name: failed_count
+        description: One when the check failed and zero otherwise.
+      - name: passed_count
+        description: One when the check passed and zero otherwise.
+      - name: not_evaluated_count
+        description: One when a prerequisite prevented evaluation and zero otherwise.
 
   - name: data_quality__component_test_quality_results
     description: Output Data Quality drilldown for relevant logical failures at data source, domain group, component, input table, and test grain. Structural findings remain in Input Data Quality and are intentionally excluded.

--- a/models/data_quality/structural/data_quality__structural.sql
+++ b/models/data_quality/structural/data_quality__structural.sql
@@ -14,18 +14,26 @@
 with column_status as (
 
     select
-          data_source
-        , {{ adapter.quote('table') }} as table_name
-        , max(table_exists) as table_exists
-        , cast(max(row_count) as {{ dbt.type_int() }}) as row_count
+          input_table_name
         , cast(sum(case when column_exists = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as missing_column_count
         , cast(sum(case when data_type_correct = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as bad_data_type_count
         , cast(sum(case when is_primary_key = 'yes' then 1 else 0 end) as {{ dbt.type_int() }}) as expected_pk_column_count
         , cast(sum(case when is_primary_key = 'yes' and column_exists = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as missing_pk_column_count
+        , cast(sum(case when column_name = 'data_source' and column_exists = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as missing_data_source_column_count
+        , cast(sum(case when column_name = 'data_source' and column_exists = 'yes' and data_type_correct = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as bad_data_source_type_count
     from {{ ref('data_quality__structural_column_details') }}
     group by
+          input_table_name
+
+)
+
+, evaluation_scope as (
+
+    select
           data_source
-        , {{ adapter.quote('table') }}
+        , input_table_name
+        , cast(row_count as {{ dbt.type_bigint() }}) as row_count
+    from {{ ref('data_quality__structural_evaluation_scope') }}
 
 )
 
@@ -33,55 +41,61 @@ with column_status as (
 
     select
           data_source
-        , {{ adapter.quote('table') }} as table_name
-        , cast(sum(case when test_result is null or test_result <> 0 then 1 else 0 end) as {{ dbt.type_int() }}) as failing_test_count
+        , input_table_name
+        , cast(count(*) as {{ dbt.type_int() }}) as test_count
+        , cast(sum(case when test_result is null then 1 else 0 end) as {{ dbt.type_int() }}) as not_evaluated_test_count
+        , cast(sum(case when test_result <> 0 then 1 else 0 end) as {{ dbt.type_int() }}) as failing_test_count
     from {{ ref('data_quality__structural_primary_key_tests') }}
     group by
           data_source
-        , {{ adapter.quote('table') }}
+        , input_table_name
 
 )
 
 select
-      column_status.data_source
-    , column_status.table_name
-    , case
-        when column_status.table_exists = 'yes' then 'pass'
-        else 'fail'
-      end as table_exists
-    , case
-        when column_status.table_exists = 'yes'
-         and coalesce(column_status.row_count, 0) > 0
-        then 'pass'
-        else 'fail'
-      end as table_populated
+      evaluation_scope.data_source
+    , evaluation_scope.input_table_name
     , case
         when column_status.missing_column_count = 0 then 'pass'
         else 'fail'
       end as columns_exist
     , case
+        when column_status.missing_column_count > 0 then 'not evaluated'
         when column_status.bad_data_type_count = 0 then 'pass'
         else 'fail'
-      end as data_types
+      end as data_types_correct
     , case
-        when column_status.table_exists = 'yes'
-         and coalesce(column_status.row_count, 0) = 0
-        then 'n/a'
-        when column_status.table_exists = 'yes'
-         and column_status.expected_pk_column_count > 0
-         and column_status.missing_pk_column_count = 0
-         and coalesce(pk_test_status.failing_test_count, 0) = 0
+        when column_status.missing_data_source_column_count > 0
+          or column_status.bad_data_source_type_count > 0
+          or evaluation_scope.row_count is null
+        then 'not evaluated'
+        when evaluation_scope.row_count > 0 then 'pass'
+        else 'fail'
+      end as table_populated
+    , case
+        when column_status.missing_data_source_column_count > 0
+          or column_status.bad_data_source_type_count > 0
+          or evaluation_scope.row_count is null
+          or evaluation_scope.row_count = 0
+          or column_status.expected_pk_column_count = 0
+          or column_status.missing_pk_column_count > 0
+          or coalesce(pk_test_status.test_count, 0) = 0
+          or coalesce(pk_test_status.not_evaluated_test_count, 0) > 0
+        then 'not evaluated'
+        when coalesce(pk_test_status.failing_test_count, 0) = 0
         then 'pass'
         else 'fail'
-      end as primary_keys
-    , column_status.row_count
-from column_status
+      end as primary_key_correct
+    , evaluation_scope.row_count
+from evaluation_scope
+inner join column_status
+    on evaluation_scope.input_table_name = column_status.input_table_name
 left outer join pk_test_status
-    on column_status.table_name = pk_test_status.table_name
+    on evaluation_scope.input_table_name = pk_test_status.input_table_name
     and (
-        column_status.data_source = pk_test_status.data_source
+        evaluation_scope.data_source = pk_test_status.data_source
         or (
-            column_status.data_source is null
+            evaluation_scope.data_source is null
             and pk_test_status.data_source is null
         )
     )

--- a/models/data_quality/structural/data_quality__structural_actual_columns.sql
+++ b/models/data_quality/structural/data_quality__structural_actual_columns.sql
@@ -22,64 +22,45 @@
 
     {% for model_node in dq_expected_input_layer_models() %}
         {% set table_name = model_node.name | replace('input_layer__', '') %}
-        {% set relation = dq_actual_relation(model_node) %}
+        {% set input_layer_domain = dq_input_layer_domain_name(model_node.name) %}
+        {% set relation = dq_required_actual_relation(model_node) %}
+        {% set actual_columns = dq_actual_columns(relation) %}
+        {% set physical_names_by_normalized_name = {} %}
 
-        {% if relation is none %}
+        {% for column in actual_columns %}
+            {% set normalized_column_name = column.name | lower %}
+
+            {% if normalized_column_name in physical_names_by_normalized_name %}
+                {{ exceptions.raise_compiler_error(
+                    "Structural Data Quality found multiple physical columns in Input Layer Wrapper '"
+                    ~ model_node.name
+                    ~ "' that normalize to '"
+                    ~ normalized_column_name
+                    ~ "': '"
+                    ~ physical_names_by_normalized_name[normalized_column_name]
+                    ~ "' and '"
+                    ~ column.name
+                    ~ "'. Structural column matching is case-insensitive, so the columns are ambiguous."
+                ) }}
+            {% endif %}
+
+            {% do physical_names_by_normalized_name.update({normalized_column_name: column.name}) %}
+        {% endfor %}
+
+        {% for column in actual_columns %}
             {% set query %}
                 select
-                      cast(null as {{ dbt.type_string() }}) as data_source
-                    , '{{ dq_source_key_sentinel() }}' as data_source_key
+                      '{{ input_layer_domain }}' as input_layer_domain
                     , '{{ table_name }}' as table_name
                     , '{{ model_node.name }}' as model_name
-                    , cast(null as {{ dbt.type_string() }}) as column_name
-                    , cast(null as {{ dbt.type_string() }}) as actual_data_type
-                    , cast(null as {{ dbt.type_string() }}) as actual_type_family
-                    , 'no' as table_exists
-                    , cast(null as {{ dbt.type_int() }}) as row_count
+                    , '{{ column.name | lower | replace("'", "''") }}' as column_name
+                    , '{{ column.name | replace("'", "''") }}' as actual_column_name
+                    , '{{ column.dtype | replace("'", "''") }}' as actual_data_type
+                    , '{{ dq_type_family(column.dtype) }}' as actual_type_family
             {% endset %}
 
             {% do actual_queries.append(query) %}
-        {% else %}
-            {% set source_dimension_sql = dq_source_dimension_sql(relation) %}
-            {% set source_count_sql = dq_source_row_count_sql(relation) %}
-            {% set column_queries = [] %}
-
-            {% for column in dq_actual_columns(relation) %}
-                {% set column_query %}
-                    select
-                          '{{ column.name | lower | replace("'", "''") }}' as column_name
-                        , '{{ column.dtype | replace("'", "''") }}' as actual_data_type
-                        , '{{ dq_type_family(column.dtype) }}' as actual_type_family
-                {% endset %}
-
-                {% do column_queries.append(column_query) %}
-            {% endfor %}
-
-            {% set query %}
-                select
-                      sources.data_source
-                    , sources.data_source_key
-                    , '{{ table_name }}' as table_name
-                    , '{{ model_node.name }}' as model_name
-                    , actual_columns.column_name
-                    , actual_columns.actual_data_type
-                    , actual_columns.actual_type_family
-                    , 'yes' as table_exists
-                    , cast(coalesce(source_counts.row_count, 0) as {{ dbt.type_int() }}) as row_count
-                from (
-                    {{ source_dimension_sql }}
-                ) as sources
-                left join (
-                    {{ source_count_sql }}
-                ) as source_counts
-                    on sources.data_source_key = source_counts.data_source_key
-                cross join (
-                    {{ column_queries | join('\nunion all\n') }}
-                ) as actual_columns
-            {% endset %}
-
-            {% do actual_queries.append(query) %}
-        {% endif %}
+        {% endfor %}
     {% endfor %}
 
     {% if actual_queries | length > 0 %}
@@ -89,27 +70,23 @@
         ) as structural_actual_columns
     {% else %}
         select
-              cast(null as {{ dbt.type_string() }}) as data_source
-            , cast(null as {{ dbt.type_string() }}) as data_source_key
+              cast(null as {{ dbt.type_string() }}) as input_layer_domain
             , cast(null as {{ dbt.type_string() }}) as table_name
             , cast(null as {{ dbt.type_string() }}) as model_name
             , cast(null as {{ dbt.type_string() }}) as column_name
+            , cast(null as {{ dbt.type_string() }}) as actual_column_name
             , cast(null as {{ dbt.type_string() }}) as actual_data_type
             , cast(null as {{ dbt.type_string() }}) as actual_type_family
-            , cast(null as {{ dbt.type_string() }}) as table_exists
-            , cast(null as {{ dbt.type_int() }}) as row_count
         {{ dq_empty_result_guard_sql() }}
     {% endif %}
 {% else %}
     select
-          cast(null as {{ dbt.type_string() }}) as data_source
-        , cast(null as {{ dbt.type_string() }}) as data_source_key
+          cast(null as {{ dbt.type_string() }}) as input_layer_domain
         , cast(null as {{ dbt.type_string() }}) as table_name
         , cast(null as {{ dbt.type_string() }}) as model_name
         , cast(null as {{ dbt.type_string() }}) as column_name
+        , cast(null as {{ dbt.type_string() }}) as actual_column_name
         , cast(null as {{ dbt.type_string() }}) as actual_data_type
         , cast(null as {{ dbt.type_string() }}) as actual_type_family
-        , cast(null as {{ dbt.type_string() }}) as table_exists
-        , cast(null as {{ dbt.type_int() }}) as row_count
     {{ dq_empty_result_guard_sql() }}
 {% endif %}

--- a/models/data_quality/structural/data_quality__structural_column_details.sql
+++ b/models/data_quality/structural/data_quality__structural_column_details.sql
@@ -18,41 +18,28 @@ with expected as (
 
 )
 
-, actual_sources as (
-
-    select
-          table_name
-        , model_name
-        , data_source
-        , data_source_key
-        , max(table_exists) as table_exists
-        , max(row_count) as row_count
-    from {{ ref('data_quality__structural_actual_columns') }}
-    group by
-          table_name
-        , model_name
-        , data_source
-        , data_source_key
-
-)
-
 , actual_columns as (
 
-    select *
+    select
+          input_layer_domain
+        , table_name
+        , model_name
+        , column_name
+        , actual_column_name
+        , actual_data_type
+        , actual_type_family
     from {{ ref('data_quality__structural_actual_columns') }}
     where column_name is not null
 
 )
 
 select
-      actual_sources.data_source
-    , expected.table_name as {{ adapter.quote('table') }}
-    , expected.column_name as {{ adapter.quote('column') }}
+      expected.table_name as input_table_name
+    , expected.column_name
     , expected.expected_data_type
+    , actual_columns.actual_column_name
     , actual_columns.actual_data_type
     , expected.is_primary_key
-    , actual_sources.table_exists
-    , cast(actual_sources.row_count as {{ dbt.type_int() }}) as row_count
     , case
         when actual_columns.column_name is not null then 'yes'
         else 'no'
@@ -66,11 +53,8 @@ select
       end as data_type_correct
     , expected.column_order
 from expected
-inner join actual_sources
-    on expected.table_name = actual_sources.table_name
-    and expected.model_name = actual_sources.model_name
 left outer join actual_columns
-    on expected.table_name = actual_columns.table_name
+    on expected.input_layer_domain = actual_columns.input_layer_domain
+    and expected.table_name = actual_columns.table_name
     and expected.model_name = actual_columns.model_name
     and expected.column_name = actual_columns.column_name
-    and actual_sources.data_source_key = actual_columns.data_source_key

--- a/models/data_quality/structural/data_quality__structural_data_sources.sql
+++ b/models/data_quality/structural/data_quality__structural_data_sources.sql
@@ -1,0 +1,54 @@
+{{ config(
+     enabled = var('data_quality_enabled', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_data_sources',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+with enabled_domains as (
+
+    select distinct
+          input_layer_domain
+    from {{ ref('data_quality__structural_source_populations') }}
+
+)
+
+, non_null_sources as (
+
+    select
+          input_layer_domain
+        , data_source
+        , data_source_key
+    from {{ ref('data_quality__structural_source_populations') }}
+    where data_source is not null
+    group by
+          input_layer_domain
+        , data_source
+        , data_source_key
+
+)
+
+select
+      input_layer_domain
+    , data_source
+    , data_source_key
+from non_null_sources
+
+union all
+
+select
+      enabled_domains.input_layer_domain
+    , cast(null as {{ dbt.type_string() }}) as data_source
+    , '{{ dq_structural_null_source_key() }}' as data_source_key
+from enabled_domains
+where not exists (
+    select 1
+    from non_null_sources
+    where non_null_sources.input_layer_domain = enabled_domains.input_layer_domain
+)

--- a/models/data_quality/structural/data_quality__structural_data_type_mismatches.sql
+++ b/models/data_quality/structural/data_quality__structural_data_type_mismatches.sql
@@ -1,0 +1,26 @@
+{{ config(
+     enabled = var('data_quality_enabled', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_data_type_mismatches',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+select
+      column_details.input_table_name
+    , column_details.column_name
+    , column_details.expected_data_type
+    , column_details.actual_data_type
+from {{ ref('data_quality__structural_column_details') }} as column_details
+where column_details.column_exists = 'yes'
+  and column_details.data_type_correct = 'no'
+group by
+      column_details.input_table_name
+    , column_details.column_name
+    , column_details.expected_data_type
+    , column_details.actual_data_type

--- a/models/data_quality/structural/data_quality__structural_evaluation_scope.sql
+++ b/models/data_quality/structural/data_quality__structural_evaluation_scope.sql
@@ -1,0 +1,92 @@
+{{ config(
+     enabled = var('data_quality_enabled', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_evaluation_scope',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+with enabled_models as (
+
+    select distinct
+          input_layer_domain
+        , table_name as input_table_name
+        , model_name
+    from {{ ref('data_quality__structural_expected_columns') }}
+
+)
+
+, actual_source_populations as (
+
+    select
+          input_layer_domain
+        , table_name as input_table_name
+        , model_name
+        , data_source
+        , data_source_key
+        , cast(max(row_count) as {{ dbt.type_bigint() }}) as row_count
+    from {{ ref('data_quality__structural_source_populations') }}
+    group by
+          input_layer_domain
+        , table_name
+        , model_name
+        , data_source
+        , data_source_key
+
+)
+
+, domain_grid as (
+
+    select
+          enabled_models.input_layer_domain
+        , enabled_models.input_table_name
+        , enabled_models.model_name
+        , data_sources.data_source
+        , data_sources.data_source_key
+        , cast(coalesce(actual_source_populations.row_count, 0) as {{ dbt.type_bigint() }}) as row_count
+    from enabled_models
+    inner join {{ ref('data_quality__structural_data_sources') }} as data_sources
+        on enabled_models.input_layer_domain = data_sources.input_layer_domain
+    left outer join actual_source_populations
+        on enabled_models.input_layer_domain = actual_source_populations.input_layer_domain
+        and enabled_models.input_table_name = actual_source_populations.input_table_name
+        and enabled_models.model_name = actual_source_populations.model_name
+        and data_sources.data_source_key = actual_source_populations.data_source_key
+
+)
+
+, model_specific_null_sources as (
+
+    select
+          actual_source_populations.input_layer_domain
+        , actual_source_populations.input_table_name
+        , actual_source_populations.model_name
+        , actual_source_populations.data_source
+        , actual_source_populations.data_source_key
+        , actual_source_populations.row_count
+    from actual_source_populations
+    where actual_source_populations.data_source is null
+      and actual_source_populations.row_count > 0
+      and not exists (
+          select 1
+          from domain_grid
+          where domain_grid.input_layer_domain = actual_source_populations.input_layer_domain
+            and domain_grid.input_table_name = actual_source_populations.input_table_name
+            and domain_grid.model_name = actual_source_populations.model_name
+            and domain_grid.data_source_key = actual_source_populations.data_source_key
+      )
+
+)
+
+select *
+from domain_grid
+
+union all
+
+select *
+from model_specific_null_sources

--- a/models/data_quality/structural/data_quality__structural_expected_columns.sql
+++ b/models/data_quality/structural/data_quality__structural_expected_columns.sql
@@ -23,6 +23,7 @@
 
     {% for model_node in dq_expected_input_layer_models() %}
         {% set table_name = model_node.name | replace('input_layer__', '') %}
+        {% set input_layer_domain = dq_input_layer_domain_name(model_node.name) %}
 
         {% for expected_column in dq_expected_columns(model_node) %}
             {% set expected_name = expected_column['name'] %}
@@ -34,7 +35,8 @@
 
             {% set query %}
                 select
-                      '{{ table_name }}' as table_name
+                      '{{ input_layer_domain }}' as input_layer_domain
+                    , '{{ table_name }}' as table_name
                     , '{{ model_node.name }}' as model_name
                     , '{{ expected_name }}' as column_name
                     , {% if expected_type is not none %}'{{ expected_type }}'{% else %}cast(null as {{ dbt.type_string() }}){% endif %} as expected_data_type
@@ -60,7 +62,8 @@
         ) as structural_expected_columns
     {% else %}
         select
-              cast(null as {{ dbt.type_string() }}) as table_name
+              cast(null as {{ dbt.type_string() }}) as input_layer_domain
+            , cast(null as {{ dbt.type_string() }}) as table_name
             , cast(null as {{ dbt.type_string() }}) as model_name
             , cast(null as {{ dbt.type_string() }}) as column_name
             , cast(null as {{ dbt.type_string() }}) as expected_data_type
@@ -71,7 +74,8 @@
     {% endif %}
 {% else %}
     select
-          cast(null as {{ dbt.type_string() }}) as table_name
+          cast(null as {{ dbt.type_string() }}) as input_layer_domain
+        , cast(null as {{ dbt.type_string() }}) as table_name
         , cast(null as {{ dbt.type_string() }}) as model_name
         , cast(null as {{ dbt.type_string() }}) as column_name
         , cast(null as {{ dbt.type_string() }}) as expected_data_type

--- a/models/data_quality/structural/data_quality__structural_missing_columns.sql
+++ b/models/data_quality/structural/data_quality__structural_missing_columns.sql
@@ -1,0 +1,23 @@
+{{ config(
+     enabled = var('data_quality_enabled', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_missing_columns',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+select
+      input_table_name
+    , column_name
+    , expected_data_type
+from {{ ref('data_quality__structural_column_details') }}
+where column_exists = 'no'
+group by
+      input_table_name
+    , column_name
+    , expected_data_type

--- a/models/data_quality/structural/data_quality__structural_primary_key_failure_counts.sql
+++ b/models/data_quality/structural/data_quality__structural_primary_key_failure_counts.sql
@@ -1,0 +1,35 @@
+{{ config(
+     enabled = var('data_quality_enabled', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_primary_key_failure_counts',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+select
+      primary_key_tests.data_source
+    , primary_key_tests.input_table_name
+    , case
+        when primary_key_tests.test = 'not null' then 'null_value'
+        when primary_key_tests.test = 'duplicate value' then 'duplicate_value'
+      end as failure_type
+    , primary_key_tests.column_name as primary_key_columns
+    , cast(primary_key_tests.test_result as {{ dbt.type_bigint() }}) as failed_record_count
+from {{ ref('data_quality__structural_primary_key_tests') }} as primary_key_tests
+inner join {{ ref('data_quality__structural') }} as structural
+    on primary_key_tests.input_table_name = structural.input_table_name
+    and (
+        primary_key_tests.data_source = structural.data_source
+        or (
+            primary_key_tests.data_source is null
+            and structural.data_source is null
+        )
+    )
+where structural.primary_key_correct = 'fail'
+  and primary_key_tests.test_result > 0
+  and primary_key_tests.test in ('not null', 'duplicate value')

--- a/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
+++ b/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
@@ -12,194 +12,224 @@
 }}
 
 {% set input_layer_model_names = dq_enabled_input_layer_model_names() %}
+{% set evaluation_scope = ref('data_quality__structural_evaluation_scope') %}
 
 {% for model_name in input_layer_model_names %}
 -- depends_on: {{ ref(model_name) }}
 {% endfor %}
 
 {% if execute %}
-    {% set pk_queries = [] %}
+    {% set model_queries = [] %}
 
     {% for model_name in input_layer_model_names %}
         {% set model_node = dq_find_model_node(model_name) %}
 
         {% if model_node is not none %}
             {% set table_name = model_name | replace('input_layer__', '') %}
-            {% set relation = dq_actual_relation(model_node) %}
+            {% set relation = dq_required_actual_relation(model_node) %}
+            {% set actual_columns = dq_actual_columns(relation) %}
             {% set pk_columns = dq_expected_pk_columns(model_node) %}
             {% set pk_column_list = pk_columns | join(', ') %}
-            {% set actual_column_types = {} %}
+            {% set pk_metrics = [] %}
             {% set missing_pk_columns = [] %}
+            {% set unsupported_pk_columns = [] %}
+            {% set grouped_value_counter = namespace(value=0) %}
+            {% set actual_data_source = dq_actual_column(actual_columns, 'data_source', relation) %}
 
-            {% if relation is not none %}
-                {% for column in dq_actual_columns(relation) %}
-                    {% do actual_column_types.update({column.name | lower: column.dtype}) %}
-                {% endfor %}
-                {% set source_dimension_sql = dq_source_dimension_sql(relation) %}
-                {% set source_count_sql = dq_source_row_count_sql(relation) %}
-                {% set source_key_expression = dq_source_key_expression_sql(relation, 'source_rows') %}
-
-                {% for pk_column in pk_columns %}
-                    {% if actual_column_types.get(pk_column) is none %}
-                        {% do missing_pk_columns.append(pk_column) %}
-                    {% endif %}
-                {% endfor %}
+            {% if actual_data_source is not none %}
+                {% set source_key_expression = dq_structural_source_key_sql(
+                    'source_rows.' ~ adapter.quote(actual_data_source.name)
+                ) %}
             {% else %}
-                {% set source_dimension_sql = dq_missing_source_dimension_sql() %}
-                {% set source_count_sql %}
-                    select
-                          '{{ dq_source_key_sentinel() }}' as data_source_key
-                        , cast(null as {{ dbt.type_int() }}) as row_count
-                {% endset %}
+                {% set source_key_expression = "'" ~ dq_structural_null_source_key() ~ "'" %}
             {% endif %}
 
             {% for pk_column in pk_columns %}
-                {% if relation is none %}
-                    {% set query %}
-                        select
-                              sources.data_source
-                            , '{{ table_name }}' as {{ adapter.quote('table') }}
-                            , '{{ pk_column }}' as {{ adapter.quote('column') }}
-                            , 'not null' as test
-                            , cast(null as {{ dbt.type_int() }}) as test_result
-                        from (
-                            {{ source_dimension_sql }}
-                        ) as sources
-                    {% endset %}
-                {% elif actual_column_types.get(pk_column) is none %}
-                    {% set query %}
-                        select
-                              sources.data_source
-                            , '{{ table_name }}' as {{ adapter.quote('table') }}
-                            , '{{ pk_column }}' as {{ adapter.quote('column') }}
-                            , 'not null' as test
-                            , cast(coalesce(source_counts.row_count, 0) as {{ dbt.type_int() }}) as test_result
-                        from (
-                            {{ source_dimension_sql }}
-                        ) as sources
-                        left join (
-                            {{ source_count_sql }}
-                        ) as source_counts
-                            on sources.data_source_key = source_counts.data_source_key
-                    {% endset %}
-                {% else %}
-                    {% set query %}
-                        select
-                              sources.data_source
-                            , '{{ table_name }}' as {{ adapter.quote('table') }}
-                            , '{{ pk_column }}' as {{ adapter.quote('column') }}
-                            , 'not null' as test
-                            , cast(coalesce(null_counts.test_result, 0) as {{ dbt.type_int() }}) as test_result
-                        from (
-                            {{ source_dimension_sql }}
-                        ) as sources
-                        left join (
-                            select
-                                  {{ source_key_expression }} as data_source_key
-                                , cast(count(*) as {{ dbt.type_int() }}) as test_result
-                            from {{ relation }} as source_rows
-                            where source_rows.{{ quote_column(pk_column) }} is null
-                            group by {{ source_key_expression }}
-                        ) as null_counts
-                            on sources.data_source_key = null_counts.data_source_key
-                    {% endset %}
+                {% set actual_column = dq_actual_column(actual_columns, pk_column, relation) %}
+                {% set grouped_alias = none %}
+
+                {% if actual_column is none %}
+                    {% do missing_pk_columns.append(pk_column) %}
+                {% elif pk_column == 'data_source' and dq_type_family(actual_column.dtype) != 'string' %}
+                    {% do unsupported_pk_columns.append(pk_column) %}
+                {% elif dq_type_family(actual_column.dtype) not in dq_supported_type_families() %}
+                    {% do unsupported_pk_columns.append(pk_column) %}
+                {% elif pk_column != 'data_source' %}
+                    {% set grouped_value_counter.value = grouped_value_counter.value + 1 %}
+                    {% set grouped_alias = 'pk_value_' ~ grouped_value_counter.value %}
                 {% endif %}
 
-                {% do pk_queries.append(query) %}
+                {% do pk_metrics.append({
+                    'column_name': pk_column,
+                    'actual_column_name': actual_column.name if actual_column is not none else none,
+                    'metric_alias': 'null_count_' ~ loop.index,
+                    'grouped_alias': grouped_alias,
+                    'is_present': actual_column is not none
+                }) %}
             {% endfor %}
 
-            {% if relation is none %}
-                {% set duplicate_query %}
+            {% set definition_queries = [] %}
+            {% for metric in pk_metrics %}
+                {% set definition_query %}
                     select
-                          sources.data_source
-                        , '{{ table_name }}' as {{ adapter.quote('table') }}
-                        , '{{ pk_column_list }}' as {{ adapter.quote('column') }}
-                        , 'duplicate value' as test
-                        , cast(null as {{ dbt.type_int() }}) as test_result
-                    from (
-                        {{ source_dimension_sql }}
-                    ) as sources
+                          'null_{{ loop.index }}' as test_key
+                        , '{{ metric["column_name"] | replace("'", "''") }}' as column_name
+                        , 'not null' as test
+                        , cast({{ 1 if missing_pk_columns | length == 0 and unsupported_pk_columns | length == 0 else 0 }} as {{ dbt.type_int() }}) as is_evaluable
                 {% endset %}
-            {% elif missing_pk_columns | length > 0 %}
-                {% set duplicate_query %}
+                {% do definition_queries.append(definition_query) %}
+            {% endfor %}
+
+            {% set duplicate_definition %}
+                select
+                      'duplicate' as test_key
+                    , '{{ pk_column_list | replace("'", "''") }}' as column_name
+                    , 'duplicate value' as test
+                    , cast({{ 1 if missing_pk_columns | length == 0 and unsupported_pk_columns | length == 0 else 0 }} as {{ dbt.type_int() }}) as is_evaluable
+            {% endset %}
+            {% do definition_queries.append(duplicate_definition) %}
+
+            {% set grouped_key_sql %}
+                select
+                      {{ source_key_expression }} as data_source_key
+                    {% for metric in pk_metrics if metric['grouped_alias'] is not none %}
+                    , source_rows.{{ adapter.quote(metric['actual_column_name']) }} as {{ metric['grouped_alias'] }}
+                    {% endfor %}
+                    , cast(count(*) as {{ dbt.type_bigint() }}) as group_record_count
+                from {{ relation }} as source_rows
+                group by
+                      {{ source_key_expression }}
+                    {% for metric in pk_metrics if metric['grouped_alias'] is not none %}
+                    , source_rows.{{ adapter.quote(metric['actual_column_name']) }}
+                    {% endfor %}
+            {% endset %}
+
+            {% set source_metrics_sql %}
+                select
+                      grouped_keys.data_source_key
+                    {% for metric in pk_metrics %}
+                    , {% if not metric['is_present'] %}
+                        cast(null as {{ dbt.type_bigint() }})
+                      {% elif metric['column_name'] == 'data_source' %}
+                        cast(sum(
+                            case
+                              when grouped_keys.data_source_key = '{{ dq_structural_null_source_key() }}'
+                              then grouped_keys.group_record_count
+                              else 0
+                            end
+                        ) as {{ dbt.type_bigint() }})
+                      {% else %}
+                        cast(sum(
+                            case
+                              when grouped_keys.{{ metric['grouped_alias'] }} is null
+                              then grouped_keys.group_record_count
+                              else 0
+                            end
+                        ) as {{ dbt.type_bigint() }})
+                      {% endif %} as {{ metric['metric_alias'] }}
+                    {% endfor %}
+                    , {% if missing_pk_columns | length > 0 or unsupported_pk_columns | length > 0 %}
+                        cast(null as {{ dbt.type_bigint() }})
+                      {% else %}
+                        cast(sum(
+                            case
+                              when grouped_keys.group_record_count > 1
+                              then grouped_keys.group_record_count
+                              else 0
+                            end
+                        ) as {{ dbt.type_bigint() }})
+                      {% endif %} as duplicate_record_count
+                from (
+                    {{ grouped_key_sql }}
+                ) as grouped_keys
+                group by grouped_keys.data_source_key
+            {% endset %}
+
+            {% set metric_case_clauses = [] %}
+            {% for metric in pk_metrics %}
+                {% do metric_case_clauses.append(
+                    "when 'null_" ~ loop.index ~ "' then source_metrics." ~ metric['metric_alias']
+                ) %}
+            {% endfor %}
+            {% do metric_case_clauses.append("when 'duplicate' then source_metrics.duplicate_record_count") %}
+
+            {% if missing_pk_columns | length > 0 or unsupported_pk_columns | length > 0 %}
+                {% set model_query %}
                     select
                           sources.data_source
-                        , '{{ table_name }}' as {{ adapter.quote('table') }}
-                        , '{{ pk_column_list }}' as {{ adapter.quote('column') }}
-                        , 'duplicate value' as test
-                        , cast(coalesce(source_counts.row_count, 0) as {{ dbt.type_int() }}) as test_result
+                        , '{{ table_name }}' as input_table_name
+                        , test_definitions.column_name
+                        , test_definitions.test
+                        , cast(null as {{ dbt.type_bigint() }}) as test_result
                     from (
-                        {{ source_dimension_sql }}
+                        select
+                              data_source
+                            , data_source_key
+                        from {{ evaluation_scope }}
+                        where model_name = '{{ model_name }}'
                     ) as sources
-                    left join (
-                        {{ source_count_sql }}
-                    ) as source_counts
-                        on sources.data_source_key = source_counts.data_source_key
+                    cross join (
+                        {{ definition_queries | join('\nunion all\n') }}
+                    ) as test_definitions
                 {% endset %}
             {% else %}
-                {% set duplicate_pk_columns = [] %}
-
-                {% for pk_column in pk_columns %}
-                    {% if pk_column != 'data_source' %}
-                        {% do duplicate_pk_columns.append(pk_column) %}
-                    {% endif %}
-                {% endfor %}
-
-                {% if duplicate_pk_columns | length == 0 %}
-                    {% set duplicate_pk_columns = pk_columns %}
-                {% endif %}
-
-                {% set duplicate_query %}
+                {% set model_query %}
+                select
+                      sources.data_source
+                    , '{{ table_name }}' as input_table_name
+                    , test_definitions.column_name
+                    , test_definitions.test
+                    , case
+                        when test_definitions.is_evaluable = 0
+                        then cast(null as {{ dbt.type_bigint() }})
+                        else cast(coalesce(
+                            case test_definitions.test_key
+                              {{ metric_case_clauses | join('\n                              ') }}
+                            end,
+                            0
+                        ) as {{ dbt.type_bigint() }})
+                      end as test_result
+                from (
                     select
-                          sources.data_source
-                        , '{{ table_name }}' as {{ adapter.quote('table') }}
-                        , '{{ pk_column_list }}' as {{ adapter.quote('column') }}
-                        , 'duplicate value' as test
-                        , cast(coalesce(source_counts.row_count, 0) - coalesce(distinct_counts.distinct_row_count, 0) as {{ dbt.type_int() }}) as test_result
-                    from (
-                        {{ source_dimension_sql }}
-                    ) as sources
-                    left join (
-                        {{ source_count_sql }}
-                    ) as source_counts
-                        on sources.data_source_key = source_counts.data_source_key
-                    left join (
-                        select
-                              distinct_rows.data_source_key
-                            , cast(count(*) as {{ dbt.type_int() }}) as distinct_row_count
-                        from (
-                            select
-                                  {{ source_key_expression }} as data_source_key
-                                {% for pk_column in duplicate_pk_columns %}
-                                , source_rows.{{ quote_column(pk_column) }}
-                                {% endfor %}
-                            from {{ relation }} as source_rows
-                            group by
-                                  {{ source_key_expression }}
-                                {% for pk_column in duplicate_pk_columns %}
-                                , source_rows.{{ quote_column(pk_column) }}
-                                {% endfor %}
-                        ) as distinct_rows
-                        group by distinct_rows.data_source_key
-                    ) as distinct_counts
-                        on sources.data_source_key = distinct_counts.data_source_key
+                          data_source
+                        , data_source_key
+                    from {{ evaluation_scope }}
+                    where model_name = '{{ model_name }}'
+                ) as sources
+                cross join (
+                    {{ definition_queries | join('\nunion all\n') }}
+                ) as test_definitions
+                left join (
+                    {{ source_metrics_sql }}
+                ) as source_metrics
+                    on sources.data_source_key = source_metrics.data_source_key
                 {% endset %}
             {% endif %}
 
-            {% do pk_queries.append(duplicate_query) %}
+            {% do model_queries.append(model_query) %}
         {% endif %}
     {% endfor %}
 
-    select *
-    from (
-        {{ pk_queries | join('\nunion all\n') }}
-    ) as structural_primary_key_tests
+    {% if model_queries | length > 0 %}
+        select *
+        from (
+            {{ model_queries | join('\nunion all\n') }}
+        ) as structural_primary_key_tests
+    {% else %}
+        select
+              cast(null as {{ dbt.type_string() }}) as data_source
+            , cast(null as {{ dbt.type_string() }}) as input_table_name
+            , cast(null as {{ dbt.type_string() }}) as column_name
+            , cast(null as {{ dbt.type_string() }}) as test
+            , cast(null as {{ dbt.type_bigint() }}) as test_result
+        {{ dq_empty_result_guard_sql() }}
+    {% endif %}
 {% else %}
     select
           cast(null as {{ dbt.type_string() }}) as data_source
-        , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('table') }}
-        , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('column') }}
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as column_name
         , cast(null as {{ dbt.type_string() }}) as test
-        , cast(null as {{ dbt.type_int() }}) as test_result
+        , cast(null as {{ dbt.type_bigint() }}) as test_result
     {{ dq_empty_result_guard_sql() }}
 {% endif %}

--- a/models/data_quality/structural/data_quality__structural_source_populations.sql
+++ b/models/data_quality/structural/data_quality__structural_source_populations.sql
@@ -1,0 +1,88 @@
+{{ config(
+     enabled = var('data_quality_enabled', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_source_populations',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+{% set input_layer_model_names = dq_enabled_input_layer_model_names() %}
+
+{% for model_name in input_layer_model_names %}
+-- depends_on: {{ ref(model_name) }}
+{% endfor %}
+
+{% if execute %}
+    {% set population_queries = [] %}
+
+    {% for model_node in dq_expected_input_layer_models() %}
+        {% set table_name = model_node.name | replace('input_layer__', '') %}
+        {% set input_layer_domain = dq_input_layer_domain_name(model_node.name) %}
+        {% set relation = dq_required_actual_relation(model_node) %}
+        {% set actual_columns = dq_actual_columns(relation) %}
+        {% set actual_data_source = dq_actual_column(actual_columns, 'data_source', relation) %}
+
+        {% if actual_data_source is not none and dq_type_family(actual_data_source.dtype) == 'string' %}
+            {% set data_source_expression = 'source_table.' ~ adapter.quote(actual_data_source.name) %}
+        {% else %}
+            {% set data_source_expression = 'null' %}
+        {% endif %}
+
+        {% set source_key_expression = dq_structural_source_key_sql('source_rows.data_source') %}
+
+        {% set query %}
+            select
+                  '{{ input_layer_domain }}' as input_layer_domain
+                , source_rows.data_source
+                , {{ source_key_expression }} as data_source_key
+                , '{{ table_name }}' as table_name
+                , '{{ model_node.name }}' as model_name
+                , cast(count(source_rows._dq_row_present) as {{ dbt.type_bigint() }}) as row_count
+            from (
+                {{ dq_empty_row_sql() }}
+            ) as empty_source
+            left outer join (
+                select
+                      cast({{ data_source_expression }} as {{ dbt.type_string() }}) as data_source
+                    , 1 as _dq_row_present
+                from {{ relation }} as source_table
+            ) as source_rows
+                on 1 = 1
+            group by
+                  source_rows.data_source
+                , {{ source_key_expression }}
+        {% endset %}
+
+        {% do population_queries.append(query) %}
+    {% endfor %}
+
+    {% if population_queries | length > 0 %}
+        select *
+        from (
+            {{ population_queries | join('\nunion all\n') }}
+        ) as structural_source_populations
+    {% else %}
+        select
+              cast(null as {{ dbt.type_string() }}) as input_layer_domain
+            , cast(null as {{ dbt.type_string() }}) as data_source
+            , cast(null as {{ dbt.type_string() }}) as data_source_key
+            , cast(null as {{ dbt.type_string() }}) as table_name
+            , cast(null as {{ dbt.type_string() }}) as model_name
+            , cast(null as {{ dbt.type_bigint() }}) as row_count
+        {{ dq_empty_result_guard_sql() }}
+    {% endif %}
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as input_layer_domain
+        , cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as data_source_key
+        , cast(null as {{ dbt.type_string() }}) as table_name
+        , cast(null as {{ dbt.type_string() }}) as model_name
+        , cast(null as {{ dbt.type_bigint() }}) as row_count
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/structural/structural_unit_tests.yml
+++ b/models/data_quality/structural/structural_unit_tests.yml
@@ -1,0 +1,728 @@
+version: 2
+
+unit_tests:
+  - name: test_structural_data_sources_builds_independent_domain_rosters
+    description: >
+      Verifies that source discovery is shared within a domain without crossing
+      claims sources into clinical or clinical sources into claims. The same
+      source name can appear independently in both domain rosters.
+    model: data_quality__structural_data_sources
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_source_populations')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'Medicare MSSP' as data_source, '__dq_structural_value__:Medicare MSSP' as data_source_key, 'eligibility' as table_name, 'input_layer__eligibility' as model_name, 10 as row_count
+          union all
+          select 'claims', 'UHC Medicaid', '__dq_structural_value__:UHC Medicaid', 'medical_claim', 'input_layer__medical_claim', 20
+          union all
+          select 'claims', 'Shared Source', '__dq_structural_value__:Shared Source', 'provider_attribution', 'input_layer__provider_attribution', 5
+          union all
+          select 'clinical', 'Epic Clinical', '__dq_structural_value__:Epic Clinical', 'patient', 'input_layer__patient', 7
+          union all
+          select 'clinical', 'Shared Source', '__dq_structural_value__:Shared Source', 'encounter', 'input_layer__encounter', 8
+          union all
+          select 'claims', '__dq_structural_null__', '__dq_structural_value__:__dq_structural_null__', 'pharmacy_claim', 'input_layer__pharmacy_claim', 1
+    expect:
+      rows:
+        - input_layer_domain: claims
+          data_source: Medicare MSSP
+          data_source_key: __dq_structural_value__:Medicare MSSP
+        - input_layer_domain: claims
+          data_source: UHC Medicaid
+          data_source_key: __dq_structural_value__:UHC Medicaid
+        - input_layer_domain: claims
+          data_source: Shared Source
+          data_source_key: __dq_structural_value__:Shared Source
+        - input_layer_domain: clinical
+          data_source: Epic Clinical
+          data_source_key: __dq_structural_value__:Epic Clinical
+        - input_layer_domain: clinical
+          data_source: Shared Source
+          data_source_key: __dq_structural_value__:Shared Source
+        - input_layer_domain: claims
+          data_source: __dq_structural_null__
+          data_source_key: __dq_structural_value__:__dq_structural_null__
+
+  - name: test_structural_data_sources_falls_back_for_empty_domain
+    description: >
+      Verifies that a domain with no non-null source receives one null-source
+      fallback without affecting another domain's discovered roster.
+    model: data_quality__structural_data_sources
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_source_populations')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, null as data_source, '__dq_structural_null__' as data_source_key, 'eligibility' as table_name, 'input_layer__eligibility' as model_name, 0 as row_count
+          union all
+          select 'claims', null, '__dq_structural_null__', 'medical_claim', 'input_layer__medical_claim', 0
+          union all
+          select 'clinical', 'Epic Clinical', '__dq_structural_value__:Epic Clinical', 'patient', 'input_layer__patient', 2
+    expect:
+      rows:
+        - input_layer_domain: claims
+          data_source: null
+          data_source_key: __dq_structural_null__
+        - input_layer_domain: clinical
+          data_source: Epic Clinical
+          data_source_key: __dq_structural_value__:Epic Clinical
+
+  - name: test_structural_evaluation_scope_expands_each_domain_roster
+    description: >
+      Verifies the domain Model-by-source grid. Claims sources expand across
+      claims Models, including provider attribution, but not clinical Models;
+      a clinical source expands only across clinical Models. Missing
+      Model/source populations receive row_count zero, while populated null
+      data_source buckets remain independently visible.
+    model: data_quality__structural_evaluation_scope
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_expected_columns')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'eligibility' as table_name, 'input_layer__eligibility' as model_name
+          union all
+          select 'claims', 'medical_claim', 'input_layer__medical_claim'
+          union all
+          select 'claims', 'pharmacy_claim', 'input_layer__pharmacy_claim'
+          union all
+          select 'claims', 'provider_attribution', 'input_layer__provider_attribution'
+          union all
+          select 'clinical', 'patient', 'input_layer__patient'
+          union all
+          select 'clinical', 'encounter', 'input_layer__encounter'
+      - input: ref('data_quality__structural_source_populations')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'eligibility' as table_name, 'input_layer__eligibility' as model_name, 'Medicare MSSP' as data_source, '__dq_structural_value__:Medicare MSSP' as data_source_key, 10 as row_count
+          union all
+          select 'claims', 'eligibility', 'input_layer__eligibility', 'UHC Medicaid', '__dq_structural_value__:UHC Medicaid', 20
+          union all
+          select 'claims', 'medical_claim', 'input_layer__medical_claim', 'Medicare MSSP', '__dq_structural_value__:Medicare MSSP', 30
+          union all
+          select 'claims', 'medical_claim', 'input_layer__medical_claim', 'UHC Medicaid', '__dq_structural_value__:UHC Medicaid', 40
+          union all
+          select 'claims', 'medical_claim', 'input_layer__medical_claim', null, '__dq_structural_null__', 2
+          union all
+          select 'claims', 'pharmacy_claim', 'input_layer__pharmacy_claim', 'UHC Medicaid', '__dq_structural_value__:UHC Medicaid', 50
+          union all
+          select 'claims', 'provider_attribution', 'input_layer__provider_attribution', 'UHC Medicaid', '__dq_structural_value__:UHC Medicaid', 5
+          union all
+          select 'clinical', 'patient', 'input_layer__patient', 'Epic Clinical', '__dq_structural_value__:Epic Clinical', 7
+          union all
+          select 'clinical', 'encounter', 'input_layer__encounter', null, '__dq_structural_null__', 0
+      - input: ref('data_quality__structural_data_sources')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'Medicare MSSP' as data_source, '__dq_structural_value__:Medicare MSSP' as data_source_key
+          union all
+          select 'claims', 'UHC Medicaid', '__dq_structural_value__:UHC Medicaid'
+          union all
+          select 'clinical', 'Epic Clinical', '__dq_structural_value__:Epic Clinical'
+    expect:
+      rows:
+        - input_layer_domain: claims
+          input_table_name: eligibility
+          model_name: input_layer__eligibility
+          data_source: Medicare MSSP
+          data_source_key: __dq_structural_value__:Medicare MSSP
+          row_count: 10
+        - input_layer_domain: claims
+          input_table_name: eligibility
+          model_name: input_layer__eligibility
+          data_source: UHC Medicaid
+          data_source_key: __dq_structural_value__:UHC Medicaid
+          row_count: 20
+        - input_layer_domain: claims
+          input_table_name: medical_claim
+          model_name: input_layer__medical_claim
+          data_source: Medicare MSSP
+          data_source_key: __dq_structural_value__:Medicare MSSP
+          row_count: 30
+        - input_layer_domain: claims
+          input_table_name: medical_claim
+          model_name: input_layer__medical_claim
+          data_source: UHC Medicaid
+          data_source_key: __dq_structural_value__:UHC Medicaid
+          row_count: 40
+        - input_layer_domain: claims
+          input_table_name: medical_claim
+          model_name: input_layer__medical_claim
+          data_source: null
+          data_source_key: __dq_structural_null__
+          row_count: 2
+        - input_layer_domain: claims
+          input_table_name: pharmacy_claim
+          model_name: input_layer__pharmacy_claim
+          data_source: Medicare MSSP
+          data_source_key: __dq_structural_value__:Medicare MSSP
+          row_count: 0
+        - input_layer_domain: claims
+          input_table_name: pharmacy_claim
+          model_name: input_layer__pharmacy_claim
+          data_source: UHC Medicaid
+          data_source_key: __dq_structural_value__:UHC Medicaid
+          row_count: 50
+        - input_layer_domain: claims
+          input_table_name: provider_attribution
+          model_name: input_layer__provider_attribution
+          data_source: Medicare MSSP
+          data_source_key: __dq_structural_value__:Medicare MSSP
+          row_count: 0
+        - input_layer_domain: claims
+          input_table_name: provider_attribution
+          model_name: input_layer__provider_attribution
+          data_source: UHC Medicaid
+          data_source_key: __dq_structural_value__:UHC Medicaid
+          row_count: 5
+        - input_layer_domain: clinical
+          input_table_name: patient
+          model_name: input_layer__patient
+          data_source: Epic Clinical
+          data_source_key: __dq_structural_value__:Epic Clinical
+          row_count: 7
+        - input_layer_domain: clinical
+          input_table_name: encounter
+          model_name: input_layer__encounter
+          data_source: Epic Clinical
+          data_source_key: __dq_structural_value__:Epic Clinical
+          row_count: 0
+
+  - name: test_structural_evaluation_scope_falls_back_when_domain_is_empty
+    description: >
+      Verifies that a completely empty enabled domain still emits one
+      null-source row with row_count zero for every enabled Model in that
+      domain.
+    model: data_quality__structural_evaluation_scope
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_expected_columns')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'eligibility' as table_name, 'input_layer__eligibility' as model_name
+          union all
+          select 'claims', 'medical_claim', 'input_layer__medical_claim'
+          union all
+          select 'claims', 'pharmacy_claim', 'input_layer__pharmacy_claim'
+      - input: ref('data_quality__structural_source_populations')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'eligibility' as table_name, 'input_layer__eligibility' as model_name, null as data_source, '__dq_structural_null__' as data_source_key, 0 as row_count
+          union all
+          select 'claims', 'medical_claim', 'input_layer__medical_claim', null, '__dq_structural_null__', 0
+          union all
+          select 'claims', 'pharmacy_claim', 'input_layer__pharmacy_claim', null, '__dq_structural_null__', 0
+      - input: ref('data_quality__structural_data_sources')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, null as data_source, '__dq_structural_null__' as data_source_key
+    expect:
+      rows:
+        - input_layer_domain: claims
+          input_table_name: eligibility
+          model_name: input_layer__eligibility
+          data_source: null
+          data_source_key: __dq_structural_null__
+          row_count: 0
+        - input_layer_domain: claims
+          input_table_name: medical_claim
+          model_name: input_layer__medical_claim
+          data_source: null
+          data_source_key: __dq_structural_null__
+          row_count: 0
+        - input_layer_domain: claims
+          input_table_name: pharmacy_claim
+          model_name: input_layer__pharmacy_claim
+          data_source: null
+          data_source_key: __dq_structural_null__
+          row_count: 0
+
+  - name: test_structural_evaluation_scope_preserves_model_missing_data_source
+    description: >
+      Verifies that a Model without a data_source column still receives the
+      non-null claims-domain source roster with zero counts, plus one observed
+      null-source bucket containing the Model's records.
+    model: data_quality__structural_evaluation_scope
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_expected_columns')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'pharmacy_claim' as table_name, 'input_layer__pharmacy_claim' as model_name
+      - input: ref('data_quality__structural_source_populations')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'pharmacy_claim' as table_name, 'input_layer__pharmacy_claim' as model_name, null as data_source, '__dq_structural_null__' as data_source_key, 10 as row_count
+      - input: ref('data_quality__structural_data_sources')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'Medicare MSSP' as data_source, '__dq_structural_value__:Medicare MSSP' as data_source_key
+          union all
+          select 'claims', 'UHC Medicaid', '__dq_structural_value__:UHC Medicaid'
+    expect:
+      rows:
+        - input_layer_domain: claims
+          input_table_name: pharmacy_claim
+          model_name: input_layer__pharmacy_claim
+          data_source: Medicare MSSP
+          data_source_key: __dq_structural_value__:Medicare MSSP
+          row_count: 0
+        - input_layer_domain: claims
+          input_table_name: pharmacy_claim
+          model_name: input_layer__pharmacy_claim
+          data_source: UHC Medicaid
+          data_source_key: __dq_structural_value__:UHC Medicaid
+          row_count: 0
+        - input_layer_domain: claims
+          input_table_name: pharmacy_claim
+          model_name: input_layer__pharmacy_claim
+          data_source: null
+          data_source_key: __dq_structural_null__
+          row_count: 10
+
+  - name: test_structural_evaluation_scope_distinguishes_literal_null_sentinel
+    description: >
+      Verifies that a literal data_source value equal to the logical null
+      sentinel remains distinct from records whose data_source is SQL null.
+    model: data_quality__structural_evaluation_scope
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_expected_columns')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'medical_claim' as table_name, 'input_layer__medical_claim' as model_name
+      - input: ref('data_quality__structural_source_populations')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'medical_claim' as table_name, 'input_layer__medical_claim' as model_name, '__dq_structural_null__' as data_source, '__dq_structural_value__:__dq_structural_null__' as data_source_key, 4 as row_count
+          union all
+          select 'claims', 'medical_claim', 'input_layer__medical_claim', null, '__dq_structural_null__', 2
+      - input: ref('data_quality__structural_data_sources')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, '__dq_structural_null__' as data_source, '__dq_structural_value__:__dq_structural_null__' as data_source_key
+    expect:
+      rows:
+        - input_layer_domain: claims
+          input_table_name: medical_claim
+          model_name: input_layer__medical_claim
+          data_source: __dq_structural_null__
+          data_source_key: __dq_structural_value__:__dq_structural_null__
+          row_count: 4
+        - input_layer_domain: claims
+          input_table_name: medical_claim
+          model_name: input_layer__medical_claim
+          data_source: null
+          data_source_key: __dq_structural_null__
+          row_count: 2
+
+  - name: test_structural_evaluation_scope_does_not_invent_null_source_for_empty_missing_column_model
+    description: >
+      Verifies that an empty Model without a data_source column receives the
+      domain's named source rows but does not receive an additional null-source
+      row. There are no records from which a null-source population could be
+      observed.
+    model: data_quality__structural_evaluation_scope
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_expected_columns')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'pharmacy_claim' as table_name, 'input_layer__pharmacy_claim' as model_name
+      - input: ref('data_quality__structural_source_populations')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'pharmacy_claim' as table_name, 'input_layer__pharmacy_claim' as model_name, null as data_source, '__dq_structural_null__' as data_source_key, 0 as row_count
+      - input: ref('data_quality__structural_data_sources')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'Medicare MSSP' as data_source, '__dq_structural_value__:Medicare MSSP' as data_source_key
+    expect:
+      rows:
+        - input_layer_domain: claims
+          input_table_name: pharmacy_claim
+          model_name: input_layer__pharmacy_claim
+          data_source: Medicare MSSP
+          data_source_key: __dq_structural_value__:Medicare MSSP
+          row_count: 0
+
+  - name: test_structural_column_details_is_source_neutral
+    description: >
+      Verifies that column and type evidence is recorded once per Model and
+      column, independent of source populations, while preserving the physical
+      warehouse identifier used by later scans.
+    model: data_quality__structural_column_details
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_expected_columns')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'pharmacy_claim' as table_name, 'input_layer__pharmacy_claim' as model_name, 'claim_id' as column_name, 'varchar' as expected_data_type, 'string' as expected_type_family, 'yes' as is_primary_key, 1 as column_order
+          union all
+          select 'claims', 'pharmacy_claim', 'input_layer__pharmacy_claim', 'data_source', 'varchar', 'string', 'yes', 2
+      - input: ref('data_quality__structural_actual_columns')
+        format: sql
+        rows: |
+          select 'claims' as input_layer_domain, 'pharmacy_claim' as table_name, 'input_layer__pharmacy_claim' as model_name, 'claim_id' as column_name, 'Claim_ID' as actual_column_name, 'VARCHAR' as actual_data_type, 'string' as actual_type_family
+          union all
+          select 'claims', 'pharmacy_claim', 'input_layer__pharmacy_claim', 'data_source', 'Data_Source', 'VARCHAR', 'string'
+    expect:
+      rows:
+        - input_table_name: pharmacy_claim
+          column_name: claim_id
+          expected_data_type: varchar
+          actual_column_name: Claim_ID
+          actual_data_type: VARCHAR
+          is_primary_key: "yes"
+          column_exists: "yes"
+          data_type_correct: "yes"
+          column_order: 1
+        - input_table_name: pharmacy_claim
+          column_name: data_source
+          expected_data_type: varchar
+          actual_column_name: Data_Source
+          actual_data_type: VARCHAR
+          is_primary_key: "yes"
+          column_exists: "yes"
+          data_type_correct: "yes"
+          column_order: 2
+
+  - name: test_structural_missing_columns_is_source_neutral_and_failure_only
+    description: >
+      Verifies that missing-column evidence is emitted once per Model and
+      column, independent of the number of sources evaluated for that Model.
+    model: data_quality__structural_missing_columns
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_column_details')
+        format: sql
+        rows: |
+          select 'medical_claim' as input_table_name, 'bill_type_code' as column_name, 'varchar' as expected_data_type, 'no' as column_exists
+          union all
+          select 'medical_claim', 'claim_id', 'varchar', 'yes'
+    expect:
+      rows:
+        - input_table_name: medical_claim
+          column_name: bill_type_code
+          expected_data_type: varchar
+
+  - name: test_structural_data_type_mismatches_excludes_missing_columns
+    description: >
+      Verifies that actual-versus-expected type failures are emitted once per
+      Model and column, that missing columns remain exclusively in the
+      missing-column detail, and that a known mismatch remains visible when a
+      different required column in the same Model is missing.
+    model: data_quality__structural_data_type_mismatches
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_column_details')
+        format: sql
+        rows: |
+          select 'medical_claim' as input_table_name, 'claim_line_number' as column_name, 'integer' as expected_data_type, 'DATE' as actual_data_type, 'yes' as column_exists, 'no' as data_type_correct
+          union all
+          select 'medical_claim', 'bill_type_code', 'varchar', null, 'no', 'no'
+          union all
+          select 'pharmacy_claim', 'prescribing_provider_npi', 'varchar', null, 'no', 'no'
+          union all
+          select 'medical_claim', 'claim_id', 'varchar', 'VARCHAR', 'yes', 'yes'
+          union all
+          select 'eligibility', 'enrollment_start_date', 'date', 'VARCHAR', 'yes', 'no'
+    expect:
+      rows:
+        - input_table_name: medical_claim
+          column_name: claim_line_number
+          expected_data_type: integer
+          actual_data_type: DATE
+        - input_table_name: eligibility
+          column_name: enrollment_start_date
+          expected_data_type: date
+          actual_data_type: VARCHAR
+
+  - name: test_structural_primary_key_failure_counts_is_failure_only
+    description: >
+      Verifies the public failure vocabulary, positive-count filtering, full
+      composite key declaration for duplicate failures, and exclusion of
+      technical helper rows when primary-key evaluation was blocked.
+    model: data_quality__structural_primary_key_failure_counts
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_primary_key_tests')
+        format: sql
+        rows: |
+          select 'UHC Medicaid' as data_source, 'medical_claim' as input_table_name, 'claim_id' as column_name, 'not null' as test, 3 as test_result
+          union all
+          select 'UHC Medicaid', 'medical_claim', 'claim_line_number', 'not null', 0
+          union all
+          select 'UHC Medicaid', 'medical_claim', 'claim_id, claim_line_number, data_source', 'duplicate value', 5
+          union all
+          select 'Medicare MSSP', 'pharmacy_claim', 'claim_id', 'not null', null
+          union all
+          select 'Medicare MSSP', 'pharmacy_claim', 'data_source', 'not null', null
+          union all
+          select 'Medicare MSSP', 'pharmacy_claim', 'claim_id, data_source', 'duplicate value', null
+          union all
+          select null, 'patient', 'patient_id', 'not null', 2
+      - input: ref('data_quality__structural')
+        format: sql
+        rows: |
+          select 'UHC Medicaid' as data_source, 'medical_claim' as input_table_name, 'fail' as primary_key_correct
+          union all
+          select 'Medicare MSSP', 'pharmacy_claim', 'not evaluated'
+          union all
+          select null, 'patient', 'fail'
+    expect:
+      rows:
+        - data_source: UHC Medicaid
+          input_table_name: medical_claim
+          failure_type: null_value
+          primary_key_columns: claim_id
+          failed_record_count: 3
+        - data_source: UHC Medicaid
+          input_table_name: medical_claim
+          failure_type: duplicate_value
+          primary_key_columns: claim_id, claim_line_number, data_source
+          failed_record_count: 5
+        - data_source: null
+          input_table_name: patient
+          failure_type: null_value
+          primary_key_columns: patient_id
+          failed_record_count: 2
+
+  - name: test_structural_four_result_dependency_rules
+    description: Verifies the four-result structural readiness contract and prerequisite handling.
+    model: data_quality__structural
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural_column_details')
+        format: sql
+        rows: |
+          select 'eligibility' as input_table_name, 'person_id' as column_name, 'yes' as is_primary_key, 'yes' as column_exists, 'yes' as data_type_correct
+          union all
+          select 'eligibility', 'data_source', 'yes', 'yes', 'yes'
+          union all
+          select 'pharmacy_claim', 'claim_id', 'yes', 'yes', 'yes'
+          union all
+          select 'pharmacy_claim', 'data_source', 'yes', 'yes', 'yes'
+          union all
+          select 'missing_non_key_table', 'claim_id', 'yes', 'yes', 'yes'
+          union all
+          select 'missing_non_key_table', 'data_source', 'yes', 'yes', 'yes'
+          union all
+          select 'missing_non_key_table', 'bill_type_code', 'no', 'no', 'no'
+          union all
+          select 'missing_key_table', 'claim_id', 'yes', 'no', 'no'
+          union all
+          select 'missing_key_table', 'data_source', 'yes', 'yes', 'yes'
+          union all
+          select 'missing_data_source_table', 'claim_id', 'yes', 'yes', 'yes'
+          union all
+          select 'missing_data_source_table', 'data_source', 'yes', 'no', 'no'
+          union all
+          select 'bad_data_source_type_table', 'claim_id', 'yes', 'yes', 'yes'
+          union all
+          select 'bad_data_source_type_table', 'data_source', 'yes', 'yes', 'no'
+          union all
+          select 'wrong_non_key_type_table', 'claim_id', 'yes', 'yes', 'yes'
+          union all
+          select 'wrong_non_key_type_table', 'data_source', 'yes', 'yes', 'yes'
+          union all
+          select 'wrong_non_key_type_table', 'bill_type_code', 'no', 'yes', 'no'
+          union all
+          select 'bad_key_table', 'claim_id', 'yes', 'yes', 'yes'
+          union all
+          select 'bad_key_table', 'data_source', 'yes', 'yes', 'yes'
+      - input: ref('data_quality__structural_evaluation_scope')
+        format: sql
+        rows: |
+          select 'all_pass' as data_source, 'eligibility' as input_table_name, 2 as row_count
+          union all
+          select 'Medicare MSSP', 'pharmacy_claim', 0
+          union all
+          select 'UHC Medicaid', 'pharmacy_claim', 2
+          union all
+          select 'missing_non_key', 'missing_non_key_table', 2
+          union all
+          select 'missing_key', 'missing_key_table', 2
+          union all
+          select null, 'missing_data_source_table', 2
+          union all
+          select 'bad_data_source_type', 'bad_data_source_type_table', 2
+          union all
+          select 'wrong_non_key_type', 'wrong_non_key_type_table', 2
+          union all
+          select 'bad_key', 'bad_key_table', 2
+      - input: ref('data_quality__structural_primary_key_tests')
+        format: sql
+        rows: |
+          select 'all_pass' as data_source, 'eligibility' as input_table_name, 0 as test_result
+          union all
+          select 'Medicare MSSP', 'pharmacy_claim', 0
+          union all
+          select 'UHC Medicaid', 'pharmacy_claim', 0
+          union all
+          select 'missing_non_key', 'missing_non_key_table', 0
+          union all
+          select 'missing_key', 'missing_key_table', null
+          union all
+          select null, 'missing_data_source_table', null
+          union all
+          select 'bad_data_source_type', 'bad_data_source_type_table', null
+          union all
+          select 'wrong_non_key_type', 'wrong_non_key_type_table', 0
+          union all
+          select 'bad_key', 'bad_key_table', 1
+    expect:
+      rows:
+        - data_source: all_pass
+          input_table_name: eligibility
+          columns_exist: pass
+          data_types_correct: pass
+          table_populated: pass
+          primary_key_correct: pass
+          row_count: 2
+        - data_source: Medicare MSSP
+          input_table_name: pharmacy_claim
+          columns_exist: pass
+          data_types_correct: pass
+          table_populated: fail
+          primary_key_correct: not evaluated
+          row_count: 0
+        - data_source: UHC Medicaid
+          input_table_name: pharmacy_claim
+          columns_exist: pass
+          data_types_correct: pass
+          table_populated: pass
+          primary_key_correct: pass
+          row_count: 2
+        - data_source: missing_non_key
+          input_table_name: missing_non_key_table
+          columns_exist: fail
+          data_types_correct: not evaluated
+          table_populated: pass
+          primary_key_correct: pass
+          row_count: 2
+        - data_source: missing_key
+          input_table_name: missing_key_table
+          columns_exist: fail
+          data_types_correct: not evaluated
+          table_populated: pass
+          primary_key_correct: not evaluated
+          row_count: 2
+        - data_source: null
+          input_table_name: missing_data_source_table
+          columns_exist: fail
+          data_types_correct: not evaluated
+          table_populated: not evaluated
+          primary_key_correct: not evaluated
+          row_count: 2
+        - data_source: bad_data_source_type
+          input_table_name: bad_data_source_type_table
+          columns_exist: pass
+          data_types_correct: fail
+          table_populated: not evaluated
+          primary_key_correct: not evaluated
+          row_count: 2
+        - data_source: wrong_non_key_type
+          input_table_name: wrong_non_key_type_table
+          columns_exist: pass
+          data_types_correct: fail
+          table_populated: pass
+          primary_key_correct: pass
+          row_count: 2
+        - data_source: bad_key
+          input_table_name: bad_key_table
+          columns_exist: pass
+          data_types_correct: pass
+          table_populated: pass
+          primary_key_correct: fail
+          row_count: 2
+
+  - name: test_structural_test_results_normalizes_exactly_four_checks
+    description: Verifies normalized structural results contain exactly four checks and classify only active failures as S1.
+    model: data_quality__structural_test_results
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    given:
+      - input: ref('data_quality__structural')
+        format: sql
+        rows: |
+          select
+                'test_source' as data_source
+              , 'medical_claim' as input_table_name
+              , 'fail' as columns_exist
+              , 'not evaluated' as data_types_correct
+              , 'pass' as table_populated
+              , 'pass' as primary_key_correct
+              , 3 as row_count
+    expect:
+      rows:
+        - data_source: test_source
+          input_table_name: medical_claim
+          test_name: structural__columns_exist
+          severity: 1
+          tested_count: 1
+          failed_count: 1
+          passed_count: 0
+          not_evaluated_count: 0
+        - data_source: test_source
+          input_table_name: medical_claim
+          test_name: structural__data_types_correct
+          severity: null
+          tested_count: 0
+          failed_count: 0
+          passed_count: 0
+          not_evaluated_count: 1
+        - data_source: test_source
+          input_table_name: medical_claim
+          test_name: structural__table_populated
+          severity: null
+          tested_count: 1
+          failed_count: 0
+          passed_count: 1
+          not_evaluated_count: 0
+        - data_source: test_source
+          input_table_name: medical_claim
+          test_name: structural__primary_key_correct
+          severity: null
+          tested_count: 1
+          failed_count: 0
+          passed_count: 1
+          not_evaluated_count: 0
+
+  - name: test_structural_primary_key_tests_returns_typed_empty_without_enabled_domain
+    description: >
+      Verifies that the primary-key helper returns a valid typed empty result
+      when no Input Layer domain is enabled.
+    model: data_quality__structural_primary_key_tests
+    config:
+      enabled: "{{ var('data_quality_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: false
+        clinical_enabled: false
+        provider_attribution_enabled: false
+    given:
+      - input: ref('data_quality__structural_evaluation_scope')
+        format: sql
+        rows: |
+          select
+                null as data_source
+              , null as data_source_key
+              , null as model_name
+              , null as row_count
+          where 1 = 0
+    expect:
+      rows: []

--- a/tests/check_structural_type_family_macros.sql
+++ b/tests/check_structural_type_family_macros.sql
@@ -1,0 +1,28 @@
+{{ config(
+     enabled = var('data_quality_enabled', false) | as_bool,
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural']
+   )
+}}
+
+{% set type_family_cases = [
+    ('varchar_alias', dq_type_family('VARCHAR'), 'string'),
+    ('bigint_alias', dq_type_family('BIGINT'), 'integer'),
+    ('boolean_alias', dq_type_family('BOOL'), 'boolean'),
+    ('date_alias', dq_type_family('DATE'), 'date'),
+    ('timestamp_alias', dq_type_family('TIMESTAMP_NTZ'), 'timestamp'),
+    ('scaled_numeric', dq_type_family('DECIMAL(18,2)'), 'numeric'),
+    ('zero_scale_number', dq_type_family('NUMBER(38,0)'), 'integer'),
+    ('bare_number', dq_type_family('NUMBER'), 'numeric'),
+    ('bigquery_bytes', bigquery__dq_type_family('BYTES'), 'binary')
+] %}
+
+{% for case in type_family_cases %}
+select
+      '{{ case[0] }}' as test_case
+    , '{{ case[1] }}' as actual_type_family
+    , '{{ case[2] }}' as expected_type_family
+where '{{ case[1] }}' <> '{{ case[2] }}'
+{% if not loop.last %}
+union all
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
## Summary
- replace the legacy Structural output with four readiness results using `pass`, `fail`, and `not evaluated`
- derive domain-scoped source rosters and evaluate the complete enabled Input Layer Model-by-source grid
- separate source-neutral schema metadata from bounded record scans and publish three focused remediation tables
- harden warehouse portability with quoted physical identifiers, portable type families, BIGINT counts, and compile-time Input Layer contract validation
- include normalized Structural results in `tag:dq_structural` and support configurations with no enabled Input Layer domain

## Public contract
The stable Structural interface is now:
- `data_quality.structural`
- `data_quality.structural_test_results`
- `data_quality.structural_missing_columns`
- `data_quality.structural_data_type_mismatches`
- `data_quality.structural_primary_key_failure_counts`

This removes `table_exists` and renames or redefines the remaining readiness fields, so downstream consumers must migrate.

## Validation
- Snowflake: 14 Structural unit tests and 1 type-family regression test passed
- DuckDB: comprehensive Structural E2E build passed 142/142 resources plus exact result assertions and targeted edge-case scenarios
- dbt parsing passed for all-domain, no-domain, and Data Quality-disabled configurations
- missing connector Model and unavailable Wrapper error paths verified
- `git diff --check`

The hosted Snowflake full-refresh CI remains required before merge because the existing local Snowflake development target did not contain the synthetic-data schema needed for a real-model build.

## Downstream dependency
Tuva Enterprise DQI currently consumes the legacy Structural schema and must migrate to this contract before the Tuva 1.0 release.

## Release note
`breaking-change`