### PR TITLE
Validate Tuva Core boolean feature variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ Common variable groups:
 - Runtime metadata and schemas: `tuva_last_run`, `tuva_schema_prefix`
 - Extension columns: `passthrough`
 
+Tuva Core's boolean feature variables (`claims_enabled`, `clinical_enabled`,
+`provider_attribution_enabled`, `parity_enabled`, `data_quality_enabled`,
+`enable_data_quality_failure_keys`, and `use_coderx_enterprise`) must be
+unquoted YAML booleans. For example:
+
+```yaml
+vars:
+  claims_enabled: true
+  clinical_enabled: false
+```
+
+Quoted values such as `"true"` and `"false"` are strings and are rejected. Direct
+`env_var()` expressions are also strings and cannot be assigned to these vars.
+Environment-driven workflows must generate typed YAML or JSON, such as a
+`--vars` mapping containing native booleans, before invoking dbt.
+
 ## Data Asset Releases
 
 Every Tuva Core release with external data assets has one complete immutable

--- a/integration_tests/models/appointment.sql
+++ b/integration_tests/models/appointment.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', false)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/condition.sql
+++ b/integration_tests/models/condition.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/eligibility.sql
+++ b/integration_tests/models/eligibility.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/integration_tests/models/encounter.sql
+++ b/integration_tests/models/encounter.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/immunization.sql
+++ b/integration_tests/models/immunization.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/lab_result.sql
+++ b/integration_tests/models/lab_result.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/location.sql
+++ b/integration_tests/models/location.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/medical_claim.sql
+++ b/integration_tests/models/medical_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/integration_tests/models/medication.sql
+++ b/integration_tests/models/medication.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/observation.sql
+++ b/integration_tests/models/observation.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/patient.sql
+++ b/integration_tests/models/patient.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', false)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/pharmacy_claim.sql
+++ b/integration_tests/models/pharmacy_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/integration_tests/models/practitioner.sql
+++ b/integration_tests/models/practitioner.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/procedure.sql
+++ b/integration_tests/models/procedure.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/integration_tests/models/provider_attribution.sql
+++ b/integration_tests/models/provider_attribution.sql
@@ -1,8 +1,8 @@
 {{ config(
      enabled = (
-         var('provider_attribution_enabled', False) == True and
-         var('claims_enabled', False)
-     ) | as_bool
+         the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) == True and
+         the_tuva_project.tuva_boolean_var('claims_enabled', false)
+     )
    )
 }}
 

--- a/integration_tests/tests/check_extension_column_contract.sql
+++ b/integration_tests/tests/check_extension_column_contract.sql
@@ -3,8 +3,8 @@
 -- derived Core outputs must not expose any integration fixture extension.
 
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
-            and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      tags = ['extension_columns'],
      severity = 'error'
    )

--- a/integration_tests/tests/check_extension_column_values.sql
+++ b/integration_tests/tests/check_extension_column_values.sql
@@ -3,8 +3,8 @@
 -- claims outputs may contain nulls on claims-derived rows.
 
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
-            and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      tags = ['extension_columns'],
      severity = 'error'
    )

--- a/integration_tests/tests/check_extension_columns_null_on_claims_derived_rows.sql
+++ b/integration_tests/tests/check_extension_columns_null_on_claims_derived_rows.sql
@@ -2,8 +2,8 @@
 -- seven hybrid Core tables.
 
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
-            and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      tags = ['extension_columns'],
      severity = 'error'
    )

--- a/integration_tests/tests/check_extension_source_only_name_collision.sql
+++ b/integration_tests/tests/check_extension_source_only_name_collision.sql
@@ -7,7 +7,7 @@
 {% set strip_prefix = passthrough_config.get('strip', false) %}
 
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
             and strip_prefix
             and (extension_prefix | lower) in ['x_', 'ext_'],
      tags = ['extension_columns'],

--- a/macros/config/tuva_boolean_var.sql
+++ b/macros/config/tuva_boolean_var.sql
@@ -1,0 +1,12 @@
+{% macro tuva_boolean_var(name, default=false) %}
+    {% set value = var(name, default) %}
+
+    {% if value is not sameas true and value is not sameas false %}
+        {% do exceptions.raise_compiler_error(
+            "Tuva variable '" ~ name ~ "' must be a native boolean "
+            ~ "(unquoted true or false in YAML). Received: '" ~ value ~ "'."
+        ) %}
+    {% endif %}
+
+    {% do return(value) %}
+{% endmacro %}

--- a/macros/data_quality/dq_summary_helpers.sql
+++ b/macros/data_quality/dq_summary_helpers.sql
@@ -1,7 +1,7 @@
 {% macro dq_enabled_input_layer_model_domains() %}
     {% set domains = [] %}
 
-    {% if var('clinical_enabled', false) | as_bool %}
+    {% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) %}
         {% do domains.append({
             'name': 'clinical',
             'model_names': [
@@ -20,14 +20,14 @@
         }) %}
     {% endif %}
 
-    {% if var('claims_enabled', false) | as_bool %}
+    {% if the_tuva_project.tuva_boolean_var('claims_enabled', false) %}
         {% set claims_model_names = [
             'input_layer__eligibility',
             'input_layer__medical_claim',
             'input_layer__pharmacy_claim'
         ] %}
 
-        {% if var('provider_attribution_enabled', false) | as_bool %}
+        {% if the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) %}
             {% do claims_model_names.append('input_layer__provider_attribution') %}
         {% endif %}
 

