### PR TITLE
Fix portable office-based surgery HCPCS casting

### DIFF
--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_surgery_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_surgery_professional.sql
@@ -7,11 +7,7 @@
 with numeric_hcpcs as (
     select *
     from {{ ref('service_category__stg_medical_claim') }} as med
-    {% if target.type in ('duckdb', 'databricks') %}
-        where try_cast('hcpcs_code' as integer) is not null
-    {% else %}
-        where {{ safe_cast('hcpcs_code', 'int') }} is not null
-    {% endif %}
+    where {{ the_tuva_project.try_to_cast_int('med.hcpcs_code') }} is not null
 )
 select distinct
     med.claim_id

--- a/models/claims_preprocessing/service_category/service_category_unit_tests.yml
+++ b/models/claims_preprocessing/service_category/service_category_unit_tests.yml
@@ -1,0 +1,66 @@
+version: 2
+
+unit_tests:
+  - name: test_office_based_surgery_requires_numeric_hcpcs_in_surgery_range
+    description: >
+      Verifies that office-based surgery includes numeric HCPCS codes in the
+      surgery range while safely excluding alphanumeric and out-of-range codes.
+      Regression coverage for https://github.com/tuva-health/tuva-core/issues/1387.
+    model: service_category__office_based_surgery_professional
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('service_category__stg_medical_claim')
+        format: sql
+        rows: |
+          select
+              'numeric_in_range' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+            , 'numeric_in_range|1|source_a' as claim_line_id
+            , '47562' as hcpcs_code
+          union all
+          select
+              'alphanumeric' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+            , 'alphanumeric|1|source_a' as claim_line_id
+            , 'A0425' as hcpcs_code
+          union all
+          select
+              'numeric_out_of_range' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+            , 'numeric_out_of_range|1|source_a' as claim_line_id
+            , '99213' as hcpcs_code
+      - input: ref('service_category__stg_office_based')
+        format: sql
+        rows: |
+          select
+              'numeric_in_range' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+          union all
+          select
+              'alphanumeric' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+          union all
+          select
+              'numeric_out_of_range' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+    expect:
+      rows:
+        - claim_id: numeric_in_range
+          claim_line_number: 1
+          data_source: source_a
+          claim_line_id: numeric_in_range|1|source_a
+          service_category_1: office-based
+          service_category_2: office-based surgery
+          service_category_3: office-based surgery
+          tuva_last_run: '2024-01-01 00:00:00'


### PR DESCRIPTION
Closes #1387

## Summary
- Replace warehouse-specific HCPCS filtering with `the_tuva_project.try_to_cast_int` on `med.hcpcs_code`.
- Restore office-based surgery classifications on DuckDB and Databricks and prevent strict-cast failures on Redshift.
- Add deterministic unit coverage for an in-range numeric, alphanumeric, and out-of-range numeric HCPCS code.
- Fabric was not affected because its adapter already implements tolerant safe casting.

## Validation
- DuckDB fail-before: the new unit test returned zero rows against the original SQL.
- `TUVA_DBT_PROFILE=duckdb scripts/dbt-local test --select test_office_based_surgery_requires_numeric_hcpcs_in_surgery_range --no-partial-parse` (1/1 passed after the fix).
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local parse --no-partial-parse` (passed).
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local build --full-refresh --select service_category__office_based_surgery_professional` (2/2 passed; model produced 88 rows).
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local build --full-refresh --select tag:service_category_grouper` (66/66 passed).
- Seeds and data assets were reused; no seed refresh was run.

## Release note
- `bug`