### PR TITLE
Retain undetermined medical claims in Core

### DIFF
--- a/models/claims_preprocessing/encounters/encounter_models.yml
+++ b/models/claims_preprocessing/encounters/encounter_models.yml
@@ -1325,7 +1325,10 @@ models:
 
   - name: encounters__combined_claim_line_crosswalk
     description: |-
-      all claim lines that belong to an encounter
+      Claim lines assigned to a classified encounter algorithm. Contract-valid
+      undetermined claims remain outside this crosswalk and flow through
+      encounters__orphaned_claims instead, even if a broad same-day anchor
+      matcher produced a candidate assignment.
 
       Primary key: claim_id, claim_line_number, data_source, encounter_type.
       claim_id is only unique within a data_source, so consumers must include
@@ -5250,6 +5253,11 @@ models:
         - ambulance
 
   - name: encounters__orphaned_claims
+    description: |-
+      Assigns a source-scoped orphaned claim encounter to each medical claim
+      line that was not mapped by an encounter algorithm. This includes
+      contract-valid undetermined claims, whose billing form cannot be routed
+      through the professional or institutional algorithms.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_claims_preprocessing

--- a/models/claims_preprocessing/encounters/encounter_unit_tests.yml
+++ b/models/claims_preprocessing/encounters/encounter_unit_tests.yml
@@ -1,6 +1,162 @@
 version: 2
 
 unit_tests:
+  - name: test_combined_encounter_crosswalk_excludes_undetermined_candidates
+    description: >
+      Broad same-day matchers can produce an encounter candidate for an
+      undetermined claim. The final combined crosswalk must exclude that
+      candidate while preserving the same classified candidate, so the
+      undetermined line flows through the orphan fallback. Regression coverage
+      for https://github.com/tuva-health/tuva-core/issues/1388.
+    model: encounters__combined_claim_line_crosswalk
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+    given:
+      - input: ref('acute_inpatient__prof_claims')
+        rows: []
+      - input: ref('emergency_department__prof_claims')
+        rows: []
+      - input: ref('inpatient_psych__prof_claims')
+        rows: []
+      - input: ref('inpatient_rehab__prof_claims')
+        rows: []
+      - input: ref('inpatient_long_term__prof_claims')
+        rows: []
+      - input: ref('inpatient_snf__prof_claims')
+        rows: []
+      - input: ref('inpatient_substance_use__prof_claims')
+        rows: []
+      - input: ref('office_visits__int_office_visits_claim_line')
+        rows: []
+      - input: ref('urgent_care__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_psych__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_rehab__match_claims_to_anchor')
+        rows: []
+      - input: ref('asc__match_claims_to_anchor')
+        rows: []
+      - input: ref('dialysis__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_hospice__match_claims_to_anchor')
+        rows: []
+      - input: ref('home_health__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_surgery__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_injections__match_claims_to_anchor')
+        rows:
+          - claim_id: undetermined_claim
+            claim_line_number: 1
+            data_source: source-a
+            old_encounter_id: anchor-1
+          - claim_id: professional_claim
+            claim_line_number: 1
+            data_source: source-a
+            old_encounter_id: anchor-1
+      - input: ref('outpatient_ptotst__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_substance_use__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_radiology__match_claims_to_anchor')
+        rows: []
+      - input: ref('outpatient_hospital_or_clinic__match_claims_to_anchor')
+        rows: []
+      - input: ref('encounters__int_institutional_claim_lines')
+        rows: []
+      - input: ref('lab__match_claims_to_anchor')
+        rows: []
+      - input: ref('dme__match_claims_to_anchor')
+        rows: []
+      - input: ref('ambulance__match_claims_to_anchor')
+        rows: []
+      - input: ref('encounters__stg_medical_claim')
+        rows:
+          - claim_id: undetermined_claim
+            claim_line_number: 1
+            data_source: source-a
+            claim_type: undetermined
+          - claim_id: professional_claim
+            claim_line_number: 1
+            data_source: source-a
+            claim_type: professional
+    expect:
+      rows:
+        - claim_id: professional_claim
+          claim_line_number: 1
+          data_source: source-a
+          old_encounter_id: anchor-1
+          encounter_id: 599f9d17ecf5bc86e964968be6fea2cf
+          encounter_type: outpatient injections
+          encounter_group: outpatient
+          priority_number: 17
+          anchor_claim_id: null
+          claim_line_attribution_number: 1
+
+  - name: test_undetermined_claim_lines_receive_source_scoped_orphan_encounters
+    description: >
+      Every line of an undetermined claim receives an orphan encounter. Lines
+      from the same claim and source share an encounter ID, while reused claim
+      keys in another source remain isolated. Regression coverage for
+      https://github.com/tuva-health/tuva-core/issues/1388.
+    model: encounters__orphaned_claims
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    given:
+      - input: ref('encounters__stg_medical_claim')
+        format: sql
+        rows: |
+          select
+              'shared-undetermined' as claim_id
+            , 1 as claim_line_number
+            , 'other' as service_category_1
+            , 'other' as service_category_2
+            , 'other' as service_category_3
+            , 'undetermined' as claim_type
+            , cast('2024-01-01' as date) as claim_start_date
+            , cast('2024-01-02' as date) as claim_end_date
+            , cast('2024-01-01' as date) as start_date
+            , cast('2024-01-01' as date) as end_date
+            , 'person-1|source-a' as patient_data_source_id
+            , 'source-a' as data_source
+          union all
+          select 'shared-undetermined', 2, 'other', 'other', 'other', 'undetermined', cast('2024-01-01' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), 'person-1|source-a', 'source-a'
+          union all
+          select 'shared-undetermined', 1, 'other', 'other', 'other', 'undetermined', cast('2024-02-01' as date), cast('2024-02-01' as date), cast('2024-02-01' as date), cast('2024-02-01' as date), 'person-1|source-b', 'source-b'
+      - input: ref('encounters__combined_claim_line_crosswalk')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set integer_type = 'int64' if target.type == 'bigquery' else 'bigint' %}
+          select
+              cast(null as {{ string_type }}) as claim_id
+            , cast(null as {{ integer_type }}) as claim_line_number
+            , cast(null as {{ string_type }}) as data_source
+          where 1 = 0
+    expect:
+      rows:
+        - claim_id: shared-undetermined
+          claim_line_number: 1
+          data_source: source-a
+          encounter_id: 02288fa2b6c8335e69225d63811d6187
+          encounter_type: orphaned claim
+          encounter_group: other
+        - claim_id: shared-undetermined
+          claim_line_number: 2
+          data_source: source-a
+          encounter_id: 02288fa2b6c8335e69225d63811d6187
+          encounter_type: orphaned claim
+          encounter_group: other
+        - claim_id: shared-undetermined
+          claim_line_number: 1
+          data_source: source-b
+          encounter_id: 4e85975bd2bdd2e25e0558d72ac95af7
+          encounter_type: orphaned claim
+          encounter_group: other
+
   - name: test_orphaned_claims_scopes_crosswalk_by_data_source
     description: >
       When two sources reuse the same claim-line key, a crosswalk match in one