--- a/models/claims_preprocessing/claims_enrollment_flags/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment_flags/claims_enrollment__flag_claims_with_enrollment.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/claims_enrollment_flags/claims_enrollment__flag_rx_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment_flags/claims_enrollment__flag_rx_claims_with_enrollment.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/acute_inpatient__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/acute_inpatient__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/ambulance__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/ambulance__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/asc__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/asc__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/dialysis__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/dialysis__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/dme__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/dme__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/emergency_department__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/emergency_department__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/home_health__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/home_health__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/inpatient_hospice__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_hospice__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/inpatient_long_term__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_long_term__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/inpatient_psych__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_psych__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/inpatient_rehab__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_rehab__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/inpatient_snf__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_snf__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/inpatient_substance_use__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/inpatient_substance_use__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/lab__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/lab__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/orphaned_claim__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/orphaned_claim__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_hospice__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_hospice__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_hospital_or_clinic__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_hospital_or_clinic__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_injections__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_injections__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_psych__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_psych__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_ptotst__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_ptotst__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_radiology__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_radiology__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_rehab__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_rehab__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_substance_use__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_substance_use__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/outpatient_surgery__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/outpatient_surgery__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/final/urgent_care__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/urgent_care__encounter_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/acute_inpatient/acute_inpatient__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulance/ambulance__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-    enabled = var('claims_enabled', False) | as_bool
+    enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
 ) }}
 
 with base_data as (

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dialysis/dialysis__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/dme/dme__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dme/dme__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/dme/dme__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dme/dme__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/dme/dme__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/dme/dme__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id_pre_sort.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__generate_encounter_id_pre_sort.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/emergency_department/emergency_department__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
@@ -2,7 +2,7 @@
 (This can happen a few ways - professional claims assigned to anchor event overlap and assigned to multiple  )
 */
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/encounters__int_institutional_claim_lines.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__int_institutional_claim_lines.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/encounters__orphaned_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__orphaned_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/home_health/home_health__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/home_health/home_health__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/home_health/home_health__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/home_health/home_health__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/home_health/home_health__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/home_health/home_health__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_hospice/inpatient_hospice__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_long_term/inpatient_long_term__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_psych/inpatient_psych__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_rehab/inpatient_rehab__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_snf/inpatient_snf__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__prof_claims.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__prof_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__start_end_dates.sql
+++ b/models/claims_preprocessing/encounters/intermediate/inpatient_substance_use/inpatient_substance_use__start_end_dates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/lab/lab__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/lab/lab__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/lab/lab__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/lab/lab__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/lab/lab__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/lab/lab__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_detail_values.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_detail_values.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 with encounter_date as (

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_claim_line.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_claim_line.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_em.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_em.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_encounter_ranking.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_encounter_ranking.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_injections.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_injections.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_ptotst.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_ptotst.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_radiology.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_radiology.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_surgery.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_surgery.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_telehealth.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_telehealth.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_union.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_office_visits_union.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospice/outpatient_hospice__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_hospital_or_clinic/outpatient_hospital_or_clinic__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_injections/outpatient_injections__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_psych/outpatient_psych__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_ptotst/outpatient_ptotst__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_radiology/outpatient_radiology__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_rehab/outpatient_rehab__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 with anchor as (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_substance_use/outpatient_substance_use__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 with anchor as (

--- a/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/outpatient_surgery/outpatient_surgery__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__anchor_events.sql
+++ b/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__anchor_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__generate_encounter_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__match_claims_to_anchor.sql
+++ b/models/claims_preprocessing/encounters/intermediate/urgent_care/urgent_care__match_claims_to_anchor.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/staging/encounters__patient_data_source_id.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__patient_data_source_id.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/staging/encounters__prof_and_lower_priority.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__prof_and_lower_priority.sql
@@ -3,7 +3,7 @@ and should be part of a higher priority encounter where one exists. We are union
 here to access downstream from one place */
 
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/staging/encounters__stg_eligibility.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__stg_eligibility.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/staging/encounters__stg_inpatient_institutional.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__stg_inpatient_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/staging/encounters__stg_medical_claim.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__stg_medical_claim.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/staging/encounters__stg_outpatient_institutional.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__stg_outpatient_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/encounters/staging/encounters__stg_professional.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__stg_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/member_month/member_month__member_month.sql
+++ b/models/claims_preprocessing/member_month/member_month__member_month.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/final/provider_attribution__assigned_beneficiaries_current.sql
+++ b/models/claims_preprocessing/provider_attribution/final/provider_attribution__assigned_beneficiaries_current.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/final/provider_attribution__assigned_beneficiaries_yearly.sql
+++ b/models/claims_preprocessing/provider_attribution/final/provider_attribution__assigned_beneficiaries_yearly.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/final/provider_attribution__member_month_attribution.sql
+++ b/models/claims_preprocessing/provider_attribution/final/provider_attribution__member_month_attribution.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 
@@ -33,7 +33,7 @@ with member_months as (
   from {{ ref('normalized__provider_attribution') }}
 )
 
-{% if var('provider_attribution_enabled', False) | as_bool -%}
+{% if the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) -%}
 
 , tuva_attribution as (
   select
@@ -72,7 +72,7 @@ select
   , external_attribution.custom_attributed_provider_practice
   , external_attribution.custom_attributed_provider_organization
   , external_attribution.custom_attributed_provider_lob
-  {% if var('provider_attribution_enabled', False) | as_bool -%}
+  {% if the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) -%}
   , tuva_attribution.tuva_attributed_provider
   , tuva_attribution.tuva_attributed_provider_bucket
   , tuva_attribution.tuva_attributed_provider_specialty
@@ -105,7 +105,7 @@ left outer join external_attribution
   and mm.payer = external_attribution.payer
   and mm.{{ quote_column('plan') }} = external_attribution.{{ quote_column('plan') }}
   and mm.data_source = external_attribution.data_source
-{% if var('provider_attribution_enabled', False) | as_bool -%}
+{% if the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) -%}
 left outer join tuva_attribution
   on mm.person_id = tuva_attribution.person_id
   and mm.member_id = tuva_attribution.member_id

--- a/models/claims_preprocessing/provider_attribution/final/provider_attribution__provider_ranking.sql
+++ b/models/claims_preprocessing/provider_attribution/final/provider_attribution__provider_ranking.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/final/provider_attribution__tuva_member_month_attribution.sql
+++ b/models/claims_preprocessing/provider_attribution/final/provider_attribution__tuva_member_month_attribution.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_current_steps.sql
+++ b/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_current_steps.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_person_years.sql
+++ b/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_person_years.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_primary_care_claims.sql
+++ b/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_primary_care_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_yearly_steps.sql
+++ b/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_yearly_steps.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__provider_classification.sql
+++ b/models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__provider_classification.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/provider_attribution/staging/provider_attribution__stg_medical_claim.sql
+++ b/models/claims_preprocessing/provider_attribution/staging/provider_attribution__stg_medical_claim.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/models/claims_preprocessing/service_category/final/service_category__service_category_grouper.sql
+++ b/models/claims_preprocessing/service_category/final/service_category__service_category_grouper.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/int_claim_level_diagnosis.sql
+++ b/models/claims_preprocessing/service_category/intermediate/int_claim_level_diagnosis.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional_maternity.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional_maternity.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional_med_surg.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional_med_surg.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional_other.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional_other.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__ambulance_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__ambulance_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__ambulance_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__ambulance_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__ambulatory_surgery_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__ambulatory_surgery_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__ambulatory_surgery_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__ambulatory_surgery_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__combined_institutional_header_level.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__combined_institutional_header_level.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__combined_institutional_line_level.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__combined_institutional_line_level.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__combined_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__combined_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__dialysis_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__dialysis_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__dialysis_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__dialysis_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__dme_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__dme_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__dme_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__dme_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__emergency_department_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__emergency_department_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__emergency_department_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__emergency_department_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__home_health_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__home_health_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__home_health_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__home_health_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_hospice_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_hospice_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_hospice_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_hospice_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_long_term_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_long_term_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_psychiatric_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_psychiatric_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_psychiatric_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_psychiatric_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_rehab_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_rehab_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_rehab_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_rehab_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_skilled_nursing_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_skilled_nursing_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_skilled_nursing_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_skilled_nursing_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_substance_use_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_substance_use_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_substance_use_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__inpatient_substance_use_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__lab_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__lab_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__lab_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__lab_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__observation_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__observation_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__observation_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__observation_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_other_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_other_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_physical_therapy_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_physical_therapy_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_radiology.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_radiology.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_surgery_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_surgery_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_visit_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_visit_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospice_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospice_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospice_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospice_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospital_or_clinic_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospital_or_clinic_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospital_or_clinic_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_hospital_or_clinic_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_physical_therapy_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_psychiatric_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_psychiatric_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 with multiple_sources as (

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_psychiatric_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_psychiatric_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_radiology_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_radiology_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_radiology_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_radiology_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_rehab_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_rehab_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_rehab_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_rehab_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_skilled_nursing_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_skilled_nursing_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_substance_use_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_substance_use_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_substance_use_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_substance_use_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_surgery_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_surgery_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_surgery_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__outpatient_surgery_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__pharmacy_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__pharmacy_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__pharmacy_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__pharmacy_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__urgent_care_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__urgent_care_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/intermediate/service_category__urgent_care_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__urgent_care_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/staging/service_category__stg_inpatient_institutional.sql
+++ b/models/claims_preprocessing/service_category/staging/service_category__stg_inpatient_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/staging/service_category__stg_medical_claim.sql
+++ b/models/claims_preprocessing/service_category/staging/service_category__stg_medical_claim.sql
@@ -1,5 +1,5 @@
 {{ config(
-  enabled = var('claims_enabled', False) | as_bool
+  enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
 ) }}
 
 with ccs_release_year as (

--- a/models/claims_preprocessing/service_category/staging/service_category__stg_office_based.sql
+++ b/models/claims_preprocessing/service_category/staging/service_category__stg_office_based.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/staging/service_category__stg_outpatient_institutional.sql
+++ b/models/claims_preprocessing/service_category/staging/service_category__stg_outpatient_institutional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/claims_preprocessing/service_category/staging/service_category__stg_professional.sql
+++ b/models/claims_preprocessing/service_category/staging/service_category__stg_professional.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/final/core__appointment.sql
+++ b/models/core/final/core__appointment.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/core/final/core__condition.sql
+++ b/models/core/final/core__condition.sql
@@ -1,11 +1,11 @@
 {{ config(
-     enabled = (var('claims_enabled', False) | as_bool)
-            or (var('clinical_enabled', False) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 
 {%- set tuva_extension_columns_from_all_conditions -%}
-{% if var('clinical_enabled', False) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) %}
     {{ select_extension_columns(ref('normalized__condition'), alias='all_conditions') }}
 {% endif %}
 {%- endset -%}
@@ -17,17 +17,17 @@
 {%- endset -%}
 
 with all_conditions as (
-{% if var('clinical_enabled', False) == true
-    and var('claims_enabled', False) == true -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true
+    and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
     {{ smart_union([ref('int_condition_from_claims'), ref('normalized__condition')]) }}
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 
     select *
     from {{ ref('normalized__condition') }}
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
     select *
     from {{ ref('int_condition_from_claims') }}

--- a/models/core/final/core__cost.sql
+++ b/models/core/final/core__cost.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/final/core__eligibility.sql
+++ b/models/core/final/core__eligibility.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/final/core__encounter.sql
+++ b/models/core/final/core__encounter.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('claims_enabled', False) | as_bool)
-            or (var('clinical_enabled', False) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 
@@ -56,7 +56,7 @@
     , data_source
 {%- endset -%}
 
-{% if var('clinical_enabled', false) == true and var('claims_enabled', false) == true -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
     {{ select_extension_columns(ref('normalized__encounter')) }}
@@ -72,7 +72,7 @@ select
     {{ tuva_metadata_columns }}
 from enc
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
     {{ select_extension_columns(ref('normalized__encounter')) }}
@@ -84,7 +84,7 @@ select
     {{ tuva_metadata_columns }}
 from {{ ref('normalized__encounter') }}
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
 {# No extension columns — input_layer__encounter is clinical-only #}

--- a/models/core/final/core__immunization.sql
+++ b/models/core/final/core__immunization.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/core/final/core__lab_result.sql
+++ b/models/core/final/core__lab_result.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/core/final/core__location.sql
+++ b/models/core/final/core__location.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('claims_enabled', False) | as_bool)
-            or (var('clinical_enabled', False) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 
@@ -24,7 +24,7 @@
     , data_source
 {%- endset -%}
 
-{% if var('clinical_enabled', False) == true and var('claims_enabled', False) == true -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
     {{ select_extension_columns(ref('normalized__location')) }}
@@ -40,7 +40,7 @@ select
     {{ tuva_metadata_columns }}
 from loc
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
     {{ select_extension_columns(ref('normalized__location')) }}
@@ -52,7 +52,7 @@ select
     {{ tuva_metadata_columns }}
 from {{ ref('normalized__location') }}
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
 {# No extension columns — input_layer__location is clinical-only #}

--- a/models/core/final/core__medical_claim.sql
+++ b/models/core/final/core__medical_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/final/core__medication.sql
+++ b/models/core/final/core__medication.sql
@@ -1,17 +1,17 @@
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
-            or (var('clinical_enabled', false) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 
 {%- set tuva_extension_columns_from_all_medications -%}
-{% if var('clinical_enabled', false) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) %}
     {{ select_extension_columns(ref('normalized__medication'), alias='meds', strip_prefix=false) }}
 {% endif %}
 {%- endset -%}
 
 {%- set tuva_extension_columns_from_source_mapping -%}
-{% if var('clinical_enabled', false) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) %}
     {{ select_extension_columns(ref('normalized__medication'), alias='sm') }}
 {% endif %}
 {%- endset -%}
@@ -22,7 +22,7 @@
    , data_source
 {%- endset -%}
 
-{%- set use_coderx_enterprise = var('use_coderx_enterprise', false) | as_bool -%}
+{%- set use_coderx_enterprise = the_tuva_project.tuva_boolean_var('use_coderx_enterprise', false) -%}
 
 with coderx_package_keys as (
     select
@@ -45,17 +45,17 @@ with coderx_package_keys as (
 ),
 
 all_medications as (
-{% if var('clinical_enabled', false) | as_bool
-    and var('claims_enabled', false) | as_bool -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false)
+    and the_tuva_project.tuva_boolean_var('claims_enabled', false) -%}
 
     {{ smart_union([ref('core__stg_claims_medication'), ref('normalized__medication')]) }}
 
-{% elif var('clinical_enabled', false) | as_bool -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) -%}
 
     select *
     from {{ ref('normalized__medication') }}
 
-{% elif var('claims_enabled', false) | as_bool -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) -%}
 
     select *
     from {{ ref('core__stg_claims_medication') }}

--- a/models/core/final/core__member_month.sql
+++ b/models/core/final/core__member_month.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/final/core__observation.sql
+++ b/models/core/final/core__observation.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/core/final/core__patient.sql
+++ b/models/core/final/core__patient.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('claims_enabled', False) | as_bool)
-            or (var('clinical_enabled', False) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 
@@ -55,8 +55,8 @@ cast(
     , data_source
 {%- endset -%}
 
-{% if var('clinical_enabled', False) == true
-   and var('claims_enabled', False) == true -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true
+   and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 {%- if execute -%}
     {%- set passthrough_config = get_extension_passthrough_config() -%}
@@ -251,7 +251,7 @@ select
     {{ final_metadata_columns }}
 from patient_base
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 
 {%- set source_extension_columns -%}
     {{ select_extension_columns(ref('core__int_patient_remove_duplicates'), alias='patient_source', strip_prefix=false) }}
@@ -300,7 +300,7 @@ select
     {{ final_metadata_columns }}
 from patient_base
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 with patient_base as (
     select

--- a/models/core/final/core__person_id_crosswalk.sql
+++ b/models/core/final/core__person_id_crosswalk.sql
@@ -1,10 +1,12 @@
 {{ config(
-     enabled = var('claims_enabled', var('clinical_enabled', False))
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var(
+       'claims_enabled',
+       the_tuva_project.tuva_boolean_var('clinical_enabled', false)
+     )
    )
 }}
 
-{% if var('clinical_enabled', False) == true and var('claims_enabled', False) == true -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 select distinct
       cast(person_id as {{ dbt.type_string() }}) as person_id
@@ -26,7 +28,7 @@ select distinct
     , cast(data_source as {{ dbt.type_string() }}) as data_source
 from {{ ref('normalized__patient') }}
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 
 select distinct
       cast(person_id as {{ dbt.type_string() }}) as person_id
@@ -38,7 +40,7 @@ select distinct
     , cast(data_source as {{ dbt.type_string() }}) as data_source
 from {{ ref('normalized__patient') }}
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 select distinct
       cast(person_id as {{ dbt.type_string() }}) as person_id

--- a/models/core/final/core__pharmacy_claim.sql
+++ b/models/core/final/core__pharmacy_claim.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/final/core__practitioner.sql
+++ b/models/core/final/core__practitioner.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('claims_enabled', False) | as_bool)
-            or (var('clinical_enabled', False) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 
@@ -20,7 +20,7 @@
     , data_source
 {%- endset -%}
 
-{% if var('clinical_enabled', False) == true and var('claims_enabled', False) == true -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
     {{ select_extension_columns(ref('normalized__practitioner')) }}
@@ -36,7 +36,7 @@ select
     {{ tuva_metadata_columns }}
 from prac
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
     {{ select_extension_columns(ref('normalized__practitioner')) }}
@@ -48,7 +48,7 @@ select
     {{ tuva_metadata_columns }}
 from {{ ref('normalized__practitioner') }}
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
 {%- set tuva_extension_columns -%}
 {# No extension columns — input_layer__practitioner is clinical-only #}

--- a/models/core/final/core__procedure.sql
+++ b/models/core/final/core__procedure.sql
@@ -1,11 +1,11 @@
 {{ config(
-     enabled = (var('claims_enabled', False) | as_bool)
-            or (var('clinical_enabled', False) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 
 {%- set tuva_extension_columns_from_all_procedures -%}
-{% if var('clinical_enabled', False) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) %}
     {{ select_extension_columns(ref('normalized__procedure'), alias='all_procedures') }}
 {% endif %}
 {%- endset -%}
@@ -17,16 +17,16 @@
 {%- endset -%}
 
 with all_procedures as (
-{% if var('clinical_enabled', False) == true and var('claims_enabled', False) == true -%}
+{% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
     {{ smart_union([ref('int_procedure_from_claims'), ref('normalized__procedure')]) }}
 
-{% elif var('clinical_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 
     select *
     from {{ ref('normalized__procedure') }}
 
-{% elif var('claims_enabled', False) == true -%}
+{% elif the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
     select *
     from {{ ref('int_procedure_from_claims') }}

--- a/models/core/final/core__utilization.sql
+++ b/models/core/final/core__utilization.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/intermediate/core__int_patient_remove_duplicates.sql
+++ b/models/core/intermediate/core__int_patient_remove_duplicates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/core/intermediate/int_condition_from_claims.sql
+++ b/models/core/intermediate/int_condition_from_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/intermediate/int_cost_service_categories.sql
+++ b/models/core/intermediate/int_cost_service_categories.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/intermediate/int_cost_service_category_1_allowed_pivot.sql
+++ b/models/core/intermediate/int_cost_service_category_1_allowed_pivot.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/intermediate/int_cost_service_category_1_paid_pivot.sql
+++ b/models/core/intermediate/int_cost_service_category_1_paid_pivot.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/intermediate/int_cost_service_category_2_allowed_pivot.sql
+++ b/models/core/intermediate/int_cost_service_category_2_allowed_pivot.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
     )
 }}
 

--- a/models/core/intermediate/int_cost_service_category_2_paid_pivot.sql
+++ b/models/core/intermediate/int_cost_service_category_2_paid_pivot.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/intermediate/int_procedure_from_claims.sql
+++ b/models/core/intermediate/int_procedure_from_claims.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/staging/core__stg_claims_encounter.sql
+++ b/models/core/staging/core__stg_claims_encounter.sql
@@ -1,6 +1,6 @@
 
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/staging/core__stg_claims_location.sql
+++ b/models/core/staging/core__stg_claims_location.sql
@@ -1,7 +1,6 @@
 
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/staging/core__stg_claims_medication.sql
+++ b/models/core/staging/core__stg_claims_medication.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/staging/core__stg_claims_practitioner.sql
+++ b/models/core/staging/core__stg_claims_practitioner.sql
@@ -1,6 +1,6 @@
 
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/core/staging/core__stg_coderx_classes.sql
+++ b/models/core/staging/core__stg_coderx_classes.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
-            or (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      materialized = 'ephemeral'
    )
 }}
@@ -19,7 +19,7 @@ with source_rows as (
         , nullif(cast(atc_3_name as {{ dbt.type_string() }}), 'NULL') as atc_3_name
         , nullif(cast(atc_4_code as {{ dbt.type_string() }}), 'NULL') as atc_4_code
         , nullif(cast(atc_4_name as {{ dbt.type_string() }}), 'NULL') as atc_4_name
-    {% if var('use_coderx_enterprise', false) | as_bool %}
+    {% if the_tuva_project.tuva_boolean_var('use_coderx_enterprise', false) %}
     from {{ source('coderx', 'classes') }}
     {% else %}
     from {{ ref('terminology__coderx_classes') }}

--- a/models/core/staging/core__stg_coderx_drugs.sql
+++ b/models/core/staging/core__stg_coderx_drugs.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
-            or (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      materialized = 'ephemeral'
    )
 }}
@@ -15,7 +15,7 @@ select
     , nullif(cast(clinical_drug_name as {{ coderx_name_type }}), 'NULL') as clinical_drug_name
     , nullif(cast(active as {{ dbt.type_string() }}), 'NULL') as active
     , nullif(cast(prescribable as {{ dbt.type_string() }}), 'NULL') as prescribable
-{% if var('use_coderx_enterprise', false) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('use_coderx_enterprise', false) %}
 from {{ source('coderx', 'drugs') }}
 {% else %}
 from {{ ref('terminology__coderx_drugs') }}

--- a/models/core/staging/core__stg_coderx_packages.sql
+++ b/models/core/staging/core__stg_coderx_packages.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('claims_enabled', false) | as_bool)
-            or (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      materialized = 'ephemeral'
    )
 }}
@@ -17,7 +17,7 @@ select
     , nullif(cast(clinical_drug_name as {{ coderx_name_type }}), 'NULL') as clinical_drug_name
     , nullif(cast(active as {{ dbt.type_string() }}), 'NULL') as active
     , nullif(cast(prescribable as {{ dbt.type_string() }}), 'NULL') as prescribable
-{% if var('use_coderx_enterprise', false) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('use_coderx_enterprise', false) %}
 from {{ source('coderx', 'packages') }}
 {% else %}
 from {{ ref('terminology__coderx_packages') }}

--- a/models/data_quality/logical/data_quality__appointment_flags.sql
+++ b/models/data_quality/logical/data_quality__appointment_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__condition_flags.sql
+++ b/models/data_quality/logical/data_quality__condition_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__eligibility_person_flags.sql
+++ b/models/data_quality/logical/data_quality__eligibility_person_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('claims_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('claims_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__eligibility_span_flags.sql
+++ b/models/data_quality/logical/data_quality__eligibility_span_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('claims_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('claims_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__encounter_flags.sql
+++ b/models/data_quality/logical/data_quality__encounter_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__immunization_flags.sql
+++ b/models/data_quality/logical/data_quality__immunization_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__lab_result_flags.sql
+++ b/models/data_quality/logical/data_quality__lab_result_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__location_flags.sql
+++ b/models/data_quality/logical/data_quality__location_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__medical_claim_claim_flags.sql
+++ b/models/data_quality/logical/data_quality__medical_claim_claim_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('claims_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('claims_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__medical_claim_line_flags.sql
+++ b/models/data_quality/logical/data_quality__medical_claim_line_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('claims_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('claims_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__medication_flags.sql
+++ b/models/data_quality/logical/data_quality__medication_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__observation_flags.sql
+++ b/models/data_quality/logical/data_quality__observation_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__patient_flags.sql
+++ b/models/data_quality/logical/data_quality__patient_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__pharmacy_claim_claim_flags.sql
+++ b/models/data_quality/logical/data_quality__pharmacy_claim_claim_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('claims_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('claims_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__pharmacy_claim_line_flags.sql
+++ b/models/data_quality/logical/data_quality__pharmacy_claim_line_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('claims_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('claims_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__practitioner_flags.sql
+++ b/models/data_quality/logical/data_quality__practitioner_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__procedure_flags.sql
+++ b/models/data_quality/logical/data_quality__procedure_flags.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool) and (var('clinical_enabled', false) | as_bool),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false)) and (the_tuva_project.tuva_boolean_var('clinical_enabled', false)),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/logical/data_quality__provider_attribution_flags.sql
+++ b/models/data_quality/logical/data_quality__provider_attribution_flags.sql
@@ -1,8 +1,8 @@
 {{ config(
      enabled = (
-       (var('data_quality_enabled', false) | as_bool)
-       and (var('claims_enabled', false) | as_bool)
-       and (var('provider_attribution_enabled', false) | as_bool)
+       (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false))
      ),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'

--- a/models/data_quality/rollups/data_quality__component_quality_results.sql
+++ b/models/data_quality/rollups/data_quality__component_quality_results.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__component_table_quality_results.sql
+++ b/models/data_quality/rollups/data_quality__component_table_quality_results.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__component_test_quality_results.sql
+++ b/models/data_quality/rollups/data_quality__component_test_quality_results.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__data_source_catalog.sql
+++ b/models/data_quality/rollups/data_quality__data_source_catalog.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__domain_catalog.sql
+++ b/models/data_quality/rollups/data_quality__domain_catalog.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__domain_input_requirements.sql
+++ b/models/data_quality/rollups/data_quality__domain_input_requirements.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__input_layer_catalog.sql
+++ b/models/data_quality/rollups/data_quality__input_layer_catalog.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__logical_failure_keys.sql
+++ b/models/data_quality/rollups/data_quality__logical_failure_keys.sql
@@ -1,7 +1,7 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and (var('enable_data_quality_failure_keys', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__logical_test_catalog.sql
+++ b/models/data_quality/rollups/data_quality__logical_test_catalog.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__logical_test_input_columns.sql
+++ b/models/data_quality/rollups/data_quality__logical_test_input_columns.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__logical_test_results.sql
+++ b/models/data_quality/rollups/data_quality__logical_test_results.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__source_quality_overview.sql
+++ b/models/data_quality/rollups/data_quality__source_quality_overview.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/rollups/data_quality__structural_test_results.sql
+++ b/models/data_quality/rollups/data_quality__structural_test_results.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural.sql
+++ b/models/data_quality/structural/data_quality__structural.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_actual_columns.sql
+++ b/models/data_quality/structural/data_quality__structural_actual_columns.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_column_details.sql
+++ b/models/data_quality/structural/data_quality__structural_column_details.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_data_sources.sql
+++ b/models/data_quality/structural/data_quality__structural_data_sources.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_data_type_mismatches.sql
+++ b/models/data_quality/structural/data_quality__structural_data_type_mismatches.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_evaluation_scope.sql
+++ b/models/data_quality/structural/data_quality__structural_evaluation_scope.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_expected_columns.sql
+++ b/models/data_quality/structural/data_quality__structural_expected_columns.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_missing_columns.sql
+++ b/models/data_quality/structural/data_quality__structural_missing_columns.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_primary_key_failure_counts.sql
+++ b/models/data_quality/structural/data_quality__structural_primary_key_failure_counts.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
+++ b/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/data_quality/structural/data_quality__structural_source_populations.sql
+++ b/models/data_quality/structural/data_quality__structural_source_populations.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      schema = (
        var('tuva_schema_prefix', None) ~ '_data_quality'
        if var('tuva_schema_prefix', None) is not none

--- a/models/input_layer/input_layer__appointment.sql
+++ b/models/input_layer/input_layer__appointment.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__condition.sql
+++ b/models/input_layer/input_layer__condition.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/input_layer/input_layer__eligibility.sql
+++ b/models/input_layer/input_layer__eligibility.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__encounter.sql
+++ b/models/input_layer/input_layer__encounter.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__immunization.sql
+++ b/models/input_layer/input_layer__immunization.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__lab_result.sql
+++ b/models/input_layer/input_layer__lab_result.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__location.sql
+++ b/models/input_layer/input_layer__location.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__medical_claim.sql
+++ b/models/input_layer/input_layer__medical_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__medication.sql
+++ b/models/input_layer/input_layer__medication.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__observation.sql
+++ b/models/input_layer/input_layer__observation.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__patient.sql
+++ b/models/input_layer/input_layer__patient.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__pharmacy_claim.sql
+++ b/models/input_layer/input_layer__pharmacy_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__practitioner.sql
+++ b/models/input_layer/input_layer__practitioner.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__procedure.sql
+++ b/models/input_layer/input_layer__procedure.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 select *

--- a/models/input_layer/input_layer__provider_attribution.sql
+++ b/models/input_layer/input_layer__provider_attribution.sql
@@ -1,18 +1,18 @@
 {{ config(
      enabled = (
-       var('provider_attribution_enabled', False)
-       and var('claims_enabled', False)
-     ) | as_bool
+       the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false)
+       and the_tuva_project.tuva_boolean_var('claims_enabled', false)
+     )
    )
 }}
 
-{% if var('provider_attribution_enabled',False) == true -%}
+{% if the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) == true -%}
 
 select *
 from {{ ref('provider_attribution') }}
 
 
-{% elif var('provider_attribution_enabled',False) ==  false -%}
+{% elif the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) ==  false -%}
 
 {% if target.type == 'fabric' %}
 select top 0

--- a/models/normalized_layer/final/normalized__appointment.sql
+++ b/models/normalized_layer/final/normalized__appointment.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__condition.sql
+++ b/models/normalized_layer/final/normalized__condition.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__eligibility.sql
+++ b/models/normalized_layer/final/normalized__eligibility.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__encounter.sql
+++ b/models/normalized_layer/final/normalized__encounter.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__immunization.sql
+++ b/models/normalized_layer/final/normalized__immunization.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__lab_result.sql
+++ b/models/normalized_layer/final/normalized__lab_result.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__location.sql
+++ b/models/normalized_layer/final/normalized__location.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__medical_claim.sql
+++ b/models/normalized_layer/final/normalized__medical_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__medical_claim_diagnoses.sql
+++ b/models/normalized_layer/final/normalized__medical_claim_diagnoses.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__medical_claim_procedures.sql
+++ b/models/normalized_layer/final/normalized__medical_claim_procedures.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__medication.sql
+++ b/models/normalized_layer/final/normalized__medication.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__observation.sql
+++ b/models/normalized_layer/final/normalized__observation.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__patient.sql
+++ b/models/normalized_layer/final/normalized__patient.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__pharmacy_claim.sql
+++ b/models/normalized_layer/final/normalized__pharmacy_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__practitioner.sql
+++ b/models/normalized_layer/final/normalized__practitioner.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__procedure.sql
+++ b/models/normalized_layer/final/normalized__procedure.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('clinical_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('clinical_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/final/normalized__provider_attribution.sql
+++ b/models/normalized_layer/final/normalized__provider_attribution.sql
@@ -1,9 +1,9 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 
-{% if var('provider_attribution_enabled', False) | as_bool -%}
+{% if the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) -%}
 
 select
       cast(person_id as {{ dbt.type_string() }}) as person_id

--- a/models/normalized_layer/intermediate/int_eligibility_casting.sql
+++ b/models/normalized_layer/intermediate/int_eligibility_casting.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/int_eligibility_dates_normalized.sql
+++ b/models/normalized_layer/intermediate/int_eligibility_dates_normalized.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/int_eligibility_state_normalized.sql
+++ b/models/normalized_layer/intermediate/int_eligibility_state_normalized.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized__eligibility_remove_duplicates.sql
+++ b/models/normalized_layer/intermediate/normalized__eligibility_remove_duplicates.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_admit_source_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_admit_source_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_admit_source_voting.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_admit_source_voting.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_admit_type_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_admit_type_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_admit_type_voting.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_admit_type_voting.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_bill_type_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_bill_type_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_bill_type_voting.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_bill_type_voting.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_discharge_disposition_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_discharge_disposition_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_discharge_disposition_voting.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_discharge_disposition_voting.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_drg_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_drg_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_drg_voting.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_drg_voting.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_medical_claim_date_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_medical_claim_date_normalize.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_medical_date_aggregation.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_medical_date_aggregation.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_medical_npi_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_medical_npi_normalize.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_place_of_service_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_place_of_service_normalize.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_present_on_admit_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_present_on_admit_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_present_on_admit_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_present_on_admit_normalize.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_present_on_admit_voting.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_present_on_admit_voting.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_procedure_code_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_procedure_code_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_procedure_code_intermediate.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_procedure_code_intermediate.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
-     | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_procedure_date_final.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_procedure_date_final.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_procedure_date_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_procedure_date_normalize.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_procedure_date_voting.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_procedure_date_voting.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_revenue_center_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_revenue_center_normalize.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/intermediate/normalized_input__int_undetermined_claim_type.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_undetermined_claim_type.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/staging/normalized_input__stg_medical_claim.sql
+++ b/models/normalized_layer/staging/normalized_input__stg_medical_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/normalized_layer/staging/normalized_input__stg_pharmacy_claim.sql
+++ b/models/normalized_layer/staging/normalized_input__stg_pharmacy_claim.sql
@@ -1,6 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False)
- | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/models/parity/parity__metrics.sql
+++ b/models/parity/parity__metrics.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('parity_enabled', false) | as_bool)
-       and (var('claims_enabled', false) | as_bool)
+     enabled = (the_tuva_project.tuva_boolean_var('parity_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/tests/check_dq_logical_selector_closure.sql
+++ b/tests/check_dq_logical_selector_closure.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )

--- a/tests/check_logical_64_bit_integer_type_macros.sql
+++ b/tests/check_logical_64_bit_integer_type_macros.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )

--- a/tests/check_logical_failure_key_counts.sql
+++ b/tests/check_logical_failure_key_counts.sql
@@ -1,7 +1,7 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and (var('enable_data_quality_failure_keys', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )

--- a/tests/check_logical_flag_grain.sql
+++ b/tests/check_logical_flag_grain.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )

--- a/tests/check_logical_flag_schema.sql
+++ b/tests/check_logical_flag_schema.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )

--- a/tests/check_logical_ingest_datetime_coverage.sql
+++ b/tests/check_logical_ingest_datetime_coverage.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical', 'dq_rollup']
    )
@@ -88,9 +88,9 @@ with input_tables as (
 select *
 from coverage_violations
 
-{% if (var('claims_enabled', false) | as_bool)
-      and (var('clinical_enabled', false) | as_bool)
-      and (var('provider_attribution_enabled', false) | as_bool) %}
+{% if (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+      and (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
+      and (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false)) %}
 union all
 select
       '__enabled_input_inventory__' as input_table_name

--- a/tests/check_logical_ingest_datetime_range_macro.sql
+++ b/tests/check_logical_ingest_datetime_range_macro.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )

--- a/tests/check_logical_public_access.sql
+++ b/tests/check_logical_public_access.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )
@@ -19,7 +19,7 @@
     'data_quality__logical_test_results'
 ] %}
 
-{% if var('enable_data_quality_failure_keys', false) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false) %}
     {% do expected_public_model_names.append('data_quality__logical_failure_keys') %}
 {% endif %}
 

--- a/tests/check_logical_public_schemas.sql
+++ b/tests/check_logical_public_schemas.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )
@@ -72,7 +72,7 @@
     }
 ] %}
 
-{% if var('enable_data_quality_failure_keys', false) | as_bool %}
+{% if the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false) %}
     {% do public_relations.append({
         'model_name': 'data_quality__logical_failure_keys',
         'expected_columns': [

--- a/tests/check_logical_result_counts.sql
+++ b/tests/check_logical_result_counts.sql
@@ -1,13 +1,13 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical']
    )
 }}
 
-{% if (var('data_quality_enabled', false) | as_bool)
-    and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)) %}
+{% if (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+    and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))) %}
     select
           data_source
         , input_table_name

--- a/tests/check_logical_test_input_columns.sql
+++ b/tests/check_logical_test_input_columns.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = (var('data_quality_enabled', false) | as_bool)
-       and ((var('claims_enabled', false) | as_bool) or (var('clinical_enabled', false) | as_bool)),
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
      severity = 'error',
      tags = ['data_quality', 'dq_logical', 'dq_rollup']
    )

--- a/tests/check_structural_type_family_macros.sql
+++ b/tests/check_structural_type_family_macros.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('data_quality_enabled', false) | as_bool,
+     enabled = the_tuva_project.tuva_boolean_var('data_quality_enabled', false),
      tags = ['data_quality', 'dq_structural']
    )
 }}

--- a/tests/test_encounter_attribution_natural_order.sql
+++ b/tests/test_encounter_attribution_natural_order.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/tests/test_encounter_claim_number_starts_at_one.sql
+++ b/tests/test_encounter_claim_number_starts_at_one.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/tests/test_encounter_id_single_data_source.sql
+++ b/tests/test_encounter_id_single_data_source.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/tests/test_encounters_stg_medical_claim_source_grain.sql
+++ b/tests/test_encounters_stg_medical_claim_source_grain.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/tests/test_orphaned_claim_dates_source_scoped.sql
+++ b/tests/test_orphaned_claim_dates_source_scoped.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', False) | as_bool
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false)
    )
 }}
 

