### PR TITLE
Fix BigQuery type family macro test

### DIFF
--- a/tests/check_structural_type_family_macros.sql
+++ b/tests/check_structural_type_family_macros.sql
@@ -16,13 +16,18 @@
     ('bigquery_bytes', bigquery__dq_type_family('BYTES'), 'binary')
 ] %}
 
-{% for case in type_family_cases %}
-select
-      '{{ case[0] }}' as test_case
-    , '{{ case[1] }}' as actual_type_family
-    , '{{ case[2] }}' as expected_type_family
-where '{{ case[1] }}' <> '{{ case[2] }}'
-{% if not loop.last %}
-union all
-{% endif %}
-{% endfor %}
+with type_family_results as (
+    {% for case in type_family_cases %}
+    select
+          '{{ case[0] }}' as test_case
+        , '{{ case[1] }}' as actual_type_family
+        , '{{ case[2] }}' as expected_type_family
+    {% if not loop.last %}
+    union all
+    {% endif %}
+    {% endfor %}
+)
+
+select *
+from type_family_results
+where actual_type_family <> expected_type_family


### PR DESCRIPTION
## Summary

- build the structural type-family regression cases as a constant CTE
- filter mismatches from that relation so BigQuery no longer receives a `WHERE` clause without a `FROM`
- preserve the existing failure-row behavior and public Data Quality contract

## Validation

- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local deps`
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local parse --no-partial-parse --vars '{"data_quality_enabled": true}'`
- `TUVA_DBT_PROFILE=tuva_dev scripts/dbt-local debug`
- `TUVA_DBT_PROFILE=tuva_dev scripts/dbt-local build --select check_structural_type_family_macros --vars '{"data_quality_enabled": true}'` — pass
- repeated the targeted DuckDB build with one intentional expected-value mismatch — failed with exactly one result; restored the expectation and reran successfully
- GoogleSQL semantic analyzer — rejected the former no-`FROM` shape and accepted the compiled fixed query
- local Snowflake execution was blocked by interactive SSO; hosted Snowflake PR CI is the execution gate

## Release note

- `bug`

Closes #1390