--- a/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
@@ -349,16 +349,24 @@ from {{ ref('ambulance__match_claims_to_anchor') }}
 
 
 select
-  claim_id
-, claim_line_number
-, data_source
-, encounter_id as old_encounter_id
-, {{ the_tuva_project.encounter_id_hash(['encounter_type', 'encounter_id']) }} as encounter_id
-, encounter_type
-, encounter_group
-, priority_number
-, anchor_claim_id
-, row_number() over (partition by claim_id, claim_line_number, data_source
-order by priority_number, case when claim_id = anchor_claim_id then 1 else 99 end
-       , encounter_type, encounter_id) as claim_line_attribution_number
-from cte
+  candidate.claim_id
+, candidate.claim_line_number
+, candidate.data_source
+, candidate.encounter_id as old_encounter_id
+, {{ the_tuva_project.encounter_id_hash(['candidate.encounter_type', 'candidate.encounter_id']) }} as encounter_id
+, candidate.encounter_type
+, candidate.encounter_group
+, candidate.priority_number
+, candidate.anchor_claim_id
+, row_number() over (partition by candidate.claim_id, candidate.claim_line_number, candidate.data_source
+order by candidate.priority_number, case when candidate.claim_id = candidate.anchor_claim_id then 1 else 99 end
+       , candidate.encounter_type, candidate.encounter_id) as claim_line_attribution_number
+from cte as candidate
+where not exists (
+    select 1
+    from {{ ref('encounters__stg_medical_claim') }} as staged_claim
+    where staged_claim.claim_id = candidate.claim_id
+      and staged_claim.claim_line_number = candidate.claim_line_number
+      and staged_claim.data_source = candidate.data_source
+      and staged_claim.claim_type = 'undetermined'
+)