--- a/tests/test_tuva_attribution_member_month_traceability.sql
+++ b/tests/test_tuva_attribution_member_month_traceability.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 

--- a/tests/test_tuva_attribution_member_month_year_consistency.sql
+++ b/tests/test_tuva_attribution_member_month_year_consistency.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = (var('provider_attribution_enabled', False) and var('claims_enabled', False))
+     enabled = (the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) and the_tuva_project.tuva_boolean_var('claims_enabled', false))
    )
 }}
 


### PR DESCRIPTION
## Summary

- add a strict `tuva_boolean_var` helper that preserves native booleans and raises a compiler error naming any non-boolean variable and value
- route every Tuva Core SQL read of the domain, Data Quality, parity, provider-attribution, and CodeRx boolean flags through the helper, removing the no-op SQL `as_bool` guards
- preserve the existing enabled-node behavior, including the separate `core__person_id_crosswalk` fallback tracked in #1392
- document the native-boolean contract and the limitation on direct `env_var()` strings

## Validation

- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local deps`
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local parse --no-partial-parse`
- compared `dbt ls` unique-id sets with `origin/main` for all-off, claims-only, clinical-only, claims+clinical+attribution, Data Quality+failure keys, and parity configurations: all identical
- verified quoted strings for all seven documented boolean flags fail with a compiler error naming the exact variable
- verified `0`, `null`, `[]`, and `{}` are rejected as non-booleans
- static audit: all 378 SQL enablement configs use the helper; no direct reads of the scoped flags or gate-related SQL `as_bool` filters remain
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local build --full-refresh --select package:integration_tests package:the_tuva_project --exclude resource_type:seed`
  - `PASS=440 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=440`

## Release Note Label

- `bug`

Closes #1396
