### PR TITLE
Fix minimum dbt version requirement

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'the_tuva_project'
 version: '1.0.0'
 config-version: 2
-require-dbt-version: ">=1.10.0"
+require-dbt-version: ">=1.10.5"
 
 profile: default
 


### PR DESCRIPTION
## Summary

- Raise require-dbt-version from >=1.10.0 to >=1.10.5.
- Ensure unsupported dbt 1.10 patches fail with a clear version-requirement error instead of a generic-test macro compilation error.

## Validation

- dbt-core 1.10.4 + dbt-snowflake 1.10.0: deps passed; parse failed as expected with Required version of dbt: >=1.10.5.
- dbt-core 1.10.5 + dbt-snowflake 1.10.0: deps and no-partial-parse passed.
- dbt-core 1.12.3 + dbt-snowflake 1.12.0: deps and no-partial-parse passed.
- TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local parse --no-partial-parse passed with dbt-core 1.11.2.

## Release note

bug

Fixes #1391