--- a/models/claims_preprocessing/provider_attribution/provider_attribution_unit_tests.yml
+++ b/models/claims_preprocessing/provider_attribution/provider_attribution_unit_tests.yml
@@ -1,0 +1,73 @@
+version: 2
+
+unit_tests:
+  - name: test_provider_attribution_staging_includes_undetermined_orphan_claims
+    description: >
+      Undetermined claims restored to the canonical medical-claim path remain
+      eligible for the existing provider-attribution rules when they have the
+      required claim content; classification is not a separate attribution
+      prerequisite. Regression coverage for
+      https://github.com/tuva-health/tuva-core/issues/1388.
+    model: provider_attribution__stg_medical_claim
+    config:
+      enabled: "{{ (var('provider_attribution_enabled', false) and var('claims_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        provider_attribution_enabled: true
+    given:
+      - input: ref('normalized__medical_claim')
+        format: sql
+        rows: |
+          {% set numeric_type = 'numeric' %}
+          select
+              'undetermined_claim' as claim_id
+            , 1 as claim_line_number
+            , 'person-1' as person_id
+            , cast('2024-01-01' as date) as claim_start_date
+            , cast('2024-01-02' as date) as claim_end_date
+            , cast(12 as {{ numeric_type }}) as allowed_amount
+            , cast(10 as {{ numeric_type }}) as paid_amount
+            , '1111111111' as rendering_npi
+            , '99213' as hcpcs_code
+            , 'source-a' as data_source
+          union all
+          select 'professional_claim', 1, 'person-2', cast('2024-02-01' as date), cast('2024-02-01' as date), cast(22 as {{ numeric_type }}), cast(20 as {{ numeric_type }}), '2222222222', '99214', 'source-b'
+      - input: ref('service_category__service_category_grouper')
+        format: sql
+        rows: |
+          select 'undetermined_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 1 as duplicate_row_number
+          union all
+          select 'professional_claim', 1, 'source-b', 1
+      - input: ref('encounters__combined_claim_line_crosswalk')
+        format: sql
+        rows: |
+          select 'professional_claim' as claim_id, 1 as claim_line_number, 'source-b' as data_source, 'enc-professional' as encounter_id, 1 as claim_line_attribution_number
+      - input: ref('encounters__orphaned_claims')
+        format: sql
+        rows: |
+          select 'undetermined_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 'enc-undetermined' as encounter_id
+    expect:
+      rows:
+        - claim_id: undetermined_claim
+          claim_line_number: 1
+          person_id: person-1
+          claim_start_date: '2024-01-01'
+          claim_end_date: '2024-01-02'
+          allowed_amount: 12
+          paid_amount: 10
+          rendering_npi: '1111111111'
+          hcpcs_code: '99213'
+          data_source: source-a
+          encounter_id: enc-undetermined
+        - claim_id: professional_claim
+          claim_line_number: 1
+          person_id: person-2
+          claim_start_date: '2024-02-01'
+          claim_end_date: '2024-02-01'
+          allowed_amount: 22
+          paid_amount: 20
+          rendering_npi: '2222222222'
+          hcpcs_code: '99214'
+          data_source: source-b
+          encounter_id: enc-professional

