### PR TITLE
Validate cms_hcc reason-grain fix (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/snowflake \
-            --select package:integration_tests package:the_tuva_project \
+            --select package:integration_tests package:the_tuva_project package:cms_hcc \
             --vars "$CI_DBT_VARS"
 
       - name: Build on BigQuery

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,2 +1,4 @@
 packages:
   - local: ../
+  - git: "https://github.com/tuva-health/cms_hcc.git"
+    revision: 80b7b9125efdc6924b2f04ff9aa8df71778d4903


### PR DESCRIPTION
## Purpose

Temporary compatibility PR to run the hosted Snowflake build for tuva-health/cms_hcc#24. **Do not merge.**

This pins the standalone package commit `80b7b9125efdc6924b2f04ff9aa8df71778d4903` and adds `package:cms_hcc` to the Snowflake selector. It contains no Tuva Core product change.

## Validation

- Local dependency install resolved the exact pinned commit.
- Local `dbt parse --no-partial-parse` passed.
- Awaiting this PRs hosted Snowflake full-refresh check.

The PR will be closed without merge after the hosted check completes.