### PR TITLE
Replace legacy drug terminology with CodeRx Open

### DIFF
--- a/data_assets.yml
+++ b/data_assets.yml
@@ -25,6 +25,12 @@ assets:
     path: terminology/terminology__claim_type.csv.gz
   - seed: terminology__code_type
     path: terminology/terminology__code_type.csv.gz
+  - seed: terminology__coderx_classes
+    path: terminology/terminology__coderx_classes.csv.gz
+  - seed: terminology__coderx_drugs
+    path: terminology/terminology__coderx_drugs.csv.gz
+  - seed: terminology__coderx_packages
+    path: terminology/terminology__coderx_packages.csv.gz
   - seed: terminology__cvx
     path: terminology/terminology__cvx.csv.gz
   - seed: terminology__discharge_disposition
@@ -69,8 +75,6 @@ assets:
     path: terminology/terminology__ms_drg.csv.gz
   - seed: terminology__ms_drg_weights_los
     path: terminology/terminology__ms_drg_weights_los.csv.gz
-  - seed: terminology__ndc
-    path: terminology/terminology__ndc.csv.gz
   - seed: terminology__nitos
     path: terminology/terminology__nitos.csv.gz
   - seed: terminology__observation_type
@@ -87,10 +91,6 @@ assets:
     path: terminology/terminology__restructured_betos.csv.gz
   - seed: terminology__revenue_center
     path: terminology/terminology__revenue_center.csv.gz
-  - seed: terminology__rxnorm_brand_generic
-    path: terminology/terminology__rxnorm_brand_generic.csv.gz
-  - seed: terminology__rxnorm_to_atc
-    path: terminology/terminology__rxnorm_to_atc.csv.gz
   - seed: terminology__sex
     path: terminology/terminology__sex.csv.gz
   - seed: terminology__snomed_ct

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,6 +11,11 @@ vars:
   ## Optional model families
   parity_enabled: false
 
+  ## Medication terminology
+  # When true, core.medication reads user-managed CodeRx tables from the
+  # coderx schema instead of the package's CodeRx Open data assets.
+  use_proprietary_coderx: false
+
   ## Seed storage configuration
   custom_bucket_name: tuva-public-resources
   tuva_seed_buckets: {}

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -12,9 +12,9 @@ vars:
   parity_enabled: false
 
   ## Medication terminology
-  # When true, core.medication reads user-managed CodeRx tables from the
-  # coderx schema instead of the package's CodeRx Open data assets.
-  use_proprietary_coderx: false
+  # When true, every CodeRx consumer reads user-managed CodeRx Enterprise
+  # tables from the coderx schema instead of the package's CodeRx Open assets.
+  use_coderx_enterprise: false
 
   ## Seed storage configuration
   custom_bucket_name: tuva-public-resources

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -20,6 +20,11 @@ vars:
   enable_data_quality_failure_keys: false  # Adds the optional key-only logical failure drilldown table.
   data_quality_domain_input_requirements: []  # Optional additional component-to-input dependency mappings.
 
+  ## Medication terminology
+  # False uses the package's CodeRx Open assets. True requires user-managed
+  # packages, drugs, and classes relations in the target database's coderx schema.
+  use_proprietary_coderx: false
+
   ## Synthetic data validation
   # These vars are for this integration_tests project. They are not normal production Tuva Core settings.
   use_synthetic_data: true             # Maps package synthetic seeds into this project's Input Layer models.

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -23,7 +23,7 @@ vars:
   ## Medication terminology
   # False uses the package's CodeRx Open assets. True requires user-managed
   # packages, drugs, and classes relations in the target database's coderx schema.
-  use_proprietary_coderx: false
+  use_coderx_enterprise: false
 
   ## Synthetic data validation
   # These vars are for this integration_tests project. They are not normal production Tuva Core settings.