--- a/models/claims_preprocessing/service_category/final/service_category__service_category_grouper.sql
+++ b/models/claims_preprocessing/service_category/final/service_category__service_category_grouper.sql
@@ -99,6 +99,24 @@ with service_category_1_mapping as (
       and b.service_category_2 = s.service_category_2
       and b.service_category_3 = s.service_category_3
     where a.claim_type = 'institutional'
+
+    union all
+
+    select distinct
+        a.claim_id
+        , a.claim_line_number
+        , a.data_source
+        , a.claim_type
+        , cast(null as {{ dbt.type_string() }}) as service_category_1
+        , cast(null as {{ dbt.type_string() }}) as service_category_2
+        , cast(null as {{ dbt.type_string() }}) as service_category_3
+        , cast(null as {{ dbt.type_string() }}) as original_service_cat_2
+        , cast(null as {{ dbt.type_string() }}) as original_service_cat_3
+        , cast(null as {{ dbt.type_int() }}) as priority
+        , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
+        , cast(null as {{ dbt.type_string() }}) as source_model_name
+    from {{ ref('service_category__stg_medical_claim') }} as a
+    where a.claim_type = 'undetermined'
 )
 
 , service_category_2_deduplication as (

--- a/models/claims_preprocessing/service_category/service_category_models.yml
+++ b/models/claims_preprocessing/service_category/service_category_models.yml
@@ -1,7 +1,13 @@
 models:
   #final
   - name: service_category__service_category_grouper
-    description: Assigns every claim line into a unique service category.
+    description: |-
+      Assigns each contract-valid medical claim line to a service category.
+      Professional and institutional claims use the service-category
+      algorithms. Claims whose claim_type is undetermined are retained with
+      other/other/other because their billing form cannot be classified
+      reliably. Null and invalid claim_type values remain outside this model
+      and are reported by input data quality checks.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_claims_preprocessing

--- a/models/claims_preprocessing/service_category/service_category_unit_tests.yml
+++ b/models/claims_preprocessing/service_category/service_category_unit_tests.yml
@@ -1,6 +1,167 @@
 version: 2
 
 unit_tests:
+  - name: test_service_category_grouper_only_falls_back_for_undetermined
+    description: >
+      Contract-valid undetermined claim lines must be retained as
+      other/other/other without routing null or invalid claim types into the
+      claims algorithms. Regression coverage for
+      https://github.com/tuva-health/tuva-core/issues/1388.
+    model: service_category__service_category_grouper
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('service_category__stg_medical_claim')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select
+              'undetermined_claim' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+            , 'undetermined' as claim_type
+            , 'ccs_1' as ccs_category
+            , 'CCS one' as ccs_category_description
+            , cast(null as {{ string_type }}) as drg_code
+            , cast(null as {{ string_type }}) as drg_description
+            , '11' as place_of_service_code
+            , 'Office' as place_of_service_description
+            , cast(null as {{ string_type }}) as revenue_center_code
+            , cast(null as {{ string_type }}) as revenue_center_description
+            , '99213' as hcpcs_code
+            , cast(null as {{ string_type }}) as default_ccsr_category_ip
+            , cast(null as {{ string_type }}) as default_ccsr_category_op
+            , cast(null as {{ string_type }}) as default_ccsr_category_description_ip
+            , cast(null as {{ string_type }}) as default_ccsr_category_description_op
+            , cast(null as {{ string_type }}) as primary_taxonomy_code
+            , cast(null as {{ string_type }}) as primary_specialty_description
+            , cast(null as {{ string_type }}) as modality
+            , cast(null as {{ string_type }}) as bill_type_code
+            , cast(null as {{ string_type }}) as bill_type_description
+          union all
+          select 'undetermined_claim', 2, 'source_a', 'undetermined', null, null, null, null, null, null, '0450', 'Emergency room', 'A0425', null, null, null, null, null, null, null, null, null
+          union all
+          select 'undetermined_claim', 1, 'source_b', 'undetermined', null, null, null, null, null, null, null, null, '87070', null, null, null, null, null, null, null, null, null
+          union all
+          select 'professional_claim', 1, 'source_a', 'professional', null, null, null, null, '11', 'Office', null, null, '99213', null, null, null, null, null, null, null, null, null
+          union all
+          select 'institutional_claim', 1, 'source_a', 'institutional', null, null, null, null, null, null, '0450', 'Emergency room', null, null, null, null, null, null, null, null, '131', 'Hospital outpatient'
+          union all
+          select 'null_claim_type', 1, 'source_a', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
+          union all
+          select 'invalid_claim_type', 1, 'source_a', 'dental', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
+      - input: ref('service_category__combined_professional')
+        format: sql
+        rows: |
+          select
+              'professional_claim' as claim_id
+            , 1 as claim_line_number
+            , 'source_a' as data_source
+            , 'office-based' as service_category_1
+            , 'office-based evaluation and management' as service_category_2
+            , 'office-based evaluation and management' as service_category_3
+            , 'service_category__office_based_visit_professional' as source_model_name
+      - input: ref('service_category__combined_institutional_header_level')
+        format: sql
+        rows: |
+          select
+              'institutional_claim' as claim_id
+            , 'source_a' as data_source
+            , 'outpatient' as service_category_1
+            , 'emergency department' as service_category_2
+            , 'emergency department' as service_category_3
+            , 'service_category__emergency_department_institutional' as source_model_name
+      - input: ref('service_category__combined_institutional_line_level')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set integer_type = 'int64' if target.type == 'bigquery' else 'bigint' %}
+          select
+              cast(null as {{ string_type }}) as claim_id
+            , cast(null as {{ integer_type }}) as claim_line_number
+            , cast(null as {{ string_type }}) as data_source
+            , cast(null as {{ string_type }}) as service_category_1
+            , cast(null as {{ string_type }}) as service_category_2
+            , cast(null as {{ string_type }}) as service_category_3
+            , cast(null as {{ string_type }}) as source_model_name
+          where 1 = 0
+      - input: ref('service_category__service_categories')
+        format: sql
+        rows: |
+          select
+              'office-based' as service_category_1
+            , 'office-based evaluation and management' as service_category_2
+            , 'office-based evaluation and management' as service_category_3
+            , 1 as priority
+          union all
+          select 'outpatient', 'emergency department', 'emergency department', 1
+    expect:
+      rows:
+        - claim_id: undetermined_claim
+          claim_line_number: 1
+          data_source: source_a
+          claim_type: undetermined
+          service_category_1: other
+          service_category_2: other
+          service_category_3: other
+          duplicate_row_number: 1
+          hcpcs_code: '99213'
+          source_model_name: null
+        - claim_id: undetermined_claim
+          claim_line_number: 2
+          data_source: source_a
+          claim_type: undetermined
+          service_category_1: other
+          service_category_2: other
+          service_category_3: other
+          duplicate_row_number: 1
+          hcpcs_code: A0425
+          source_model_name: null
+        - claim_id: undetermined_claim
+          claim_line_number: 1
+          data_source: source_b
+          claim_type: undetermined
+          service_category_1: other
+          service_category_2: other
+          service_category_3: other
+          duplicate_row_number: 1
+          hcpcs_code: '87070'
+          source_model_name: null
+        - claim_id: professional_claim
+          claim_line_number: 1
+          data_source: source_a
+          claim_type: professional
+          service_category_1: office-based
+          service_category_2: office-based evaluation and management
+          service_category_3: office-based evaluation and management
+          duplicate_row_number: 1
+          hcpcs_code: '99213'
+          source_model_name: service_category__office_based_visit_professional
+        - claim_id: institutional_claim
+          claim_line_number: 1
+          data_source: source_a
+          claim_type: institutional
+          service_category_1: outpatient
+          service_category_2: emergency department
+          service_category_3: emergency department
+          duplicate_row_number: 1
+          hcpcs_code: null
+          source_model_name: service_category__emergency_department_institutional
+        - claim_id: institutional_claim
+          claim_line_number: 1
+          data_source: source_a
+          claim_type: institutional
+          service_category_1: other
+          service_category_2: other
+          service_category_3: other
+          duplicate_row_number: 2
+          hcpcs_code: null
+          source_model_name: null
+
   - name: test_office_based_surgery_requires_numeric_hcpcs_in_surgery_range
     description: >
       Verifies that office-based surgery includes numeric HCPCS codes in the

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -1680,6 +1680,8 @@ models:
 
       This model pulls from claims preprocessing, enriches claim lines with encounter grouping, service categories, terminology descriptions, and enrollment matching, and passes through claim extension columns and file metadata. Header-level fields, such as claim_type, person_id, payer, plan, claim_start_date, claim_end_date, admission_date, and discharge_date, should be consistent across all lines for the same claim_id. Line-level fields, such as claim_line_start_date, claim_line_end_date, revenue_center_code, hcpcs_code, service_unit_quantity, and payment amounts, may vary across claim lines.
 
