### PR TITLE
Fix clinical-only person crosswalk enablement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -884,6 +884,18 @@ jobs:
         run: |
           read -r -a ci_selectors <<< "$CI_DBT_SELECTOR"
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/snowflake
+          if [[ "$CI_SCOPE" == "core" ]]; then
+            # Regression for #1392: explicit claims=false must not mask clinical=true.
+            dbt --quiet ls \
+              --project-dir ./integration_tests \
+              --profiles-dir ./integration_tests/profiles/snowflake \
+              --no-partial-parse \
+              --resource-type model \
+              --select core__person_id_crosswalk \
+              --output name \
+              --vars '{"claims_enabled": false, "clinical_enabled": true, "provider_attribution_enabled": false, "data_quality_enabled": false, "parity_enabled": false, "use_coderx_enterprise": false}' \
+              | grep -Fxq core__person_id_crosswalk
+          fi
           dbt build --full-refresh \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/snowflake \

--- a/models/core/final/core__person_id_crosswalk.sql
+++ b/models/core/final/core__person_id_crosswalk.sql
@@ -1,8 +1,6 @@
 {{ config(
-     enabled = the_tuva_project.tuva_boolean_var(
-       'claims_enabled',
-       the_tuva_project.tuva_boolean_var('clinical_enabled', false)
-     )
+     enabled = (the_tuva_project.tuva_boolean_var('claims_enabled', false))
+            or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))
    )
 }}
 


### PR DESCRIPTION
## Summary

- enable `core__person_id_crosswalk` when either strict Boolean domain flag is true, so explicit `claims_enabled: false` no longer masks `clinical_enabled: true`
- add a query-free Core CI regression that asserts the crosswalk remains selectable under the documented clinical-only configuration

## Validation

- demonstrated the new `dbt ls` assertion fails before the gate change and passes afterward
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local parse --no-partial-parse`
- verified claims-only selects the crosswalk and all-off does not select it
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local build --full-refresh --select +core__person_id_crosswalk --exclude resource_type:seed --vars '{"claims_enabled": false, "clinical_enabled": true, "provider_attribution_enabled": false, "data_quality_enabled": false, "parity_enabled": false, "use_coderx_enterprise": false}'`
  - `PASS=7 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=7`
- workflow YAML parsed successfully; `git diff --check` passed

## Release Note Label

- `bug`

Closes #1392