--- a/macros/data_quality/dq_logical_flag_manifest.sql
+++ b/macros/data_quality/dq_logical_flag_manifest.sql
@@ -870,7 +870,7 @@
         {
             "test_name": "pharmacy_claim__ndc_code_invalid",
             "display_name": "ndc_code is invalid",
-            "description": "Checks whether ndc_code is populated but not found in Tuva NDC terminology.",
+            "description": "Checks whether ndc_code is populated but not found in the bundled CodeRx Open packages terminology.",
             "test_type": "invalid",
             "severity": 2,
             "affected_columns": ["ndc_code"]
@@ -1726,7 +1726,7 @@
         {
             "test_name": "medication__source_code_invalid",
             "display_name": "source_code is invalid",
-            "description": "Checks whether a populated source_code is absent from Tuva NDC terminology when source_code_type identifies NDC without regard to letter case. Tuva removes hyphens from both values before comparison. Every other source_code_type, including RxNorm, ATC, and a source-system-specific name, is not applicable to this code-validity test.",
+            "description": "Checks whether a populated source_code is absent from the bundled CodeRx Open packages terminology when source_code_type identifies NDC without regard to letter case. Tuva removes hyphens from both values before comparison. Every other source_code_type, including RxNorm, ATC, and a source-system-specific name, is not applicable to this code-validity test.",
             "test_type": "invalid",
             "severity": 2,
             "affected_columns": ["source_code_type", "source_code"]
@@ -1734,7 +1734,7 @@
         {
             "test_name": "medication__ndc_code_invalid",
             "display_name": "ndc_code is invalid",
-            "description": "Checks whether a populated ndc_code is absent from Tuva NDC terminology after Tuva removes hyphens from both values before comparison.",
+            "description": "Checks whether a populated ndc_code is absent from the bundled CodeRx Open packages terminology after Tuva removes hyphens from both values before comparison.",
             "test_type": "invalid",
             "severity": 2,
             "affected_columns": ["ndc_code"]

--- a/macros/data_quality/dq_logical_flag_manifest.sql
+++ b/macros/data_quality/dq_logical_flag_manifest.sql
@@ -870,7 +870,7 @@
         {
             "test_name": "pharmacy_claim__ndc_code_invalid",
             "display_name": "ndc_code is invalid",
-            "description": "Checks whether ndc_code is populated but not found in the bundled CodeRx Open packages terminology.",
+            "description": "Checks whether ndc_code is populated but not found in the selected CodeRx packages terminology.",
             "test_type": "invalid",
             "severity": 2,
             "affected_columns": ["ndc_code"]
@@ -1726,7 +1726,7 @@
         {
             "test_name": "medication__source_code_invalid",
             "display_name": "source_code is invalid",
-            "description": "Checks whether a populated source_code is absent from the bundled CodeRx Open packages terminology when source_code_type identifies NDC without regard to letter case. Tuva removes hyphens from both values before comparison. Every other source_code_type, including RxNorm, ATC, and a source-system-specific name, is not applicable to this code-validity test.",
+            "description": "Checks whether a populated source_code is absent from the selected CodeRx packages terminology when source_code_type identifies NDC without regard to letter case. Tuva removes hyphens from both values before comparison. Every other source_code_type, including RxNorm, ATC, and a source-system-specific name, is not applicable to this code-validity test.",
             "test_type": "invalid",
             "severity": 2,
             "affected_columns": ["source_code_type", "source_code"]
@@ -1734,7 +1734,7 @@
         {
             "test_name": "medication__ndc_code_invalid",
             "display_name": "ndc_code is invalid",
-            "description": "Checks whether a populated ndc_code is absent from the bundled CodeRx Open packages terminology after Tuva removes hyphens from both values before comparison.",
+            "description": "Checks whether a populated ndc_code is absent from the selected CodeRx packages terminology after Tuva removes hyphens from both values before comparison.",
             "test_type": "invalid",
             "severity": 2,
             "affected_columns": ["ndc_code"]

--- a/models/core/coderx_sources.yml
+++ b/models/core/coderx_sources.yml
@@ -1,0 +1,45 @@
+version: 2
+
+sources:
+  - name: coderx
+    description: |-
+      Optional user-managed licensed CodeRx data marts. These relations are read
+      only when `use_proprietary_coderx` is true; Tuva does not install, load, or
+      distribute them.
+    schema: coderx
+    tables:
+      - name: packages
+        description: NDC package records and their associated RxNorm drug concepts.
+        columns:
+          - name: ndc11
+          - name: ndc
+          - name: drug_id
+          - name: drug_name
+          - name: is_brand
+          - name: clinical_drug_id
+          - name: clinical_drug_name
+          - name: active
+          - name: prescribable
+      - name: drugs
+        description: RxNorm drug concepts and normalized drug names.
+        columns:
+          - name: drug_id
+          - name: drug_name
+          - name: is_brand
+          - name: clinical_drug_id
+          - name: clinical_drug_name
+          - name: active
+          - name: prescribable
+      - name: classes
+        description: RxNorm drug concepts mapped to ATC classification levels.
+        columns:
+          - name: drug_id
+          - name: drug_name
+          - name: atc_1_code
+          - name: atc_1_name
+          - name: atc_2_code
+          - name: atc_2_name
+          - name: atc_3_code
+          - name: atc_3_name
+          - name: atc_4_code
+          - name: atc_4_name

--- a/models/core/coderx_sources.yml
+++ b/models/core/coderx_sources.yml
@@ -3,8 +3,8 @@ version: 2
 sources:
   - name: coderx
     description: |-
-      Optional user-managed licensed CodeRx data marts. These relations are read
-      only when `use_proprietary_coderx` is true; Tuva does not install, load, or
+      Optional user-managed CodeRx Enterprise data marts. These relations are read
+      only when `use_coderx_enterprise` is true; Tuva does not install, load, or
       distribute them.
     schema: coderx
     tables:

--- a/models/core/coderx_unit_tests.yml
+++ b/models/core/coderx_unit_tests.yml
@@ -1,0 +1,284 @@
+version: 2
+
+unit_tests:
+  - name: test_coderx_packages_uses_open_asset_by_default
+    description: Verifies the default package router uses CodeRx Open and normalizes literal NULL values.
+    model: core__stg_coderx_packages
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: true
+        claims_enabled: false
+        use_proprietary_coderx: false
+    given:
+      - input: ref('terminology__coderx_packages')
+        format: sql
+        rows: |
+          select
+              '00011122233' as ndc11
+            , 'NULL' as ndc
+            , '100' as drug_id
+            , 'Open drug' as drug_name
+            , 'false' as is_brand
+            , '100' as clinical_drug_id
+            , 'Open drug' as clinical_drug_name
+            , 'true' as active
+            , 'true' as prescribable
+    expect:
+      rows:
+        - ndc11: '00011122233'
+          ndc: null
+          drug_id: '100'
+          drug_name: Open drug
+
+  - name: test_coderx_packages_uses_user_managed_source_when_enabled
+    description: Verifies the licensed-data switch routes package reads to coderx.packages.
+    model: core__stg_coderx_packages
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: true
+        claims_enabled: false
+        use_proprietary_coderx: true
+    given:
+      - input: source('coderx', 'packages')
+        format: sql
+        rows: |
+          select
+              '99988877766' as ndc11
+            , '99988-8777-66' as ndc
+            , '900' as drug_id
+            , 'Licensed drug' as drug_name
+            , 'true' as is_brand
+            , '901' as clinical_drug_id
+            , 'Licensed clinical drug' as clinical_drug_name
+            , 'true' as active
+            , 'true' as prescribable
+    expect:
+      rows:
+        - ndc11: '99988877766'
+          ndc: 99988-8777-66
+          drug_id: '900'
+          drug_name: Licensed drug
+
+  - name: test_coderx_drugs_uses_open_asset_by_default
+    description: Verifies the default drug router uses CodeRx Open and normalizes literal NULL values.
+    model: core__stg_coderx_drugs
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: true
+        claims_enabled: false
+        use_proprietary_coderx: false
+    given:
+      - input: ref('terminology__coderx_drugs')
+        format: sql
+        rows: |
+          select
+              '100' as drug_id
+            , 'Open drug' as drug_name
+            , 'false' as is_brand
+            , 'NULL' as clinical_drug_id
+            , 'NULL' as clinical_drug_name
+            , 'true' as active
+            , 'true' as prescribable
+    expect:
+      rows:
+        - drug_id: '100'
+          drug_name: Open drug
+          clinical_drug_id: null
+          clinical_drug_name: null
+
+  - name: test_coderx_drugs_uses_user_managed_source_when_enabled
+    description: Verifies the licensed-data switch routes drug reads to coderx.drugs.
+    model: core__stg_coderx_drugs
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: true
+        claims_enabled: false
+        use_proprietary_coderx: true
+    given:
+      - input: source('coderx', 'drugs')
+        format: sql
+        rows: |
+          select
+              '900' as drug_id
+            , 'Licensed drug' as drug_name
+            , 'true' as is_brand
+            , '901' as clinical_drug_id
+            , 'Licensed clinical drug' as clinical_drug_name
+            , 'true' as active
+            , 'true' as prescribable
+    expect:
+      rows:
+        - drug_id: '900'
+          drug_name: Licensed drug
+          clinical_drug_id: '901'
+          clinical_drug_name: Licensed clinical drug
+
+  - name: test_coderx_classes_uses_open_asset_by_default
+    description: Verifies the default class router uses CodeRx Open and normalizes literal NULL values.
+    model: core__stg_coderx_classes
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: true
+        claims_enabled: false
+        use_proprietary_coderx: false
+    given:
+      - input: ref('terminology__coderx_classes')
+        format: sql
+        rows: |
+          select
+              '100' as drug_id
+            , 'Open drug' as drug_name
+            , 'A' as atc_1_code
+            , 'Alimentary tract and metabolism' as atc_1_name
+            , 'A01' as atc_2_code
+            , 'Stomatological preparations' as atc_2_name
+            , 'A01A' as atc_3_code
+            , 'Stomatological preparations' as atc_3_name
+            , 'NULL' as atc_4_code
+            , 'NULL' as atc_4_name
+    expect:
+      rows:
+        - drug_id: '100'
+          atc_3_code: A01A
+          atc_3_name: Stomatological preparations
+          atc_4_code: null
+          atc_4_name: null
+
+  - name: test_coderx_classes_uses_user_managed_source_when_enabled
+    description: |-
+      Verifies the licensed-data switch routes class reads to coderx.classes and selects one deterministic non-null level 3 class when a drug has multiple class rows.
+    model: core__stg_coderx_classes
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: true
+        claims_enabled: false
+        use_proprietary_coderx: true
+    given:
+      - input: source('coderx', 'classes')
+        format: sql
+        rows: |
+          select
+              '900' as drug_id
+            , 'Licensed drug' as drug_name
+            , 'B' as atc_1_code
+            , 'Blood and blood forming organs' as atc_1_name
+            , 'B01' as atc_2_code
+            , 'Antithrombotic agents' as atc_2_name
+            , 'B01A' as atc_3_code
+            , 'Antithrombotic agents' as atc_3_name
+            , 'B01AA' as atc_4_code
+            , 'Vitamin K antagonists' as atc_4_name
+          union all
+          select
+              '900'
+            , 'Licensed drug'
+            , 'B'
+            , 'Blood and blood forming organs'
+            , 'B02'
+            , 'Antihemorrhagics'
+            , 'B02A'
+            , 'Antifibrinolytics'
+            , 'B02AA'
+            , 'Amino acids'
+    expect:
+      rows:
+        - drug_id: '900'
+          atc_3_code: B01A
+          atc_3_name: Antithrombotic agents
+          atc_4_code: B01AA
+          atc_4_name: Vitamin K antagonists
+
+  - name: test_core_medication_does_not_fall_back_to_open_description_in_licensed_mode
+    description: |-
+      Verifies an unmatched licensed package does not leak the CodeRx Open description carried by core.pharmacy_claim into the normalized NDC description.
+    model: core__medication
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: false
+        claims_enabled: true
+        use_proprietary_coderx: true
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('core__stg_claims_medication')
+        format: sql
+        rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+              'claim_medication' as medication_id
+            , 'claims' as source_type
+            , 'person' as person_id
+            , 'member' as member_id
+            , null as patient_id
+            , null as encounter_id
+            , 'claim' as claim_id
+            , 1 as claim_line_number
+            , 'payer' as payer
+            , 'plan' as {{ plan_identifier }}
+            , cast('2024-01-01' as date) as dispensing_date
+            , cast(null as date) as prescribing_date
+            , 'ndc' as source_code_type
+            , '99999999999' as source_code
+            , 'Open source description' as source_description
+            , '99999999999' as ndc_code
+            , 'Open normalized description' as ndc_description
+            , null as rxnorm_code
+            , null as atc_code
+            , null as route
+            , null as strength
+            , 30 as quantity
+            , null as quantity_unit
+            , 30 as days_supply
+            , null as practitioner_id
+            , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+            , 'source' as data_source
+      - input: ref('core__stg_coderx_packages')
+        format: sql
+        rows: |
+          select
+              '11111111111' as ndc11
+            , null as ndc
+            , '100' as drug_id
+            , 'Licensed drug' as drug_name
+      - input: ref('core__stg_coderx_drugs')
+        format: sql
+        rows: |
+          select 'no_match' as drug_id, 'No match' as drug_name where 1 = 0
+      - input: ref('core__stg_coderx_classes')
+        format: sql
+        rows: |
+          select
+              'no_match' as drug_id
+            , null as atc_1_code
+            , null as atc_1_name
+            , null as atc_2_code
+            , null as atc_2_name
+            , null as atc_3_code
+            , null as atc_3_name
+            , null as atc_4_code
+            , null as atc_4_name
+          where 1 = 0
+    expect:
+      rows:
+        - medication_id: claim_medication
+          source_description: null
+          ndc_code: '99999999999'
+          ndc_description: null
+          rxnorm_code: null
+          rxnorm_description: null
+          atc_code: null
+          atc_description: null

--- a/models/core/coderx_unit_tests.yml
+++ b/models/core/coderx_unit_tests.yml
@@ -10,7 +10,7 @@ unit_tests:
       vars:
         clinical_enabled: true
         claims_enabled: false
-        use_proprietary_coderx: false
+        use_coderx_enterprise: false
     given:
       - input: ref('terminology__coderx_packages')
         format: sql
@@ -33,7 +33,7 @@ unit_tests:
           drug_name: Open drug
 
   - name: test_coderx_packages_uses_user_managed_source_when_enabled
-    description: Verifies the licensed-data switch routes package reads to coderx.packages.
+    description: Verifies the CodeRx Enterprise switch routes package reads to coderx.packages.
     model: core__stg_coderx_packages
     config:
       enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
@@ -41,7 +41,7 @@ unit_tests:
       vars:
         clinical_enabled: true
         claims_enabled: false
-        use_proprietary_coderx: true
+        use_coderx_enterprise: true
     given:
       - input: source('coderx', 'packages')
         format: sql
@@ -50,10 +50,10 @@ unit_tests:
               '99988877766' as ndc11
             , '99988-8777-66' as ndc
             , '900' as drug_id
-            , 'Licensed drug' as drug_name
+            , 'CodeRx Enterprise drug' as drug_name
             , 'true' as is_brand
             , '901' as clinical_drug_id
-            , 'Licensed clinical drug' as clinical_drug_name
+            , 'CodeRx Enterprise clinical drug' as clinical_drug_name
             , 'true' as active
             , 'true' as prescribable
     expect:
@@ -61,7 +61,7 @@ unit_tests:
         - ndc11: '99988877766'
           ndc: 99988-8777-66
           drug_id: '900'
-          drug_name: Licensed drug
+          drug_name: CodeRx Enterprise drug
 
   - name: test_coderx_drugs_uses_open_asset_by_default
     description: Verifies the default drug router uses CodeRx Open and normalizes literal NULL values.
@@ -72,7 +72,7 @@ unit_tests:
       vars:
         clinical_enabled: true
         claims_enabled: false
-        use_proprietary_coderx: false
+        use_coderx_enterprise: false
     given:
       - input: ref('terminology__coderx_drugs')
         format: sql
@@ -93,7 +93,7 @@ unit_tests:
           clinical_drug_name: null
 
   - name: test_coderx_drugs_uses_user_managed_source_when_enabled
-    description: Verifies the licensed-data switch routes drug reads to coderx.drugs.
+    description: Verifies the CodeRx Enterprise switch routes drug reads to coderx.drugs.
     model: core__stg_coderx_drugs
     config:
       enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
@@ -101,25 +101,25 @@ unit_tests:
       vars:
         clinical_enabled: true
         claims_enabled: false
-        use_proprietary_coderx: true
+        use_coderx_enterprise: true
     given:
       - input: source('coderx', 'drugs')
         format: sql
         rows: |
           select
               '900' as drug_id
-            , 'Licensed drug' as drug_name
+            , 'CodeRx Enterprise drug' as drug_name
             , 'true' as is_brand
             , '901' as clinical_drug_id
-            , 'Licensed clinical drug' as clinical_drug_name
+            , 'CodeRx Enterprise clinical drug' as clinical_drug_name
             , 'true' as active
             , 'true' as prescribable
     expect:
       rows:
         - drug_id: '900'
-          drug_name: Licensed drug
+          drug_name: CodeRx Enterprise drug
           clinical_drug_id: '901'
-          clinical_drug_name: Licensed clinical drug
+          clinical_drug_name: CodeRx Enterprise clinical drug
 
   - name: test_coderx_classes_uses_open_asset_by_default
     description: Verifies the default class router uses CodeRx Open and normalizes literal NULL values.
@@ -130,7 +130,7 @@ unit_tests:
       vars:
         clinical_enabled: true
         claims_enabled: false
-        use_proprietary_coderx: false
+        use_coderx_enterprise: false
     given:
       - input: ref('terminology__coderx_classes')
         format: sql
@@ -156,7 +156,7 @@ unit_tests:
 
   - name: test_coderx_classes_uses_user_managed_source_when_enabled
     description: |-
-      Verifies the licensed-data switch routes class reads to coderx.classes and selects one deterministic non-null level 3 class when a drug has multiple class rows.
+      Verifies the CodeRx Enterprise switch routes class reads to coderx.classes and selects one deterministic non-null level 3 class when a drug has multiple class rows.
     model: core__stg_coderx_classes
     config:
       enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
@@ -164,14 +164,14 @@ unit_tests:
       vars:
         clinical_enabled: true
         claims_enabled: false
-        use_proprietary_coderx: true
+        use_coderx_enterprise: true
     given:
       - input: source('coderx', 'classes')
         format: sql
         rows: |
           select
               '900' as drug_id
-            , 'Licensed drug' as drug_name
+            , 'CodeRx Enterprise drug' as drug_name
             , 'B' as atc_1_code
             , 'Blood and blood forming organs' as atc_1_name
             , 'B01' as atc_2_code
@@ -183,7 +183,7 @@ unit_tests:
           union all
           select
               '900'
-            , 'Licensed drug'
+            , 'CodeRx Enterprise drug'
             , 'B'
             , 'Blood and blood forming organs'
             , 'B02'
@@ -200,9 +200,9 @@ unit_tests:
           atc_4_code: B01AA
           atc_4_name: Vitamin K antagonists
 
-  - name: test_core_medication_does_not_fall_back_to_open_description_in_licensed_mode
+  - name: test_core_medication_keeps_unmatched_coderx_enterprise_enrichment_null
     description: |-
-      Verifies an unmatched licensed package does not leak the CodeRx Open description carried by core.pharmacy_claim into the normalized NDC description.
+      Verifies an unmatched CodeRx Enterprise package remains unenriched and does not fall back to CodeRx Open terminology.
     model: core__medication
     config:
       enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
@@ -210,7 +210,7 @@ unit_tests:
       vars:
         clinical_enabled: false
         claims_enabled: true
-        use_proprietary_coderx: true
+        use_coderx_enterprise: true
         tuva_last_run: '2024-01-01 00:00:00'
     given:
       - input: ref('core__stg_claims_medication')
@@ -233,9 +233,9 @@ unit_tests:
             , cast(null as date) as prescribing_date
             , 'ndc' as source_code_type
             , '99999999999' as source_code
-            , 'Open source description' as source_description
+            , 'Stale CodeRx Open source description' as source_description
             , '99999999999' as ndc_code
-            , 'Open normalized description' as ndc_description
+            , 'Stale CodeRx Open normalized description' as ndc_description
             , null as rxnorm_code
             , null as atc_code
             , null as route
@@ -253,7 +253,7 @@ unit_tests:
               '11111111111' as ndc11
             , null as ndc
             , '100' as drug_id
-            , 'Licensed drug' as drug_name
+            , 'CodeRx Enterprise drug' as drug_name
       - input: ref('core__stg_coderx_drugs')
         format: sql
         rows: |
@@ -282,3 +282,159 @@ unit_tests:
           rxnorm_description: null
           atc_code: null
           atc_description: null
+
+  - name: test_core_medication_enriches_matched_coderx_enterprise_package
+    description: |-
+      Verifies a matched CodeRx Enterprise package enriches claims medication with NDC, RxNorm, and ATC codes and descriptions.
+    model: core__medication
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: false
+        claims_enabled: true
+        use_coderx_enterprise: true
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('core__stg_claims_medication')
+        format: sql
+        rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+              'enterprise_claim_medication' as medication_id
+            , 'claims' as source_type
+            , 'person' as person_id
+            , 'member' as member_id
+            , null as patient_id
+            , null as encounter_id
+            , 'claim' as claim_id
+            , 1 as claim_line_number
+            , 'payer' as payer
+            , 'plan' as {{ plan_identifier }}
+            , cast('2024-01-01' as date) as dispensing_date
+            , cast(null as date) as prescribing_date
+            , 'ndc' as source_code_type
+            , '99988877766' as source_code
+            , 'CodeRx Enterprise package drug' as source_description
+            , '99988877766' as ndc_code
+            , 'CodeRx Enterprise package drug' as ndc_description
+            , null as rxnorm_code
+            , null as atc_code
+            , null as route
+            , null as strength
+            , 30 as quantity
+            , null as quantity_unit
+            , 30 as days_supply
+            , null as practitioner_id
+            , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+            , 'source' as data_source
+      - input: ref('core__stg_coderx_packages')
+        format: sql
+        rows: |
+          select
+              '99988877766' as ndc11
+            , '99988-8777-66' as ndc
+            , 'RX900' as drug_id
+            , 'CodeRx Enterprise package drug' as drug_name
+      - input: ref('core__stg_coderx_drugs')
+        format: sql
+        rows: |
+          select
+              'RX900' as drug_id
+            , 'CodeRx Enterprise RxNorm drug' as drug_name
+      - input: ref('core__stg_coderx_classes')
+        format: sql
+        rows: |
+          select
+              'RX900' as drug_id
+            , 'B' as atc_1_code
+            , 'Blood and blood forming organs' as atc_1_name
+            , 'B01' as atc_2_code
+            , 'Antithrombotic agents' as atc_2_name
+            , 'B01A' as atc_3_code
+            , 'Antithrombotic agents' as atc_3_name
+            , 'B01AA' as atc_4_code
+            , 'Vitamin K antagonists' as atc_4_name
+    expect:
+      rows:
+        - medication_id: enterprise_claim_medication
+          source_description: CodeRx Enterprise package drug
+          ndc_code: '99988877766'
+          ndc_description: CodeRx Enterprise package drug
+          rxnorm_code: RX900
+          rxnorm_description: CodeRx Enterprise RxNorm drug
+          atc_code: B01A
+          atc_description: Antithrombotic agents
+
+  - name: test_normalized_pharmacy_claim_uses_coderx_enterprise_package_description
+    description: |-
+      Verifies pharmacy claim normalization obtains its NDC description from the shared CodeRx package interface in Enterprise mode.
+    model: normalized__pharmacy_claim
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        clinical_enabled: false
+        use_coderx_enterprise: true
+        _extension_columns_override: []
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('input_layer__pharmacy_claim')
+        format: sql
+        rows: |
+          select '__not_used__' as claim_id where 1 = 0
+      - input: ref('normalized_input__stg_pharmacy_claim')
+        format: sql
+        rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+              'enterprise_pharmacy_claim' as claim_id
+            , 1 as claim_line_number
+            , 'person' as person_id
+            , 'member' as member_id
+            , 'payer' as payer
+            , 'plan' as {{ plan_identifier }}
+            , null as prescribing_provider_npi
+            , null as dispensing_provider_npi
+            , cast('2024-01-01' as date) as dispensing_date
+            , '99988877766' as ndc_code
+            , 30 as quantity
+            , 30 as days_supply
+            , 0 as refills
+            , cast('2024-01-02' as date) as paid_date
+            , 10 as paid_amount
+            , 12 as allowed_amount
+            , 15 as charge_amount
+            , 1 as coinsurance_amount
+            , 2 as copayment_amount
+            , 3 as deductible_amount
+            , 1 as in_network_flag
+            , 'source' as data_source
+            , 'file.csv' as file_name
+            , cast('2024-01-03 00:00:00' as {{ timestamp_type }}) as file_date
+            , cast('2024-01-04 00:00:00' as {{ timestamp_type }}) as ingest_datetime
+      - input: ref('provider_data__provider')
+        format: sql
+        rows: |
+          select
+              'no_match' as npi
+            , null as entity_type_code
+            , null as provider_last_name
+            , null as provider_first_name
+            , null as provider_organization_name
+          where 1 = 0
+      - input: ref('core__stg_coderx_packages')
+        format: sql
+        rows: |
+          select
+              '99988877766' as ndc11
+            , 'CodeRx Enterprise package drug' as drug_name
+    expect:
+      rows:
+        - claim_id: enterprise_pharmacy_claim
+          claim_line_number: 1
+          ndc_code: '99988877766'
+          ndc_description: CodeRx Enterprise package drug

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -2104,7 +2104,7 @@ models:
     description: |-
       The medication table contains medication records from clinical source systems and pharmacy claims. Clinical rows represent medication orders, administrations, and dispense records documented in an EHR or other clinical system. Claims rows represent adjudicated pharmacy claim lines from core.pharmacy_claim.
 
-      When clinical data is enabled, this model pulls from input_layer__medication through normalized__medication. When claims data is enabled, this model pulls from core.pharmacy_claim through core__stg_claims_medication. Tuva derives NDC, RxNorm, and ATC descriptions from terminology when standard medication codes are available. Claims-derived rows use pharmacy_claim_id as medication_id, set source_type to claims, populate claim_id and claim_line_number from core.pharmacy_claim, and populate practitioner_id from the prescribing provider NPI.
+      When clinical data is enabled, this model pulls from input_layer__medication through normalized__medication. When claims data is enabled, this model pulls from core.pharmacy_claim through core__stg_claims_medication. Tuva derives NDC, RxNorm, and ATC codes and descriptions from the package's CodeRx Open data assets when standard medication codes are available. When `use_proprietary_coderx` is true, the enrichment instead uses user-managed `packages`, `drugs`, and `classes` relations in the target database's `coderx` schema. If CodeRx supplies multiple class rows for a drug, Tuva selects the lexicographically first non-null level 3 ATC code to preserve the medication grain. Claims-derived rows use pharmacy_claim_id as medication_id, set source_type to claims, populate claim_id and claim_line_number from core.pharmacy_claim, and populate practitioner_id from the prescribing provider NPI.
 
       Primary key: medication_id, data_source.
     tests:
@@ -2233,51 +2233,56 @@ models:
       - name: source_description
         description: Medication name or description from the source system. Clinical
           rows are populated from input_layer__medication.source_description.
-          Claims rows are populated from core.pharmacy_claim.ndc_description.
+          Because pharmacy claims do not carry a raw medication description,
+          claims rows are populated from the CodeRx package selected by
+          use_proprietary_coderx when that NDC matches.
         config:
           meta:
             data_type: varchar
       - name: ndc_code
         description: National Drug Code for the medication. Clinical rows may be
           populated from input_layer__medication.ndc_code or derived from
-          terminology. Claims rows are populated from core.pharmacy_claim.ndc_code.
+          CodeRx packages. Claims rows are populated from core.pharmacy_claim.ndc_code.
         config:
           meta:
             terminology: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory
             data_type: varchar
       - name: ndc_description
         description: Medication description associated with ndc_code. This is derived
-          from Tuva NDC terminology when available and may also come from
-          core.pharmacy_claim.ndc_description for claims rows.
+          from the matched CodeRx package when available. The original clinical
+          description remains available in source_description; claims
+          source_description also uses the selected CodeRx package because claims
+          do not supply a raw medication description.
         config:
           meta:
             data_type: varchar
       - name: rxnorm_code
         description: RxNorm RxCUI for the medication. Clinical rows may be populated
-          from input_layer__medication.rxnorm_code or derived from terminology.
-          Claims rows are derived from NDC terminology when available.
+          from input_layer__medication.rxnorm_code or derived from CodeRx drugs.
+          Claims rows are derived through the matched CodeRx package when available.
         config:
           meta:
             terminology: https://www.nlm.nih.gov/research/umls/rxnorm/index.html
             data_type: varchar
       - name: rxnorm_description
         description: Medication description associated with rxnorm_code, derived from
-          RxNorm terminology when available.
+          the matched CodeRx drug when available.
         config:
           meta:
             data_type: varchar
       - name: atc_code
         description: WHO Anatomical Therapeutic Chemical classification code for the
           medication. Clinical rows may be populated from
-          input_layer__medication.atc_code or derived from terminology. Claims rows
-          are derived through NDC/RxNorm terminology when available.
+          input_layer__medication.atc_code or derived from the level 3 CodeRx class.
+          Claims rows are derived through the matched NDC and RxNorm concepts when available.
         config:
           meta:
             terminology: https://www.who.int/tools/atc-ddd-toolkit/atc-classification
             data_type: varchar
       - name: atc_description
         description: Medication classification description associated with atc_code,
-          derived from terminology when available.
+          derived from the matching CodeRx class hierarchy level when an ATC code
+          is supplied, or from the selected level 3 class when Tuva derives the code.
         config:
           meta:
             data_type: varchar
@@ -3068,8 +3073,8 @@ models:
             terminology: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory
             data_type: varchar
       - name: ndc_description
-        description: Description of ndc_code, derived from Tuva NDC terminology when
-          available.
+        description: Description of ndc_code, derived from the bundled CodeRx Open
+          packages terminology when available.
         config:
           meta:
             data_type: varchar
@@ -3510,6 +3515,70 @@ models:
         - core
         - core_stage_claims
       materialized: table
+  - name: core__stg_coderx_classes
+    description: |-
+      Canonical CodeRx drug-class interface used by core.medication and dependent Tuva packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.classes source when use_proprietary_coderx is true. Selects the lexicographically first non-null level 3 ATC code when a drug has multiple class rows, preserving one row per drug_id.
+    columns:
+      - name: drug_id
+        description: RxNorm RxCUI for the classified drug.
+      - name: drug_name
+        description: RxNorm name for the classified drug.
+      - name: atc_1_code
+        description: ATC level 1 code from the selected class hierarchy.
+      - name: atc_1_name
+        description: ATC level 1 name from the selected class hierarchy.
+      - name: atc_2_code
+        description: ATC level 2 code from the selected class hierarchy.
+      - name: atc_2_name
+        description: ATC level 2 name from the selected class hierarchy.
+      - name: atc_3_code
+        description: ATC level 3 code from the selected class hierarchy.
+      - name: atc_3_name
+        description: ATC level 3 name from the selected class hierarchy.
+      - name: atc_4_code
+        description: ATC level 4 code from the selected class hierarchy.
+      - name: atc_4_name
+        description: ATC level 4 name from the selected class hierarchy.
+  - name: core__stg_coderx_drugs
+    description: |-
+      Canonical CodeRx drug interface used by core.medication and dependent Tuva packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.drugs source when use_proprietary_coderx is true.
+    columns:
+      - name: drug_id
+        description: RxNorm RxCUI for the drug concept.
+      - name: drug_name
+        description: RxNorm name for the drug concept.
+      - name: is_brand
+        description: Indicates whether the drug concept is branded.
+      - name: clinical_drug_id
+        description: RxNorm RxCUI for the corresponding unbranded clinical drug.
+      - name: clinical_drug_name
+        description: RxNorm name for the corresponding unbranded clinical drug.
+      - name: active
+        description: Indicates whether the CodeRx record is active.
+      - name: prescribable
+        description: Indicates whether the CodeRx record is prescribable.
+  - name: core__stg_coderx_packages
+    description: |-
+      Canonical CodeRx package interface used by core.medication and dependent Tuva packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.packages source when use_proprietary_coderx is true.
+    columns:
+      - name: ndc11
+        description: Eleven-digit National Drug Code for the package.
+      - name: ndc
+        description: Hyphenated ten-digit National Drug Code when supplied by CodeRx.
+      - name: drug_id
+        description: RxNorm RxCUI for the drug associated with the package.
+      - name: drug_name
+        description: RxNorm name for the drug associated with the package.
+      - name: is_brand
+        description: Indicates whether the drug concept is branded.
+      - name: clinical_drug_id
+        description: RxNorm RxCUI for the corresponding unbranded clinical drug.
+      - name: clinical_drug_name
+        description: RxNorm name for the corresponding unbranded clinical drug.
+      - name: active
+        description: Indicates whether the CodeRx record is active.
+      - name: prescribable
+        description: Indicates whether the CodeRx record is prescribable.
   - name: core__stg_claims_medication
     description: |-
       This model maps core pharmacy claim rows into the medication structure so pharmacy claims can contribute claims-derived rows to core.medication.

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -2104,7 +2104,7 @@ models:
     description: |-
       The medication table contains medication records from clinical source systems and pharmacy claims. Clinical rows represent medication orders, administrations, and dispense records documented in an EHR or other clinical system. Claims rows represent adjudicated pharmacy claim lines from core.pharmacy_claim.
 
-      When clinical data is enabled, this model pulls from input_layer__medication through normalized__medication. When claims data is enabled, this model pulls from core.pharmacy_claim through core__stg_claims_medication. Tuva derives NDC, RxNorm, and ATC codes and descriptions from the package's CodeRx Open data assets when standard medication codes are available. When `use_proprietary_coderx` is true, the enrichment instead uses user-managed `packages`, `drugs`, and `classes` relations in the target database's `coderx` schema. If CodeRx supplies multiple class rows for a drug, Tuva selects the lexicographically first non-null level 3 ATC code to preserve the medication grain. Claims-derived rows use pharmacy_claim_id as medication_id, set source_type to claims, populate claim_id and claim_line_number from core.pharmacy_claim, and populate practitioner_id from the prescribing provider NPI.
+      When clinical data is enabled, this model pulls from input_layer__medication through normalized__medication. When claims data is enabled, this model pulls from core.pharmacy_claim through core__stg_claims_medication. Tuva derives NDC, RxNorm, and ATC codes and descriptions from the package's CodeRx Open data assets when standard medication codes are available. When `use_coderx_enterprise` is true, Tuva's shared CodeRx interfaces instead use user-managed `packages`, `drugs`, and `classes` relations in the target database's `coderx` schema throughout pharmacy normalization, medication enrichment, data quality, and dependent packages. If CodeRx supplies multiple class rows for a drug, Tuva selects the lexicographically first non-null level 3 ATC code to preserve the medication grain. Claims-derived rows use pharmacy_claim_id as medication_id, set source_type to claims, populate claim_id and claim_line_number from core.pharmacy_claim, and populate practitioner_id from the prescribing provider NPI.
 
       Primary key: medication_id, data_source.
     tests:
@@ -2235,7 +2235,7 @@ models:
           rows are populated from input_layer__medication.source_description.
           Because pharmacy claims do not carry a raw medication description,
           claims rows are populated from the CodeRx package selected by
-          use_proprietary_coderx when that NDC matches.
+          use_coderx_enterprise when that NDC matches.
         config:
           meta:
             data_type: varchar
@@ -3517,7 +3517,7 @@ models:
       materialized: table
   - name: core__stg_coderx_classes
     description: |-
-      Canonical CodeRx drug-class interface used by core.medication and dependent Tuva packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.classes source when use_proprietary_coderx is true. Selects the lexicographically first non-null level 3 ATC code when a drug has multiple class rows, preserving one row per drug_id.
+      Canonical CodeRx drug-class interface used throughout Tuva Core and by dependent packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.classes source when use_coderx_enterprise is true. Selects the lexicographically first non-null level 3 ATC code when a drug has multiple class rows, preserving one row per drug_id.
     columns:
       - name: drug_id
         description: RxNorm RxCUI for the classified drug.
@@ -3541,7 +3541,7 @@ models:
         description: ATC level 4 name from the selected class hierarchy.
   - name: core__stg_coderx_drugs
     description: |-
-      Canonical CodeRx drug interface used by core.medication and dependent Tuva packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.drugs source when use_proprietary_coderx is true.
+      Canonical CodeRx drug interface used throughout Tuva Core and by dependent packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.drugs source when use_coderx_enterprise is true.
     columns:
       - name: drug_id
         description: RxNorm RxCUI for the drug concept.
@@ -3559,7 +3559,7 @@ models:
         description: Indicates whether the CodeRx record is prescribable.
   - name: core__stg_coderx_packages
     description: |-
-      Canonical CodeRx package interface used by core.medication and dependent Tuva packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.packages source when use_proprietary_coderx is true.
+      Canonical CodeRx package interface used throughout Tuva Core and by dependent packages. Reads the bundled CodeRx Open asset by default and the user-managed coderx.packages source when use_coderx_enterprise is true.
     columns:
       - name: ndc11
         description: Eleven-digit National Drug Code for the package.

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -3073,7 +3073,7 @@ models:
             terminology: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory
             data_type: varchar
       - name: ndc_description
-        description: Description of ndc_code, derived from the bundled CodeRx Open
+        description: Description of ndc_code, derived from the selected CodeRx
           packages terminology when available.
         config:
           meta:

--- a/models/core/final/core__medication.sql
+++ b/models/core/final/core__medication.sql
@@ -1,17 +1,17 @@
 {{ config(
-     enabled = (var('claims_enabled', False) | as_bool)
-            or (var('clinical_enabled', False) | as_bool)
+     enabled = (var('claims_enabled', false) | as_bool)
+            or (var('clinical_enabled', false) | as_bool)
    )
 }}
 
 {%- set tuva_extension_columns_from_all_medications -%}
-{% if var('clinical_enabled', False) | as_bool %}
+{% if var('clinical_enabled', false) | as_bool %}
     {{ select_extension_columns(ref('normalized__medication'), alias='meds', strip_prefix=false) }}
 {% endif %}
 {%- endset -%}
 
 {%- set tuva_extension_columns_from_source_mapping -%}
-{% if var('clinical_enabled', False) | as_bool %}
+{% if var('clinical_enabled', false) | as_bool %}
     {{ select_extension_columns(ref('normalized__medication'), alias='sm', strip_prefix=false) }}
 {% endif %}
 {%- endset -%}
@@ -21,18 +21,40 @@
    , data_source
 {%- endset -%}
 
-with all_medications as (
-{% if var('clinical_enabled', False) == true
-    and var('claims_enabled', False) == true -%}
+{%- set use_proprietary_coderx = var('use_proprietary_coderx', false) | as_bool -%}
+
+with coderx_package_keys as (
+    select
+          ndc11 as ndc_lookup_code
+        , ndc11
+        , drug_id
+        , drug_name
+    from {{ ref('core__stg_coderx_packages') }}
+
+    union all
+
+    select
+          replace(ndc, '-', '') as ndc_lookup_code
+        , ndc11
+        , drug_id
+        , drug_name
+    from {{ ref('core__stg_coderx_packages') }}
+    where ndc is not null
+      and replace(ndc, '-', '') <> ndc11
+),
+
+all_medications as (
+{% if var('clinical_enabled', false) | as_bool
+    and var('claims_enabled', false) | as_bool -%}
 
     {{ smart_union([ref('core__stg_claims_medication'), ref('normalized__medication')]) }}
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif var('clinical_enabled', false) | as_bool -%}
 
     select *
     from {{ ref('normalized__medication') }}
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif var('claims_enabled', false) | as_bool -%}
 
     select *
     from {{ ref('core__stg_claims_medication') }}
@@ -42,109 +64,100 @@ with all_medications as (
 
 source_mapping as (
     select
-     meds.medication_id
-   , meds.source_type
-   , meds.person_id
-   , meds.member_id
-   , meds.patient_id
-   , meds.encounter_id
-   , meds.claim_id
-   , meds.claim_line_number
-   , meds.payer
-   , meds.{{ quote_column('plan') }}
-   , meds.dispensing_date
-   , meds.prescribing_date
-   , meds.source_code_type
-   , meds.source_code
-   , meds.source_description
-   , coalesce(
-       meds.ndc_code
-       , ndc.ndc
-       ) as ndc_code
-   , coalesce(
-       meds.ndc_description
-       , ndc.fda_description
-       , ndc.rxnorm_description
-       ) as ndc_description
-   , coalesce(
-        meds.rxnorm_code
-        , rxatc.rxcui
-        ) as rxnorm_code
-   , rxatc.rxnorm_description as rxnorm_description
-   , coalesce(
-        meds.atc_code
-        , rxatc.atc_3_code
-        ) as atc_code
-   , rxatc.atc_4_name as atc_description
-   , meds.route
-   , meds.strength
-   , meds.quantity
-   , meds.quantity_unit
-   , meds.days_supply
-   , meds.practitioner_id
-   , meds.data_source
-   , meds.tuva_last_run
-   {{ tuva_extension_columns_from_all_medications }}
-from all_medications as meds
-    left outer join {{ ref('terminology__ndc') }} as ndc
-        on lower(meds.source_code_type) = 'ndc'
-        and replace(meds.source_code, '-', '') = replace(ndc.ndc, '-', '')
-    left outer join {{ ref('terminology__rxnorm_to_atc') }} as rxatc
-        on lower(meds.source_code_type) = 'rxnorm'
-        and meds.source_code = rxatc.rxcui
-   )
+          meds.medication_id
+        , meds.source_type
+        , meds.person_id
+        , meds.member_id
+        , meds.patient_id
+        , meds.encounter_id
+        , meds.claim_id
+        , meds.claim_line_number
+        , meds.payer
+        , meds.{{ quote_column('plan') }}
+        , meds.dispensing_date
+        , meds.prescribing_date
+        , meds.source_code_type
+        , meds.source_code
+        , case
+            when lower(cast(meds.source_type as {{ dbt.type_string() }})) = 'claims'
+              then source_package.drug_name
+            else meds.source_description
+          end as source_description
+        , coalesce(meds.ndc_code, source_package.ndc11) as ndc_code
+        , meds.ndc_description
+        , coalesce(meds.rxnorm_code, source_drug.drug_id) as rxnorm_code
+        , meds.atc_code
+        , meds.route
+        , meds.strength
+        , meds.quantity
+        , meds.quantity_unit
+        , meds.days_supply
+        , meds.practitioner_id
+        , meds.data_source
+        , meds.tuva_last_run
+        {{ tuva_extension_columns_from_all_medications }}
+    from all_medications as meds
+    left join coderx_package_keys as source_package
+        on lower(cast(meds.source_code_type as {{ dbt.type_string() }})) = 'ndc'
+       and replace(cast(meds.source_code as {{ dbt.type_string() }}), '-', '')
+           = source_package.ndc_lookup_code
+    left join {{ ref('core__stg_coderx_drugs') }} as source_drug
+        on lower(cast(meds.source_code_type as {{ dbt.type_string() }})) = 'rxnorm'
+       and cast(meds.source_code as {{ dbt.type_string() }}) = source_drug.drug_id
+)
 
-
--- add auto rxnorm + atc
 select
-     sm.medication_id
-   , sm.source_type
-   , sm.person_id
-   , sm.member_id
-   , sm.patient_id
-   , sm.encounter_id
-   , sm.claim_id
-   , sm.claim_line_number
-   , sm.payer
-   , sm.{{ quote_column('plan') }}
-   , sm.dispensing_date
-   , sm.prescribing_date
-   , sm.source_code_type
-   , sm.source_code
-   , sm.source_description
-   , sm.ndc_code
-   , coalesce(
-        sm.ndc_description
-        , ndc.fda_description
-        , ndc.rxnorm_description
-        ) as ndc_description
-   , coalesce(
-        sm.rxnorm_code
-        , ndc.rxcui
-        ) as rxnorm_code
-   , coalesce(
-        sm.rxnorm_description
-        , ndc.rxnorm_description
-        , rxatc.rxnorm_description
-        ) as rxnorm_description
-   , coalesce(
-        sm.atc_code
-        , rxatc.atc_3_code
-        ) as atc_code
-   , coalesce(
-        sm.atc_description
-        , rxatc.atc_3_name
-        ) as atc_description
-   , sm.route
-   , sm.strength
-   , sm.quantity
-   , sm.quantity_unit
-   , sm.days_supply
-   , sm.practitioner_id
-   {{ tuva_extension_columns_from_source_mapping }}
-   {{ tuva_metadata_columns }}
+      sm.medication_id
+    , sm.source_type
+    , sm.person_id
+    , sm.member_id
+    , sm.patient_id
+    , sm.encounter_id
+    , sm.claim_id
+    , sm.claim_line_number
+    , sm.payer
+    , sm.{{ quote_column('plan') }}
+    , sm.dispensing_date
+    , sm.prescribing_date
+    , sm.source_code_type
+    , sm.source_code
+    , sm.source_description
+    , sm.ndc_code
+    , coalesce(
+          case
+            when coalesce(lower(sm.source_type), '') <> 'claims' then sm.ndc_description
+          end
+        , ndc_package.drug_name
+        {% if not use_proprietary_coderx %}
+        , sm.ndc_description
+        {% endif %}
+      ) as ndc_description
+    , coalesce(sm.rxnorm_code, ndc_package.drug_id) as rxnorm_code
+    , case
+        when sm.rxnorm_code is not null then rxnorm_drug.drug_name
+        else coalesce(rxnorm_drug.drug_name, ndc_package.drug_name)
+      end as rxnorm_description
+    , coalesce(sm.atc_code, drug_class.atc_3_code) as atc_code
+    , case
+        when sm.atc_code is null then drug_class.atc_3_name
+        when sm.atc_code = drug_class.atc_1_code then drug_class.atc_1_name
+        when sm.atc_code = drug_class.atc_2_code then drug_class.atc_2_name
+        when sm.atc_code = drug_class.atc_3_code then drug_class.atc_3_name
+        when sm.atc_code = drug_class.atc_4_code then drug_class.atc_4_name
+      end as atc_description
+    , sm.route
+    , sm.strength
+    , sm.quantity
+    , sm.quantity_unit
+    , sm.days_supply
+    , sm.practitioner_id
+    {{ tuva_extension_columns_from_source_mapping }}
+    {{ tuva_metadata_columns }}
 from source_mapping as sm
-    left outer join {{ ref('terminology__ndc') }} as ndc
-        on replace(sm.ndc_code, '-', '') = replace(ndc.ndc, '-', '')
-    left outer join {{ ref('terminology__rxnorm_to_atc') }} as rxatc
-        on coalesce(sm.rxnorm_code, ndc.rxcui) = rxatc.rxcui
+left join coderx_package_keys as ndc_package
+    on replace(cast(sm.ndc_code as {{ dbt.type_string() }}), '-', '')
+       = ndc_package.ndc_lookup_code
+left join {{ ref('core__stg_coderx_drugs') }} as rxnorm_drug
+    on coalesce(sm.rxnorm_code, ndc_package.drug_id) = rxnorm_drug.drug_id
+left join {{ ref('core__stg_coderx_classes') }} as drug_class
+    on coalesce(sm.rxnorm_code, ndc_package.drug_id) = drug_class.drug_id

--- a/models/core/final/core__medication.sql
+++ b/models/core/final/core__medication.sql
@@ -21,7 +21,7 @@
    , data_source
 {%- endset -%}
 
-{%- set use_proprietary_coderx = var('use_proprietary_coderx', false) | as_bool -%}
+{%- set use_coderx_enterprise = var('use_coderx_enterprise', false) | as_bool -%}
 
 with coderx_package_keys as (
     select
@@ -128,7 +128,7 @@ select
             when coalesce(lower(sm.source_type), '') <> 'claims' then sm.ndc_description
           end
         , ndc_package.drug_name
-        {% if not use_proprietary_coderx %}
+        {% if not use_coderx_enterprise %}
         , sm.ndc_description
         {% endif %}
       ) as ndc_description

--- a/models/core/final/core__pharmacy_claim.sql
+++ b/models/core/final/core__pharmacy_claim.sql
@@ -3,6 +3,8 @@
    )
 }}
 
+{%- set coderx_name_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar(3000)' -%}
+
 {%- set tuva_core_columns -%}
        {{ concat_custom([
         "cast(pharm.claim_id as " ~ dbt.type_string() ~ ")",
@@ -23,7 +25,7 @@
        , cast(pharm.dispensing_provider_name as {{ dbt.type_string() }}) as dispensing_provider_name
        , {{ try_to_cast_date('pharm.dispensing_date') }} as dispensing_date
        , cast(pharm.ndc_code as {{ dbt.type_string() }}) as ndc_code
-       , cast(pharm.ndc_description as {{ dbt.type_string() }}) as ndc_description
+       , cast(pharm.ndc_description as {{ coderx_name_type }}) as ndc_description
        , cast(pharm.quantity as {{ dbt.type_int() }}) as quantity
        , cast(pharm.days_supply as {{ dbt.type_int() }}) as days_supply
        , cast(pharm.refills as {{ dbt.type_int() }}) as refills

--- a/models/core/staging/core__stg_claims_medication.sql
+++ b/models/core/staging/core__stg_claims_medication.sql
@@ -3,6 +3,8 @@
    )
 }}
 
+{%- set coderx_name_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar(3000)' -%}
+
 select
       cast(pharmacy_claim_id as {{ dbt.type_string() }}) as medication_id
     , cast('claims' as {{ dbt.type_string() }}) as source_type
@@ -18,9 +20,9 @@ select
     , cast(null as date) as prescribing_date
     , cast('ndc' as {{ dbt.type_string() }}) as source_code_type
     , cast(ndc_code as {{ dbt.type_string() }}) as source_code
-    , cast(ndc_description as {{ dbt.type_string() }}) as source_description
+    , cast(ndc_description as {{ coderx_name_type }}) as source_description
     , cast(ndc_code as {{ dbt.type_string() }}) as ndc_code
-    , cast(ndc_description as {{ dbt.type_string() }}) as ndc_description
+    , cast(ndc_description as {{ coderx_name_type }}) as ndc_description
     , cast(null as {{ dbt.type_string() }}) as rxnorm_code
     , cast(null as {{ dbt.type_string() }}) as atc_code
     , cast(null as {{ dbt.type_string() }}) as route

--- a/models/core/staging/core__stg_coderx_classes.sql
+++ b/models/core/staging/core__stg_coderx_classes.sql
@@ -1,0 +1,61 @@
+{{ config(
+     enabled = (var('claims_enabled', false) | as_bool)
+            or (var('clinical_enabled', false) | as_bool),
+     materialized = 'ephemeral'
+   )
+}}
+
+{%- set coderx_name_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar(3000)' -%}
+
+with source_rows as (
+    select
+          nullif(cast(drug_id as {{ dbt.type_string() }}), 'NULL') as drug_id
+        , nullif(cast(drug_name as {{ coderx_name_type }}), 'NULL') as drug_name
+        , nullif(cast(atc_1_code as {{ dbt.type_string() }}), 'NULL') as atc_1_code
+        , nullif(cast(atc_1_name as {{ dbt.type_string() }}), 'NULL') as atc_1_name
+        , nullif(cast(atc_2_code as {{ dbt.type_string() }}), 'NULL') as atc_2_code
+        , nullif(cast(atc_2_name as {{ dbt.type_string() }}), 'NULL') as atc_2_name
+        , nullif(cast(atc_3_code as {{ dbt.type_string() }}), 'NULL') as atc_3_code
+        , nullif(cast(atc_3_name as {{ dbt.type_string() }}), 'NULL') as atc_3_name
+        , nullif(cast(atc_4_code as {{ dbt.type_string() }}), 'NULL') as atc_4_code
+        , nullif(cast(atc_4_name as {{ dbt.type_string() }}), 'NULL') as atc_4_name
+    {% if var('use_proprietary_coderx', false) | as_bool %}
+    from {{ source('coderx', 'classes') }}
+    {% else %}
+    from {{ ref('terminology__coderx_classes') }}
+    {% endif %}
+),
+
+ranked as (
+    select
+          *
+        , row_number() over (
+              partition by drug_id
+              order by
+                    case when atc_3_code is null then 1 else 0 end
+                  , coalesce(atc_3_code, '')
+                  , coalesce(atc_3_name, '')
+                  , coalesce(atc_4_code, '')
+                  , coalesce(atc_4_name, '')
+                  , coalesce(atc_2_code, '')
+                  , coalesce(atc_2_name, '')
+                  , coalesce(atc_1_code, '')
+                  , coalesce(atc_1_name, '')
+                  , coalesce(drug_name, '')
+          ) as class_rank
+    from source_rows
+)
+
+select
+      drug_id
+    , drug_name
+    , atc_1_code
+    , atc_1_name
+    , atc_2_code
+    , atc_2_name
+    , atc_3_code
+    , atc_3_name
+    , atc_4_code
+    , atc_4_name
+from ranked
+where class_rank = 1

--- a/models/core/staging/core__stg_coderx_classes.sql
+++ b/models/core/staging/core__stg_coderx_classes.sql
@@ -19,7 +19,7 @@ with source_rows as (
         , nullif(cast(atc_3_name as {{ dbt.type_string() }}), 'NULL') as atc_3_name
         , nullif(cast(atc_4_code as {{ dbt.type_string() }}), 'NULL') as atc_4_code
         , nullif(cast(atc_4_name as {{ dbt.type_string() }}), 'NULL') as atc_4_name
-    {% if var('use_proprietary_coderx', false) | as_bool %}
+    {% if var('use_coderx_enterprise', false) | as_bool %}
     from {{ source('coderx', 'classes') }}
     {% else %}
     from {{ ref('terminology__coderx_classes') }}

--- a/models/core/staging/core__stg_coderx_drugs.sql
+++ b/models/core/staging/core__stg_coderx_drugs.sql
@@ -15,7 +15,7 @@ select
     , nullif(cast(clinical_drug_name as {{ coderx_name_type }}), 'NULL') as clinical_drug_name
     , nullif(cast(active as {{ dbt.type_string() }}), 'NULL') as active
     , nullif(cast(prescribable as {{ dbt.type_string() }}), 'NULL') as prescribable
-{% if var('use_proprietary_coderx', false) | as_bool %}
+{% if var('use_coderx_enterprise', false) | as_bool %}
 from {{ source('coderx', 'drugs') }}
 {% else %}
 from {{ ref('terminology__coderx_drugs') }}

--- a/models/core/staging/core__stg_coderx_drugs.sql
+++ b/models/core/staging/core__stg_coderx_drugs.sql
@@ -1,0 +1,22 @@
+{{ config(
+     enabled = (var('claims_enabled', false) | as_bool)
+            or (var('clinical_enabled', false) | as_bool),
+     materialized = 'ephemeral'
+   )
+}}
+
+{%- set coderx_name_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar(3000)' -%}
+
+select
+      nullif(cast(drug_id as {{ dbt.type_string() }}), 'NULL') as drug_id
+    , nullif(cast(drug_name as {{ coderx_name_type }}), 'NULL') as drug_name
+    , nullif(cast(is_brand as {{ dbt.type_string() }}), 'NULL') as is_brand
+    , nullif(cast(clinical_drug_id as {{ dbt.type_string() }}), 'NULL') as clinical_drug_id
+    , nullif(cast(clinical_drug_name as {{ coderx_name_type }}), 'NULL') as clinical_drug_name
+    , nullif(cast(active as {{ dbt.type_string() }}), 'NULL') as active
+    , nullif(cast(prescribable as {{ dbt.type_string() }}), 'NULL') as prescribable
+{% if var('use_proprietary_coderx', false) | as_bool %}
+from {{ source('coderx', 'drugs') }}
+{% else %}
+from {{ ref('terminology__coderx_drugs') }}
+{% endif %}

--- a/models/core/staging/core__stg_coderx_packages.sql
+++ b/models/core/staging/core__stg_coderx_packages.sql
@@ -17,7 +17,7 @@ select
     , nullif(cast(clinical_drug_name as {{ coderx_name_type }}), 'NULL') as clinical_drug_name
     , nullif(cast(active as {{ dbt.type_string() }}), 'NULL') as active
     , nullif(cast(prescribable as {{ dbt.type_string() }}), 'NULL') as prescribable
-{% if var('use_proprietary_coderx', false) | as_bool %}
+{% if var('use_coderx_enterprise', false) | as_bool %}
 from {{ source('coderx', 'packages') }}
 {% else %}
 from {{ ref('terminology__coderx_packages') }}

--- a/models/core/staging/core__stg_coderx_packages.sql
+++ b/models/core/staging/core__stg_coderx_packages.sql
@@ -1,0 +1,24 @@
+{{ config(
+     enabled = (var('claims_enabled', false) | as_bool)
+            or (var('clinical_enabled', false) | as_bool),
+     materialized = 'ephemeral'
+   )
+}}
+
+{%- set coderx_name_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar(3000)' -%}
+
+select
+      nullif(cast(ndc11 as {{ dbt.type_string() }}), 'NULL') as ndc11
+    , nullif(cast(ndc as {{ dbt.type_string() }}), 'NULL') as ndc
+    , nullif(cast(drug_id as {{ dbt.type_string() }}), 'NULL') as drug_id
+    , nullif(cast(drug_name as {{ coderx_name_type }}), 'NULL') as drug_name
+    , nullif(cast(is_brand as {{ dbt.type_string() }}), 'NULL') as is_brand
+    , nullif(cast(clinical_drug_id as {{ dbt.type_string() }}), 'NULL') as clinical_drug_id
+    , nullif(cast(clinical_drug_name as {{ coderx_name_type }}), 'NULL') as clinical_drug_name
+    , nullif(cast(active as {{ dbt.type_string() }}), 'NULL') as active
+    , nullif(cast(prescribable as {{ dbt.type_string() }}), 'NULL') as prescribable
+{% if var('use_proprietary_coderx', false) | as_bool %}
+from {{ source('coderx', 'packages') }}
+{% else %}
+from {{ ref('terminology__coderx_packages') }}
+{% endif %}

--- a/models/data_quality/logical/claims_logical_unit_tests.yml
+++ b/models/data_quality/logical/claims_logical_unit_tests.yml
@@ -290,7 +290,7 @@ unit_tests:
         format: sql
         rows: |
           select 'valid_npi' as npi
-      - input: ref('terminology__coderx_packages')
+      - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
           select 'valid_ndc' as ndc11, null as ndc
@@ -382,7 +382,7 @@ unit_tests:
         format: sql
         rows: |
           select 'valid_npi' as npi
-      - input: ref('terminology__coderx_packages')
+      - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
           select 'valid_ndc' as ndc11, null as ndc

--- a/models/data_quality/logical/claims_logical_unit_tests.yml
+++ b/models/data_quality/logical/claims_logical_unit_tests.yml
@@ -290,10 +290,10 @@ unit_tests:
         format: sql
         rows: |
           select 'valid_npi' as npi
-      - input: ref('terminology__ndc')
+      - input: ref('terminology__coderx_packages')
         format: sql
         rows: |
-          select 'valid_ndc' as ndc
+          select 'valid_ndc' as ndc11, null as ndc
     expect:
       rows:
         - claim_id: missing_values
@@ -382,10 +382,10 @@ unit_tests:
         format: sql
         rows: |
           select 'valid_npi' as npi
-      - input: ref('terminology__ndc')
+      - input: ref('terminology__coderx_packages')
         format: sql
         rows: |
-          select 'valid_ndc' as ndc
+          select 'valid_ndc' as ndc11, null as ndc
     expect:
       rows:
         - claim_id: paid_month_match

--- a/models/data_quality/logical/clinical_semantic_unit_tests.yml
+++ b/models/data_quality/logical/clinical_semantic_unit_tests.yml
@@ -859,7 +859,7 @@ unit_tests:
         format: sql
         rows: |
           select 'cross_practitioner' as practitioner_id, 'source' as data_source
-      - input: ref('terminology__coderx_packages')
+      - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
           select '12345678901' as ndc11, '12345-6789-01' as ndc

--- a/models/data_quality/logical/clinical_semantic_unit_tests.yml
+++ b/models/data_quality/logical/clinical_semantic_unit_tests.yml
@@ -824,6 +824,10 @@ unit_tests:
             , 'ndc', '99999-9999-99', '99999-9999-99', null, null
             , cast(null as decimal(18, 2)), cast(null as decimal(18, 2)), 'source'
           union all
+          select 'ndc_literal_null', 'p1', 'a1', null, null, cast(null as date), cast(null as date)
+            , 'ndc', 'NULL', 'NULL', null, null
+            , cast(null as decimal(18, 2)), cast(null as decimal(18, 2)), 'source'
+          union all
           select 'cross_source_patient_pair', 'cross_person_patient', 'cross_patient_patient', null
             , null, cast(null as date), cast(null as date), null, null, null, null, null
             , cast(null as decimal(18, 2)), cast(null as decimal(18, 2)), 'source_b'
@@ -855,10 +859,12 @@ unit_tests:
         format: sql
         rows: |
           select 'cross_practitioner' as practitioner_id, 'source' as data_source
-      - input: ref('terminology__ndc')
+      - input: ref('terminology__coderx_packages')
         format: sql
         rows: |
-          select '12345678901' as ndc
+          select '12345678901' as ndc11, '12345-6789-01' as ndc
+          union all
+          select '00000000000', 'NULL'
     expect:
       rows:
         - medication_id: pair_fail
@@ -910,6 +916,14 @@ unit_tests:
           source_code_invalid: 0
           ndc_code_invalid: 0
         - medication_id: ndc_invalid
+          person_patient_pair_not_in_patient: 0
+          encounter_person_patient_pair_not_in_encounter: null
+          practitioner_id_not_in_practitioner: null
+          source_code_type_null_when_source_code_present: 0
+          source_code_null: 0
+          source_code_invalid: 1
+          ndc_code_invalid: 1
+        - medication_id: ndc_literal_null
           person_patient_pair_not_in_patient: 0
           encounter_person_patient_pair_not_in_encounter: null
           practitioner_id_not_in_practitioner: null
@@ -1252,7 +1266,8 @@ unit_tests:
   - name: test_core_medication_matches_code_types_and_ndc_format_consistently
     description: >
       Verifies case-insensitive NDC and RxNorm source-type matching, hyphen-free
-      NDC lookup comparison, and preservation of raw source fields.
+      NDC lookup comparison, CodeRx enrichment through ATC level 3, and
+      preservation of raw source fields.
     model: core__medication
     config:
       enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
@@ -1302,23 +1317,55 @@ unit_tests:
             , 'RXNORM', 'R1', 'Raw RxNorm description', null, null, null, null
             , null, null, cast(null as integer), null, cast(null as integer), null
             , 'source', cast('2024-01-01 00:00:00' as {{ timestamp_type }})
-      - input: ref('terminology__ndc')
+          union all
+          select 'explicit_atc', 'clinical', 'p1', null, 'a1', null, null
+            , cast(null as integer), null, null, cast(null as date), cast(null as date)
+            , 'RXNORM', 'R3', 'Raw explicit ATC description', null, null, null, 'C01AA'
+            , null, null, cast(null as integer), null, cast(null as integer), null
+            , 'source', cast('2024-01-01 00:00:00' as {{ timestamp_type }})
+          union all
+          select 'conflicting_explicit_rxnorm', 'clinical', 'p1', null, 'a1', null, null
+            , cast(null as integer), null, null, cast(null as date), cast(null as date)
+            , 'NDC', '12345-6789-01', 'Raw conflicting RxNorm description', null, null, 'R404', null
+            , null, null, cast(null as integer), null, cast(null as integer), null
+            , 'source', cast('2024-01-01 00:00:00' as {{ timestamp_type }})
+      - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
           select
-              '12345678901' as ndc
-            , 'NDC description' as fda_description
-            , null as rxnorm_description
-            , null as rxcui
-      - input: ref('terminology__rxnorm_to_atc')
+              '12345678901' as ndc11
+            , '12345-6789-01' as ndc
+            , 'R2' as drug_id
+            , 'NDC drug description' as drug_name
+      - input: ref('core__stg_coderx_drugs')
         format: sql
         rows: |
           select
-              'R1' as rxcui
-            , 'RxNorm description' as rxnorm_description
+              'R1' as drug_id
+            , 'RxNorm description' as drug_name
+          union all
+          select 'R2', 'NDC drug description'
+          union all
+          select 'R3', 'Explicit ATC drug description'
+      - input: ref('core__stg_coderx_classes')
+        format: sql
+        rows: |
+          select
+              'R1' as drug_id
+            , 'A' as atc_1_code
+            , 'Alimentary tract and metabolism' as atc_1_name
+            , 'A01' as atc_2_code
+            , 'Stomatological preparations' as atc_2_name
             , 'A3' as atc_3_code
-            , 'ATC level 4' as atc_4_name
             , 'ATC level 3' as atc_3_name
+            , 'A3A' as atc_4_code
+            , 'ATC level 4' as atc_4_name
+          union all
+          select 'R2', 'B', 'Blood and blood forming organs', 'B01', 'Antithrombotic agents'
+            , 'B3', 'NDC ATC level 3', 'B3A', 'NDC ATC level 4'
+          union all
+          select 'R3', 'C', 'Cardiovascular system', 'C01', 'Cardiac therapy'
+            , 'C01A', 'Cardiac glycosides', 'C01AA', 'Digitalis glycosides'
     expect:
       rows:
         - medication_id: ndc_case
@@ -1326,10 +1373,11 @@ unit_tests:
           source_code: 12345-6789-01
           source_description: Raw NDC description
           ndc_code: '12345678901'
-          ndc_description: NDC description
-          rxnorm_code: null
-          rxnorm_description: null
-          atc_code: null
+          ndc_description: NDC drug description
+          rxnorm_code: R2
+          rxnorm_description: NDC drug description
+          atc_code: B3
+          atc_description: NDC ATC level 3
         - medication_id: rxnorm_case
           source_code_type: RXNORM
           source_code: R1
@@ -1339,3 +1387,24 @@ unit_tests:
           rxnorm_code: R1
           rxnorm_description: RxNorm description
           atc_code: A3
+          atc_description: ATC level 3
+        - medication_id: explicit_atc
+          source_code_type: RXNORM
+          source_code: R3
+          source_description: Raw explicit ATC description
+          ndc_code: null
+          ndc_description: null
+          rxnorm_code: R3
+          rxnorm_description: Explicit ATC drug description
+          atc_code: C01AA
+          atc_description: Digitalis glycosides
+        - medication_id: conflicting_explicit_rxnorm
+          source_code_type: NDC
+          source_code: 12345-6789-01
+          source_description: Raw conflicting RxNorm description
+          ndc_code: '12345678901'
+          ndc_description: NDC drug description
+          rxnorm_code: R404
+          rxnorm_description: null
+          atc_code: null
+          atc_description: null

--- a/models/data_quality/logical/data_quality__medication_flags.sql
+++ b/models/data_quality/logical/data_quality__medication_flags.sql
@@ -67,13 +67,13 @@ practitioner_rows as (
 ndc_rows as (
     select distinct
           ndc11 as ndc_lookup_code
-    from {{ ref('terminology__coderx_packages') }}
+    from {{ ref('core__stg_coderx_packages') }}
 
     union
 
     select distinct
           replace(nullif(ndc, 'NULL'), '-', '') as ndc_lookup_code
-    from {{ ref('terminology__coderx_packages') }}
+    from {{ ref('core__stg_coderx_packages') }}
     where nullif(ndc, 'NULL') is not null
 ),
 

--- a/models/data_quality/logical/data_quality__medication_flags.sql
+++ b/models/data_quality/logical/data_quality__medication_flags.sql
@@ -66,8 +66,15 @@ practitioner_rows as (
 
 ndc_rows as (
     select distinct
-          ndc
-    from {{ ref('terminology__ndc') }}
+          ndc11 as ndc_lookup_code
+    from {{ ref('terminology__coderx_packages') }}
+
+    union
+
+    select distinct
+          replace(nullif(ndc, 'NULL'), '-', '') as ndc_lookup_code
+    from {{ ref('terminology__coderx_packages') }}
+    where nullif(ndc, 'NULL') is not null
 ),
 
 final as (
@@ -125,11 +132,11 @@ final as (
         , {{ dq_logical_int_flag_sql(
               "source_rows.source_code is not null "
               ~ "and lower(cast(source_rows.source_code_type as " ~ string_type ~ ")) = 'ndc' "
-              ~ "and source_ndc_rows.ndc is null",
+              ~ "and source_ndc_rows.ndc_lookup_code is null",
               "source_rows.source_code is not null "
               ~ "and lower(cast(source_rows.source_code_type as " ~ string_type ~ ")) = 'ndc'"
           ) }} as source_code_invalid
-        , {{ dq_logical_int_flag_sql("source_rows.ndc_code is not null and ndc_rows.ndc is null", "source_rows.ndc_code is not null") }} as ndc_code_invalid
+        , {{ dq_logical_int_flag_sql("source_rows.ndc_code is not null and ndc_rows.ndc_lookup_code is null", "source_rows.ndc_code is not null") }} as ndc_code_invalid
         , {{ dq_logical_int_flag_sql("source_rows.quantity is not null and source_rows.quantity < 0", "source_rows.quantity is not null") }} as quantity_negative
         , {{ dq_logical_int_flag_sql("source_rows.days_supply is not null and source_rows.days_supply < 0", "source_rows.days_supply is not null") }} as days_supply_negative
     from source_rows
@@ -155,10 +162,12 @@ final as (
         on source_rows.practitioner_id = practitioner_rows.practitioner_id
        and source_rows.data_source = practitioner_rows.data_source
     left join ndc_rows as source_ndc_rows
-        on replace(cast(source_rows.source_code as {{ string_type }}), '-', '') = replace(cast(source_ndc_rows.ndc as {{ string_type }}), '-', '')
+        on replace(cast(source_rows.source_code as {{ string_type }}), '-', '')
+           = cast(source_ndc_rows.ndc_lookup_code as {{ string_type }})
        and lower(cast(source_rows.source_code_type as {{ string_type }})) = 'ndc'
     left join ndc_rows
-        on replace(cast(source_rows.ndc_code as {{ string_type }}), '-', '') = replace(cast(ndc_rows.ndc as {{ string_type }}), '-', '')
+        on replace(cast(source_rows.ndc_code as {{ string_type }}), '-', '')
+           = cast(ndc_rows.ndc_lookup_code as {{ string_type }})
 )
 
 select *

--- a/models/data_quality/logical/data_quality__pharmacy_claim_line_flags.sql
+++ b/models/data_quality/logical/data_quality__pharmacy_claim_line_flags.sql
@@ -81,7 +81,7 @@ final as (
           ) }} as dispensing_provider_npi_invalid
         , {{ dq_logical_int_flag_sql("source_rows.ndc_code is null", "1 = 1") }} as ndc_code_null
         , {{ dq_logical_int_flag_sql(
-            "ndc_lookup.ndc is null",
+            "ndc_lookup.ndc11 is null",
             "source_rows.ndc_code is not null"
           ) }} as ndc_code_invalid
         , {{ dq_logical_int_flag_sql("source_rows.quantity is null", "1 = 1") }} as quantity_null
@@ -121,8 +121,9 @@ final as (
         on cast(source_rows.prescribing_provider_npi as {{ string_type }}) = cast(prescribing_provider_lookup.npi as {{ string_type }})
     left join {{ ref('provider_data__provider') }} as dispensing_provider_lookup
         on cast(source_rows.dispensing_provider_npi as {{ string_type }}) = cast(dispensing_provider_lookup.npi as {{ string_type }})
-    left join {{ ref('terminology__ndc') }} as ndc_lookup
-        on cast(source_rows.ndc_code as {{ string_type }}) = cast(ndc_lookup.ndc as {{ string_type }})
+    left join {{ ref('terminology__coderx_packages') }} as ndc_lookup
+        on cast(source_rows.ndc_code as {{ string_type }})
+           = cast(ndc_lookup.ndc11 as {{ string_type }})
 )
 
 select *

--- a/models/data_quality/logical/data_quality__pharmacy_claim_line_flags.sql
+++ b/models/data_quality/logical/data_quality__pharmacy_claim_line_flags.sql
@@ -121,7 +121,7 @@ final as (
         on cast(source_rows.prescribing_provider_npi as {{ string_type }}) = cast(prescribing_provider_lookup.npi as {{ string_type }})
     left join {{ ref('provider_data__provider') }} as dispensing_provider_lookup
         on cast(source_rows.dispensing_provider_npi as {{ string_type }}) = cast(dispensing_provider_lookup.npi as {{ string_type }})
-    left join {{ ref('terminology__coderx_packages') }} as ndc_lookup
+    left join {{ ref('core__stg_coderx_packages') }} as ndc_lookup
         on cast(source_rows.ndc_code as {{ string_type }})
            = cast(ndc_lookup.ndc11 as {{ string_type }})
 )

--- a/models/normalized_layer/final/normalized__pharmacy_claim.sql
+++ b/models/normalized_layer/final/normalized__pharmacy_claim.sql
@@ -60,5 +60,5 @@ left outer join {{ ref('provider_data__provider') }} as pres
       on pharm.prescribing_provider_npi = pres.npi
 left outer join {{ ref('provider_data__provider') }} as disp
       on pharm.dispensing_provider_npi = disp.npi
-left outer join {{ ref('terminology__coderx_packages') }} as coderx_packages
+left outer join {{ ref('core__stg_coderx_packages') }} as coderx_packages
       on cast(pharm.ndc_code as {{ dbt.type_string() }}) = coderx_packages.ndc11

--- a/models/normalized_layer/final/normalized__pharmacy_claim.sql
+++ b/models/normalized_layer/final/normalized__pharmacy_claim.sql
@@ -4,6 +4,7 @@
    )
 }}
 
+{%- set coderx_name_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar(3000)' -%}
 
 select
       cast(claim_id as {{ dbt.type_string() }}) as claim_id
@@ -36,7 +37,7 @@ select
     end as dispensing_provider_name
     , cast(dispensing_date as date) as dispensing_date
     , cast(ndc_code as {{ dbt.type_string() }}) as ndc_code
-    , cast(ndc.fda_description as {{ dbt.type_string() }}) as ndc_description
+    , cast(coderx_packages.drug_name as {{ coderx_name_type }}) as ndc_description
     , cast(quantity as int) as quantity
     , cast(days_supply as int) as days_supply
     , cast(refills as int) as refills
@@ -59,5 +60,5 @@ left outer join {{ ref('provider_data__provider') }} as pres
       on pharm.prescribing_provider_npi = pres.npi
 left outer join {{ ref('provider_data__provider') }} as disp
       on pharm.dispensing_provider_npi = disp.npi
-left outer join {{ ref('terminology__ndc') }} as ndc
-      on pharm.ndc_code = ndc.ndc
+left outer join {{ ref('terminology__coderx_packages') }} as coderx_packages
+      on cast(pharm.ndc_code as {{ dbt.type_string() }}) = coderx_packages.ndc11

--- a/seeds/terminology/terminology__coderx_classes.csv
+++ b/seeds/terminology/terminology__coderx_classes.csv
@@ -1,0 +1,1 @@
+"drug_id","drug_name","atc_1_code","atc_1_name","atc_2_code","atc_2_name","atc_3_code","atc_3_name","atc_4_code","atc_4_name"

--- a/seeds/terminology/terminology__coderx_drugs.csv
+++ b/seeds/terminology/terminology__coderx_drugs.csv
@@ -1,0 +1,1 @@
+"drug_id","drug_name","is_brand","clinical_drug_id","clinical_drug_name","active","prescribable"

--- a/seeds/terminology/terminology__coderx_packages.csv
+++ b/seeds/terminology/terminology__coderx_packages.csv
@@ -1,0 +1,1 @@
+"ndc11","ndc","drug_id","drug_name","is_brand","clinical_drug_id","clinical_drug_name","active","prescribable"

--- a/seeds/terminology/terminology__ndc.csv
+++ b/seeds/terminology/terminology__ndc.csv
@@ -1,1 +1,0 @@
-"ndc","rxcui","rxnorm_description","fda_description"

--- a/seeds/terminology/terminology__rxnorm_brand_generic.csv
+++ b/seeds/terminology/terminology__rxnorm_brand_generic.csv
@@ -1,1 +1,0 @@
-product_rxcui,product_name,product_tty,prescribable_name,brand_vs_generic,brand_name,clinical_product_rxcui,clinical_product_name,clinical_product_tty,ingredient_name,dose_form_name,active,prescribable

--- a/seeds/terminology/terminology__rxnorm_to_atc.csv
+++ b/seeds/terminology/terminology__rxnorm_to_atc.csv
@@ -1,1 +1,0 @@
-rxcui,rxnorm_description,atc_1_code,atc_1_name,atc_2_code,atc_2_name,atc_3_code,atc_3_name,atc_4_code,atc_4_name

--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -1260,47 +1260,68 @@ seeds:
       - name: deprecated_date
         description: 'The date when the MS-DRG code was deprecated.'
 
-  - name: terminology__ndc
+  - name: terminology__coderx_packages
     description: |-
-      National Drug Codes identify drug products, labelers, strengths, dosage forms, and package sizes in
-      drug claims and pharmacy data. Tuva sources this proprietary asset from CodeRx through an annual
-      update agreement. Tuva uses this asset in the core medication model, input normalization models,
-      data quality checks, semantic layer models, and total cost of care pharmacy models.
+      CodeRx Open package records map National Drug Codes to RxNorm drug concepts. Tuva distributes this
+      annual open snapshot for medication enrichment, pharmacy normalization, and data quality checks.
     config:
       meta:
         data_asset:
-          display_name: "NDC"
+          display_name: "CodeRx Packages"
           maintainer: "CodeRx"
-          source_url: "https://coderx.io/source-data"
-          source_release: ""
-          source_last_updated: ""
-          tuva_last_updated: "2026-04-29"
+          source_url: "https://coderx.io/coderx-open"
+          source_release: "CodeRx Open snapshot 2026-07-08"
+          source_last_updated: "2026-07-08"
+          tuva_last_updated: "2026-08-24"
           update_frequency: "annually"
-          notes: "Proprietary CodeRx asset updated annually under Tuva's CodeRx agreement."
-      post_hook: "{{ load_versioned_seed('terminology','terminology__ndc.csv.gz') }}"
+          notes: "CodeRx Open package data distributed with Tuva Core."
+      post_hook: "{{ load_versioned_seed('terminology','terminology__coderx_packages.csv.gz') }}"
       schema: |
-        {%- if  var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_terminology{% else %}terminology{%- endif -%}
-      alias: ndc
+        {%- if var('tuva_schema_prefix', None) != None -%}{{ var('tuva_schema_prefix') }}_terminology{% else %}terminology{%- endif -%}
+      alias: coderx_packages
       tags:
         - terminology
       column_types:
+        ndc11: |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(11) {%- endif -%}
         ndc: |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(20) {%- endif -%}
+        drug_id: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        rxcui: |
+        drug_name: |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
+        is_brand: |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(10) {%- endif -%}
+        clinical_drug_id: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        rxnorm_description: |
+        clinical_drug_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
-        fda_description: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
+        active: |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(10) {%- endif -%}
+        prescribable: |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(10) {%- endif -%}
     columns:
+      - name: ndc11
+        description: Eleven-digit National Drug Code for the package.
+        tests:
+          - not_null
+          - unique
       - name: ndc
-        description: 'The National Drug Code (NDC).'
-      - name: rxcui
-        description: 'The RxCUI identifier associated with the NDC.'
-      - name: rxnorm_description
-        description: 'The description of the RxNorm concept.'
-      - name: fda_description
-        description: 'The FDA description of the drug.'
+        description: Hyphenated ten-digit National Drug Code when CodeRx supplies one.
+      - name: drug_id
+        description: RxNorm RxCUI for the drug associated with the package.
+      - name: drug_name
+        description: RxNorm name for the drug associated with the package.
+      - name: is_brand
+        description: Indicates whether the drug concept is branded.
+      - name: clinical_drug_id
+        description: RxNorm RxCUI for the corresponding unbranded clinical drug.
+      - name: clinical_drug_name
+        description: RxNorm name for the corresponding unbranded clinical drug.
+      - name: active
+        description: Indicates whether the CodeRx record is active.
+      - name: prescribable
+        description: Indicates whether the CodeRx record is prescribable.
 
   - name: terminology__observation_type
     description: |-
@@ -1489,33 +1510,31 @@ seeds:
       - name: revenue_center_description
         description: 'A description of the revenue center.'
 
-  - name: terminology__rxnorm_to_atc
+  - name: terminology__coderx_classes
     description: |-
-      The RxNorm to ATC crosswalk maps drug concepts to Anatomical Therapeutic Chemical classes for
-      medication grouping and pharmacy analytics. Tuva sources this proprietary asset from CodeRx through
-      an annual update agreement. Tuva uses this asset in the core medication model and semantic layer
-      models.
+      CodeRx Open class records map RxNorm drug concepts to Anatomical Therapeutic Chemical classification
+      levels. Tuva distributes this annual open snapshot for medication enrichment and analytics.
     config:
       meta:
         data_asset:
-          display_name: "RxNorm to ATC"
+          display_name: "CodeRx Classes"
           maintainer: "CodeRx"
-          source_url: "https://coderx.io/source-data"
-          source_release: ""
-          source_last_updated: ""
-          tuva_last_updated: "2026-04-29"
+          source_url: "https://coderx.io/coderx-open"
+          source_release: "CodeRx Open snapshot 2026-07-08"
+          source_last_updated: "2026-07-08"
+          tuva_last_updated: "2026-08-24"
           update_frequency: "annually"
-          notes: "Proprietary CodeRx asset updated annually under Tuva's CodeRx agreement."
-      post_hook: "{{ load_versioned_seed('terminology','terminology__rxnorm_to_atc.csv.gz') }}"
+          notes: "CodeRx Open drug class data distributed with Tuva Core."
+      post_hook: "{{ load_versioned_seed('terminology','terminology__coderx_classes.csv.gz') }}"
       schema: |
-        {%- if  var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_terminology{% else %}terminology{%- endif -%}
-      alias: rxnorm_to_atc
+        {%- if var('tuva_schema_prefix', None) != None -%}{{ var('tuva_schema_prefix') }}_terminology{% else %}terminology{%- endif -%}
+      alias: coderx_classes
       tags:
         - terminology
       column_types:
-        rxcui: |
+        drug_id: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        rxnorm_description: |
+        drug_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
         atc_1_code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
@@ -1534,26 +1553,28 @@ seeds:
         atc_4_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
     columns:
-      - name: rxcui
-        description: 'The RxNorm code.'
-      - name: rxnorm_description
-        description: 'Description of the RxNorm concept.'
+      - name: drug_id
+        description: RxNorm RxCUI for the classified drug.
+        tests:
+          - not_null
+      - name: drug_name
+        description: RxNorm name for the classified drug.
       - name: atc_1_code
-        description: 'The ATC level 1 code.'
+        description: The ATC level 1 code.
       - name: atc_1_name
-        description: 'The name of the ATC level 1 code.'
+        description: The name of the ATC level 1 code.
       - name: atc_2_code
-        description: 'The ATC level 2 code.'
+        description: The ATC level 2 code.
       - name: atc_2_name
-        description: 'The name of the ATC level 2 code.'
+        description: The name of the ATC level 2 code.
       - name: atc_3_code
-        description: 'The ATC level 3 code.'
+        description: The ATC level 3 code.
       - name: atc_3_name
-        description: 'The name of the ATC level 3 code.'
+        description: The name of the ATC level 3 code.
       - name: atc_4_code
-        description: 'The ATC level 4 code.'
+        description: The ATC level 4 code.
       - name: atc_4_name
-        description: 'The name of the ATC level 4 code.'
+        description: The name of the ATC level 4 code.
 
 
   - name: terminology__snomed_icd_10_map
@@ -1740,55 +1761,60 @@ seeds:
         description: 'The description of the child SNOMED concept.'
 
 
-  - name: terminology__rxnorm_brand_generic
+  - name: terminology__coderx_drugs
     description: |-
-      RxNorm brand and generic mappings identify whether drug concepts represent branded or generic
-      products. Tuva sources this proprietary asset from CodeRx through an annual update agreement. Tuva
-      uses this asset in semantic layer models and total cost of care pharmacy models.
+      CodeRx Open drug records describe active, prescribable RxNorm concepts and their corresponding
+      unbranded clinical drug concepts. Tuva distributes this annual open snapshot for medication enrichment.
     config:
       meta:
         data_asset:
-          display_name: "RxNorm Brand Generic"
+          display_name: "CodeRx Drugs"
           maintainer: "CodeRx"
-          source_url: "https://coderx.io/source-data"
-          source_release: ""
-          source_last_updated: ""
-          tuva_last_updated: "2026-04-29"
+          source_url: "https://coderx.io/coderx-open"
+          source_release: "CodeRx Open snapshot 2026-07-08"
+          source_last_updated: "2026-07-08"
+          tuva_last_updated: "2026-08-24"
           update_frequency: "annually"
-          notes: "Proprietary CodeRx asset updated annually under Tuva's CodeRx agreement."
-      post_hook: "{{ load_versioned_seed('terminology','terminology__rxnorm_brand_generic.csv.gz') }}"
+          notes: "CodeRx Open drug data distributed with Tuva Core."
+      post_hook: "{{ load_versioned_seed('terminology','terminology__coderx_drugs.csv.gz') }}"
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}{{ var('tuva_schema_prefix') }}_terminology{% else %}terminology{%- endif -%}
-      alias: rxnorm_brand_generic
+      alias: coderx_drugs
       tags:
         - terminology
       column_types:
-        product_rxcui: |
+        drug_id: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        product_name: |
+        drug_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
-        product_tty: |
+        is_brand: |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(10) {%- endif -%}
+        clinical_drug_id: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        prescribable_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
-        brand_vs_generic: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        brand_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(1000) {%- endif -%}
-        clinical_product_rxcui: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        clinical_product_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
-        clinical_product_tty: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        ingredient_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
-        dose_form_name: |
+        clinical_drug_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(3000) {%- endif -%}
         active: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(10) {%- endif -%}
         prescribable: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(10) {%- endif -%}
+    columns:
+      - name: drug_id
+        description: RxNorm RxCUI for the drug concept.
+        tests:
+          - not_null
+          - unique
+      - name: drug_name
+        description: RxNorm name for the drug concept.
+      - name: is_brand
+        description: Indicates whether the drug concept is branded.
+      - name: clinical_drug_id
+        description: RxNorm RxCUI for the corresponding unbranded clinical drug.
+      - name: clinical_drug_name
+        description: RxNorm name for the corresponding unbranded clinical drug.
+      - name: active
+        description: Indicates whether the CodeRx record is active.
+      - name: prescribable
+        description: Indicates whether the CodeRx record is prescribable.
 
   - name: terminology__nitos
     description: |-


### PR DESCRIPTION
## Summary

- replace the legacy NDC, RxNorm-to-ATC, and brand/generic terminology assets with the version-aligned CodeRx Open packages, drugs, and classes assets
- route medication terminology through shared Core interfaces used by pharmacy normalization, logical data quality, claims medication staging, and core.medication
- add the optional use_coderx_enterprise variable so those consumers can instead read user-managed coderx.packages, coderx.drugs, and coderx.classes relations
- preserve medication grain with deterministic ATC selection and add focused Open and Enterprise routing coverage

## Validation

- Snowflake full refresh excluding already-loaded seeds: 435/435 passed, 0 warnings, 0 errors
- Open-mode unit suite: 55/55 passed
- Enterprise-mode mocked unit suite: 55/55 passed
- affected Snowflake models against the published CodeRx Open assets: 6/6 passed
- relevant medication and pharmacy data tests: 11/11 passed
- dbt parse with no partial parsing passed
- git diff check passed

Real CodeRx Enterprise table validation is intentionally deferred until licensed test data is available; its routing contract is covered with dbt unit-test mocks.

## Release note

- `terminology`

## Linked issue

- None