+      Contract-valid claims with claim_type = undetermined are retained. They receive other/other/other service categories and an orphaned claim encounter until their billing form classification can be resolved.
+
       Table grain: One record per medical claim line per data source.
 
       Primary key: medical_claim_id.

--- a/models/core/medical_claim_unit_tests.yml
+++ b/models/core/medical_claim_unit_tests.yml
@@ -1,0 +1,177 @@
+version: 2
+
+unit_tests:
+  - name: test_core_medical_claim_retains_undetermined_lines
+    description: >
+      Core retains every undetermined claim line with its source values,
+      other/other/other service categories, and the source-scoped orphan
+      encounter produced by claims preprocessing. A classified claim is kept
+      as a negative control. Regression coverage for
+      https://github.com/tuva-health/tuva-core/issues/1388.
+    model: core__medical_claim
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        tuva_last_run: '2024-01-01 00:00:00'
+        _extension_columns_override: []
+    given:
+      - input: ref('normalized__medical_claim')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          {% set numeric_type = 'numeric' %}
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          with base as (
+              select
+                  'mc-u-1' as medical_claim_id
+                , 'undetermined_claim' as claim_id
+                , 1 as claim_line_number
+                , 'undetermined' as claim_type
+                , 'person-1' as person_id
+                , 'member-1' as member_id
+                , 'payer-a' as payer
+                , 'plan-a' as {{ plan_identifier }}
+                , cast('2024-01-01' as date) as claim_start_date
+                , cast('2024-01-02' as date) as claim_end_date
+                , cast('2024-01-01' as date) as claim_line_start_date
+                , cast('2024-01-01' as date) as claim_line_end_date
+                , cast(1 as {{ numeric_type }}) as service_unit_quantity
+                , '99213' as hcpcs_code
+                , '1111111111' as rendering_npi
+                , cast('2024-01-10' as date) as paid_date
+                , cast(10 as {{ numeric_type }}) as paid_amount
+                , cast(12 as {{ numeric_type }}) as allowed_amount
+                , cast(15 as {{ numeric_type }}) as charge_amount
+                , cast(1 as {{ numeric_type }}) as coinsurance_amount
+                , cast(2 as {{ numeric_type }}) as copayment_amount
+                , cast(3 as {{ numeric_type }}) as deductible_amount
+                , cast(16 as {{ numeric_type }}) as total_cost_amount
+                , 1 as in_network_flag
+                , cast('2024-01-31' as date) as file_date
+                , cast('2024-02-01 00:00:00' as {{ timestamp_type }}) as ingest_datetime
+                , 'medical_claim.csv' as file_name
+                , 'source-a' as data_source
+              union all
+              select 'mc-u-2', 'undetermined_claim', 2, 'undetermined', 'person-1', 'member-1', 'payer-a', 'plan-a', cast('2024-01-01' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), cast(2 as {{ numeric_type }}), 'A0425', '1111111111', cast('2024-01-10' as date), cast(20 as {{ numeric_type }}), cast(22 as {{ numeric_type }}), cast(25 as {{ numeric_type }}), cast(2 as {{ numeric_type }}), cast(3 as {{ numeric_type }}), cast(4 as {{ numeric_type }}), cast(31 as {{ numeric_type }}), 0, cast('2024-01-31' as date), cast('2024-02-01 00:00:00' as {{ timestamp_type }}), 'medical_claim.csv', 'source-a'
+              union all
+              select 'mc-p-1', 'professional_claim', 1, 'professional', 'person-2', 'member-2', 'payer-b', 'plan-b', cast('2024-03-01' as date), cast('2024-03-01' as date), cast('2024-03-01' as date), cast('2024-03-01' as date), cast(1 as {{ numeric_type }}), '99214', '2222222222', cast('2024-03-10' as date), cast(30 as {{ numeric_type }}), cast(32 as {{ numeric_type }}), cast(35 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(32 as {{ numeric_type }}), 1, cast('2024-03-31' as date), cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'medical_claim.csv', 'source-b'
+          )
+          select
+              base.*
+            , cast(null as date) as admission_date
+            , cast(null as date) as discharge_date
+            , cast(null as {{ string_type }}) as admit_source_code
+            , cast(null as {{ string_type }}) as admit_source_description
+            , cast(null as {{ string_type }}) as admit_type_code
+            , cast(null as {{ string_type }}) as admit_type_description
+            , cast(null as {{ string_type }}) as discharge_disposition_code
+            , cast(null as {{ string_type }}) as discharge_disposition_description
+            , cast(null as {{ string_type }}) as place_of_service_code
+            , cast(null as {{ string_type }}) as place_of_service_description
+            , cast(null as {{ string_type }}) as bill_type_code
+            , cast(null as {{ string_type }}) as bill_type_description
+            , cast(null as {{ string_type }}) as drg_code_type
+            , cast(null as {{ string_type }}) as drg_code
+            , cast(null as {{ string_type }}) as drg_description
+            , cast(null as {{ string_type }}) as revenue_center_code
+            , cast(null as {{ string_type }}) as revenue_center_description
+            , cast(null as {{ string_type }}) as hcpcs_modifier_1
+            , cast(null as {{ string_type }}) as hcpcs_modifier_2
+            , cast(null as {{ string_type }}) as hcpcs_modifier_3
+            , cast(null as {{ string_type }}) as hcpcs_modifier_4
+            , cast(null as {{ string_type }}) as hcpcs_modifier_5
+            , cast(null as {{ string_type }}) as rendering_tin
+            , cast(null as {{ string_type }}) as rendering_name
+            , cast(null as {{ string_type }}) as billing_npi
+            , cast(null as {{ string_type }}) as billing_tin
+            , cast(null as {{ string_type }}) as billing_name
+            , cast(null as {{ string_type }}) as facility_npi
+            , cast(null as {{ string_type }}) as facility_name
+          from base
+      - input: ref('service_category__service_category_grouper')
+        format: sql
+        rows: |
+          select 'undetermined_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 'other' as service_category_1, 'other' as service_category_2, 'other' as service_category_3, 1 as duplicate_row_number
+          union all
+          select 'undetermined_claim', 2, 'source-a', 'other', 'other', 'other', 1
+          union all
+          select 'professional_claim', 1, 'source-b', 'office-based', 'office-based evaluation and management', 'office-based evaluation and management', 1
+      - input: ref('encounters__combined_claim_line_crosswalk')
+        format: sql
+        rows: |
+          select
+              'professional_claim' as claim_id
+            , 1 as claim_line_number
+            , 'source-b' as data_source
+            , 'enc-professional' as encounter_id
+            , 'office visit' as encounter_type
+            , 'outpatient' as encounter_group
+            , 1 as claim_line_attribution_number
+      - input: ref('encounters__orphaned_claims')
+        format: sql
+        rows: |
+          select 'undetermined_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 'enc-undetermined' as encounter_id, 'orphaned claim' as encounter_type, 'other' as encounter_group
+          union all
+          select 'undetermined_claim', 2, 'source-a', 'enc-undetermined', 'orphaned claim', 'other'
+      - input: ref('claims_enrollment__flag_claims_with_enrollment')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set integer_type = 'int64' if target.type == 'bigquery' else 'bigint' %}
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          select
+              cast(null as {{ string_type }}) as claim_id
+            , cast(null as {{ integer_type }}) as claim_line_number
+            , cast(null as {{ string_type }}) as person_id
+            , cast(null as {{ string_type }}) as payer
+            , cast(null as {{ string_type }}) as {{ plan_identifier }}
+            , cast(null as {{ string_type }}) as data_source
+            , cast(null as {{ string_type }}) as member_month_id
+          where 1 = 0
+    expect:
+      rows:
+        - medical_claim_id: mc-u-1
+          claim_id: undetermined_claim
+          claim_line_number: 1
+          claim_type: undetermined
+          encounter_id: enc-undetermined
+          encounter_type: orphaned claim
+          encounter_group: other
+          service_category_1: other
+          service_category_2: other
+          service_category_3: other
+          paid_amount: 10
+          allowed_amount: 12
+          charge_amount: 15
+          data_source: source-a
+        - medical_claim_id: mc-u-2
+          claim_id: undetermined_claim
+          claim_line_number: 2
+          claim_type: undetermined
+          encounter_id: enc-undetermined
+          encounter_type: orphaned claim
+          encounter_group: other
+          service_category_1: other
+          service_category_2: other
+          service_category_3: other
+          paid_amount: 20
+          allowed_amount: 22
+          charge_amount: 25
+          data_source: source-a
+        - medical_claim_id: mc-p-1
+          claim_id: professional_claim
+          claim_line_number: 1
+          claim_type: professional
+          encounter_id: enc-professional
+          encounter_type: office visit
+          encounter_group: outpatient
+          service_category_1: office-based
+          service_category_2: office-based evaluation and management
+          service_category_3: office-based evaluation and management
+          paid_amount: 30
+          allowed_amount: 32
+          charge_amount: 35
+          data_source: source-b

