### PR TITLE
Fix cross-warehouse regex portability

### DIFF
--- a/macros/cross_database_utils/apply_regex.sql
+++ b/macros/cross_database_utils/apply_regex.sql
@@ -1,3 +1,12 @@
+{#
+    Returns a case-sensitive regular-expression search predicate. Patterns are
+    not implicitly anchored; callers can use ^ and $ when they require a
+    full-string match. The default implementation covers Databricks.
+
+    Fabric Warehouse does not expose a general-purpose regular-expression
+    predicate. Use a narrower portable predicate such as is_numeric_string
+    when the required semantics can be expressed across every adapter.
+#}
 {%- macro apply_regex(column_name, regex) -%}
 
     {{ return(adapter.dispatch('apply_regex', 'the_tuva_project')(column_name, regex)) }}
@@ -6,13 +15,13 @@
 
 {%- macro default__apply_regex(column_name, regex) -%}
 
-    regexp_like({{ column_name }}, '{{ regex}}')
+    regexp_like({{ column_name }}, '{{ regex }}')
 
 {%- endmacro -%}
 
 {%- macro snowflake__apply_regex(column_name, regex) -%}
 
-    regexp_like({{ column_name }}, '{{ regex }}')
+    regexp_instr({{ column_name }}, '{{ regex }}') > 0
 
 {%- endmacro -%}
 
@@ -22,15 +31,25 @@
 
 {%- endmacro -%}
 
+{%- macro fabric__apply_regex(column_name, regex) -%}
+
+    {{ exceptions.raise_compiler_error(
+        "the_tuva_project.apply_regex is not supported on Fabric Warehouse. "
+        ~ "Use a portable domain predicate such as "
+        ~ "the_tuva_project.is_numeric_string instead."
+    ) }}
+
+{%- endmacro -%}
+
 {%- macro postgres__apply_regex(column_name, regex) -%}
 
-    {{ column_name }} similar to '{{ regex }}'
+    {{ column_name }} ~ '{{ regex }}'
 
 {%- endmacro -%}
 
 {%- macro redshift__apply_regex(column_name, regex) -%}
 
-     {{ column_name }} similar to '{{ regex }}'
+    {{ column_name }} ~ '{{ regex }}'
 
 {%- endmacro -%}
 
@@ -39,4 +58,3 @@
     regexp_matches({{ column_name }}, '{{ regex }}')
 
 {%- endmacro -%}
-

--- a/macros/cross_database_utils/is_numeric_string.sql
+++ b/macros/cross_database_utils/is_numeric_string.sql
@@ -1,0 +1,45 @@
+{#
+    Returns whether a string has the lexical form of a decimal number:
+
+      * an optional leading + or - sign
+      * zero or more digits before an optional decimal point
+      * one or more trailing digits
+
+    This intentionally rejects whitespace, exponent notation, thousands
+    separators, and a trailing decimal point. A null input returns null.
+#}
+{%- macro is_numeric_string(column_name) -%}
+
+    {{ return(adapter.dispatch('is_numeric_string', 'the_tuva_project')(column_name)) }}
+
+{%- endmacro -%}
+
+{%- macro default__is_numeric_string(column_name) -%}
+
+    {{ the_tuva_project.apply_regex(column_name, '^[+-]?([0-9]*[.])?[0-9]+$') }}
+
+{%- endmacro -%}
+
+{%- macro fabric__is_numeric_string(column_name) -%}
+
+    {%- set unsigned_value -%}
+        case
+            when left({{ column_name }}, 1) in ('+', '-')
+                then substring(
+                    {{ column_name }},
+                    2,
+                    datalength({{ column_name }})
+                )
+            else {{ column_name }}
+        end
+    {%- endset -%}
+
+    (
+            {{ unsigned_value }} like '%[0123456789]'
+        and {{ unsigned_value }} not like '%[^0123456789.]%'
+        and {{ unsigned_value }} not like '%.%.%'
+        and datalength({{ unsigned_value }})
+            = datalength(rtrim({{ unsigned_value }}))
+    )
+
+{%- endmacro -%}

--- a/tests/check_apply_regex_contract.sql
+++ b/tests/check_apply_regex_contract.sql
@@ -1,0 +1,54 @@
+{{ config(
+     enabled = target.type != 'fabric',
+     severity = 'error',
+     tags = ['contract', 'regex_contract']
+   )
+}}
+
+{#
+  apply_regex is a case-sensitive search predicate. These fixtures distinguish
+  search semantics from an implicit full-string match and pin explicit anchor
+  and null behavior across the adapters that expose regular expressions.
+#}
+
+{% if target.type != 'fabric' %}
+{% set regex_cases = [
+    ('unanchored_search', "'prefix123suffix'", '[0-9]+', '1'),
+    ('explicit_start_anchor_rejects_prefix', "'prefix123suffix'", '^[0-9]+', '0'),
+    ('explicit_end_anchor_rejects_suffix', "'prefix123suffix'", '[0-9]+$', '0'),
+    ('explicit_full_string_match', "'123'", '^[0-9]+$', '1'),
+    ('case_sensitive_rejection', "'ABC'", '^[a-z]+$', '0'),
+    ('case_sensitive_match', "'abc'", '^[a-z]+$', '1'),
+    (
+        'null_input',
+        'cast(null as ' ~ dbt.type_string() ~ ')',
+        '[0-9]+',
+        'cast(null as ' ~ dbt.type_int() ~ ')'
+    )
+] %}
+
+with contract_cases as (
+    {% for case in regex_cases %}
+    select
+          '{{ case[0] }}' as case_name
+        , cast(case
+            when {{ the_tuva_project.apply_regex(case[1], case[2]) }} then 1
+            when not ({{ the_tuva_project.apply_regex(case[1], case[2]) }}) then 0
+          end as {{ dbt.type_int() }}) as actual_result
+        , {{ case[3] }} as expected_result
+    {% if not loop.last %}
+    union all
+    {% endif %}
+    {% endfor %}
+)
+
+select
+      case_name
+    , actual_result
+    , expected_result
+from contract_cases
+where coalesce(actual_result, -1) <> coalesce(expected_result, -1)
+{% else %}
+select 1 as disabled_on_fabric
+where 1 = 0
+{% endif %}

--- a/tests/check_numeric_string_contract.sql
+++ b/tests/check_numeric_string_contract.sql
@@ -1,0 +1,74 @@
+{{ config(
+     severity = 'error',
+     tags = ['contract', 'numeric_string_contract']
+   )
+}}
+
+{#
+  Numeric strings are a cross-warehouse lexical contract. The fixture includes
+  signed integers and decimals, a leading decimal point, malformed punctuation,
+  non-decimal notation, whitespace, and null behavior.
+#}
+
+{% set numeric_string_cases = [
+    ('zero', "'0'", '1'),
+    ('unsigned_integer', "'123'", '1'),
+    ('positive_integer', "'+123'", '1'),
+    ('negative_integer', "'-123'", '1'),
+    ('leading_decimal_point', "'.5'", '1'),
+    ('signed_leading_decimal_point', "'-.5'", '1'),
+    ('unsigned_decimal', "'0.5'", '1'),
+    ('positive_decimal', "'+0.5'", '1'),
+    ('negative_decimal', "'-0.5'", '1'),
+    ('leading_zeroes', "'0001.20'", '1'),
+    ('empty_string', "''", '0'),
+    ('sign_only', "'+'", '0'),
+    ('decimal_point_only', "'.'", '0'),
+    ('signed_decimal_point_only', "'-.'", '0'),
+    ('trailing_decimal_point', "'1.'", '0'),
+    ('multiple_decimal_points', "'1..2'", '0'),
+    ('alphabetic_prefix', "'a1'", '0'),
+    ('alphabetic_suffix', "'1a'", '0'),
+    ('leading_whitespace', "' 1'", '0'),
+    ('trailing_whitespace', "'1 '", '0'),
+    ('exponent_notation', "'1e3'", '0'),
+    ('multiple_signs', "'--1'", '0'),
+    ('embedded_sign', "'1-2'", '0'),
+    ('thousands_separator', "'1,000'", '0'),
+    ('nan_literal', "'NaN'", '0'),
+    (
+        'null_input',
+        'cast(null as ' ~ dbt.type_string() ~ ')',
+        'cast(null as ' ~ dbt.type_int() ~ ')'
+    )
+] %}
+
+with test_cases as (
+    {% for case in numeric_string_cases %}
+    select
+          '{{ case[0] }}' as case_name
+        , {{ case[1] }} as input_value
+        , {{ case[2] }} as expected_result
+    {% if not loop.last %}
+    union all
+    {% endif %}
+    {% endfor %}
+)
+
+, actual_results as (
+    select
+          case_name
+        , cast(case
+            when {{ the_tuva_project.is_numeric_string('input_value') }} then 1
+            when not ({{ the_tuva_project.is_numeric_string('input_value') }}) then 0
+          end as {{ dbt.type_int() }}) as actual_result
+        , expected_result
+    from test_cases
+)
+
+select
+      case_name
+    , actual_result
+    , expected_result
+from actual_results
+where coalesce(actual_result, -1) <> coalesce(expected_result, -1)


### PR DESCRIPTION
## Summary

- Standardize apply_regex as a case-sensitive search predicate on Snowflake, Postgres, and Redshift.
- Fail clearly for unsupported arbitrary regex on Fabric Warehouse and add a portable is_numeric_string predicate for the shared mart use case.
- Add contract fixtures for anchoring, case sensitivity, nulls, signed numbers, decimals, and malformed values.

## Validation

- TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local parse --no-partial-parse
- TUVA_DBT_PROFILE=duckdb scripts/dbt-local build --select check_apply_regex_contract check_numeric_string_contract --no-partial-parse
- Combined Core, CMS HCC, and Quality Measures dependency graph parsed and compiled successfully on the Snowflake target.
- Fabric, Redshift, and Databricks adapter rendering verified in isolated adapter environments.
- Hosted Snowflake CI pending.

## Release note

bug

## Issue

Related to #1395. The coordinated CMS HCC and Quality Measures PRs migrate all known callers to is_numeric_string.