--- a/tests/core_medical_claim_valid_claim_type_completeness.sql
+++ b/tests/core_medical_claim_valid_claim_type_completeness.sql
@@ -1,0 +1,126 @@
+{{ config(
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false),
+     severity = 'error',
+     tags = ['core', 'medical_claim_contract']
+   )
+}}
+
+{#
+  Claim type routes a valid claim line through claims preprocessing; it must
+  not decide whether that line reaches Core. Reconcile all contract-valid
+  normalized lines to Core and lock the conservative semantics used when the
+  billing form is undetermined.
+#}
+
+with expected_claim_lines as (
+    select
+          medical_claim_id
+        , claim_id
+        , claim_line_number
+        , claim_type
+        , data_source
+        , count(*) as expected_count
+    from {{ ref('normalized__medical_claim') }}
+    where claim_type in ('professional', 'institutional', 'undetermined')
+      and claim_id is not null
+      and claim_line_number is not null
+      and person_id is not null
+      and data_source is not null
+    group by
+          medical_claim_id
+        , claim_id
+        , claim_line_number
+        , claim_type
+        , data_source
+)
+
+, actual_claim_lines as (
+    select
+          medical_claim_id
+        , claim_id
+        , claim_line_number
+        , claim_type
+        , data_source
+        , count(*) as actual_count
+    from {{ ref('core__medical_claim') }}
+    group by
+          medical_claim_id
+        , claim_id
+        , claim_line_number
+        , claim_type
+        , data_source
+)
+
+, missing_or_duplicate_claim_lines as (
+    select
+          'missing_or_duplicate_core_claim_line' as failure_type
+        , expected.medical_claim_id
+        , expected.claim_id
+        , expected.claim_line_number
+        , expected.claim_type
+        , expected.data_source
+        , expected.expected_count
+        , coalesce(actual.actual_count, 0) as actual_count
+    from expected_claim_lines as expected
+    left join actual_claim_lines as actual
+        on expected.medical_claim_id = actual.medical_claim_id
+        and expected.claim_id = actual.claim_id
+        and expected.claim_line_number = actual.claim_line_number
+        and expected.claim_type = actual.claim_type
+        and expected.data_source = actual.data_source
+    where expected.expected_count <> coalesce(actual.actual_count, 0)
+)
+
+, unexpected_claim_lines as (
+    select
+          'unexpected_core_claim_line' as failure_type
+        , actual.medical_claim_id
+        , actual.claim_id
+        , actual.claim_line_number
+        , actual.claim_type
+        , actual.data_source
+        , 0 as expected_count
+        , actual.actual_count
+    from actual_claim_lines as actual
+    left join expected_claim_lines as expected
+        on actual.medical_claim_id = expected.medical_claim_id
+        and actual.claim_id = expected.claim_id
+        and actual.claim_line_number = expected.claim_line_number
+        and actual.claim_type = expected.claim_type
+        and actual.data_source = expected.data_source
+    where expected.medical_claim_id is null
+)
+
+, invalid_undetermined_semantics as (
+    select
+          'invalid_undetermined_core_semantics' as failure_type
+        , medical_claim_id
+        , claim_id
+        , claim_line_number
+        , claim_type
+        , data_source
+        , 1 as expected_count
+        , 1 as actual_count
+    from {{ ref('core__medical_claim') }}
+    where claim_type = 'undetermined'
+      and (
+           coalesce(service_category_1, '') <> 'other'
+        or coalesce(service_category_2, '') <> 'other'
+        or coalesce(service_category_3, '') <> 'other'
+        or coalesce(encounter_type, '') <> 'orphaned claim'
+        or coalesce(encounter_group, '') <> 'other'
+      )
+)
+
+select *
+from missing_or_duplicate_claim_lines
+
+union all
+
+select *
+from unexpected_claim_lines
+
+union all
+
+select *
+from invalid_undetermined_semantics

--- a/tests/undetermined_claims_excluded_from_combined_encounter_crosswalk.sql
+++ b/tests/undetermined_claims_excluded_from_combined_encounter_crosswalk.sql
@@ -1,0 +1,26 @@
+{{ config(
+     enabled = the_tuva_project.tuva_boolean_var('claims_enabled', false),
+     severity = 'error',
+     tags = ['claims_preprocessing', 'encounter_contract']
+   )
+}}
+
+{#
+  Broad encounter matchers can produce same-day candidate assignments without
+  consulting claim_type. Undetermined claims must remain unclassified so they
+  flow through the orphan fallback and do not acquire claim-line encounter
+  mappings used by Core condition and procedure.
+#}
+
+select
+      crosswalk.claim_id
+    , crosswalk.claim_line_number
+    , crosswalk.data_source
+    , crosswalk.encounter_id
+    , crosswalk.encounter_type
+from {{ ref('encounters__combined_claim_line_crosswalk') }} as crosswalk
+inner join {{ ref('encounters__stg_medical_claim') }} as staged_claim
+    on crosswalk.claim_id = staged_claim.claim_id
+    and crosswalk.claim_line_number = staged_claim.claim_line_number
+    and crosswalk.data_source = staged_claim.data_source
+where staged_claim.claim_type = 'undetermined'


### PR DESCRIPTION
## Summary

- Retain exact claim_type = undetermined medical claim lines by assigning other / other / other service categories.
- Keep those lines out of classified encounter algorithms, including broad same-day matchers, so they receive source-scoped orphaned claim encounters.
- Add contract documentation, non-vacuous cross-warehouse unit coverage, and permanent completeness and encounter-crosswalk invariants.

## Semantics

Only the contract-valid undetermined value is restored. Null and invalid claim types remain excluded and visible through input data quality checks. Core condition and procedure behavior is unchanged because undetermined lines do not enter the classified encounter crosswalk. Restoring medical claims can add rows and amounts to downstream practitioner, location, attribution, cost, and utilization outputs.

## Validation

- Snowflake parse with --no-partial-parse: passed.
- Focused Snowflake DAG build: 26/26 passed.
- Focused DuckDB unit suite: passed.
- Direct combined-crosswalk unit on Snowflake and DuckDB: passed.
- Snowflake full-refresh build excluding unchanged seeds: 471/471 passed, 0 warnings, 0 errors.

The issue originally requested a synthetic-small fixture. Repository data-safety policy requires explicit approval before changing integration_tests/seeds, so this PR instead uses deterministic inline unit fixtures that exercise multiple undetermined lines, source scoping, professional and institutional controls, encounter fallback, the Core boundary, and provider attribution across warehouses.

Release-note disposition: bug

Closes #1388