### PR TITLE
Make practitioner and location source-native

### DIFF
--- a/macros/core/smart_union.sql
+++ b/macros/core/smart_union.sql
@@ -16,6 +16,11 @@
         relations: List of relations to union
         source_index: Source tracking column name (default: '_source'). Set to none to disable.
 
+    Unit-test override:
+        dbt unit-test refs compile to ephemeral CTEs that cannot be introspected
+        reliably. `_smart_union_columns_override` supplies the complete shared
+        column list for tests whose mocked relations have the same columns.
+
     Usage:
         {{ smart_union([ref('stg_claims'), ref('stg_clinical')]) }}
         -- Adds _source column: 1 = first relation, 2 = second, etc.
@@ -32,15 +37,60 @@
     {{ return('') }}
 {%- endif -%}
 
-{%- set all_columns = {} -%}
-{%- for relation in relations -%}
-    {%- set cols = adapter.get_columns_in_relation(relation) -%}
-    {%- for col in cols -%}
-        {%- if col.name.lower() not in all_columns -%}
-            {%- do all_columns.update({col.name.lower(): col}) -%}
+{%- set columns_override = var('_smart_union_columns_override', none) -%}
+{%- if columns_override is not none -%}
+    {%- if columns_override is string
+        or columns_override is mapping
+        or columns_override is not sequence -%}
+        {%- do exceptions.raise_compiler_error(
+            "Invalid `_smart_union_columns_override`: expected a list of column-name strings."
+        ) -%}
+    {%- endif -%}
+    {%- if columns_override | length == 0 -%}
+        {%- do exceptions.raise_compiler_error(
+            "Invalid `_smart_union_columns_override`: expected at least one column name."
+        ) -%}
+    {%- endif -%}
+    {%- set override_names_by_lower = {} -%}
+    {%- for column_name in columns_override -%}
+        {%- if column_name is not string or column_name | length == 0 -%}
+            {%- do exceptions.raise_compiler_error(
+                "Invalid `_smart_union_columns_override`: every item must be a "
+                ~ "non-empty column-name string."
+            ) -%}
         {%- endif -%}
+        {%- set column_name_lower = column_name | lower -%}
+        {%- if column_name_lower in override_names_by_lower -%}
+            {%- do exceptions.raise_compiler_error(
+                "Invalid `_smart_union_columns_override`: column names `"
+                ~ override_names_by_lower[column_name_lower] ~ "` and `" ~ column_name
+                ~ "` are equal case-insensitively."
+            ) -%}
+        {%- endif -%}
+        {%- do override_names_by_lower.update({column_name_lower: column_name}) -%}
     {%- endfor -%}
-{%- endfor -%}
+{%- endif -%}
+
+{%- set all_columns = {} -%}
+{%- if columns_override is not none -%}
+    {%- for column_name in columns_override -%}
+        {%- do all_columns.update({
+            column_name | lower: {
+                'name': column_name,
+                'data_type': dbt.type_string()
+            }
+        }) -%}
+    {%- endfor -%}
+{%- else -%}
+    {%- for relation in relations -%}
+        {%- set cols = adapter.get_columns_in_relation(relation) -%}
+        {%- for col in cols -%}
+            {%- if col.name.lower() not in all_columns -%}
+                {%- do all_columns.update({col.name.lower(): col}) -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
+{%- endif -%}
 
 {%- set core_cols = [] -%}
 {%- set ext_cols = [] -%}
@@ -55,7 +105,11 @@
 {%- set sorted_columns = core_cols + ext_cols -%}
 
 {%- for relation in relations -%}
-    {%- set relation_cols = adapter.get_columns_in_relation(relation) | map(attribute='name') | map('lower') | list -%}
+    {%- if columns_override is not none -%}
+        {%- set relation_cols = columns_override | map('lower') | list -%}
+    {%- else -%}
+        {%- set relation_cols = adapter.get_columns_in_relation(relation) | map(attribute='name') | map('lower') | list -%}
+    {%- endif -%}
 
     select
     {%- if source_index %}
@@ -63,7 +117,9 @@
     {%- endif %}
     {%- for col in sorted_columns %}
         {%- if col.name.lower() in relation_cols %}
-        {{ adapter.quote(col.name) }}
+        {#- Overrides are an internal unit-test hook and do not carry the
+            adapter-normalized identifier casing returned by introspection. -#}
+        {{ col.name if columns_override is not none else adapter.quote(col.name) }}
         {%- else %}
         cast(null as {{ col.data_type }}) as {{ adapter.quote(col.name) }}
         {%- endif %}

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -1575,9 +1575,15 @@ models:
     description: |-
       The location table contains information about physical locations where clinical care is delivered, documented, or managed. A location may represent a facility, clinic, department, practice site, laboratory, imaging center, or other service location.
 
-      When clinical data is enabled, this table pulls location records from input_layer__location. When claims data is enabled, Tuva derives organization locations from provider data for organization NPIs that appear on medical or pharmacy claims. Clinical extension columns are pulled through when clinical data is enabled.
+      When clinical data is enabled, this table pulls location records from input_layer__location. When claims data is enabled, Tuva derives one organization location per NPI and claims data source from provider data for organization NPIs that appear on medical or pharmacy claims. When both paths produce the same location_id and data_source, the clinical record takes precedence. Clinical extension columns are pulled through when clinical data is enabled.
 
-      Primary key: location_id.
+      Primary key: location_id, data_source.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - location_id
+              - data_source
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_core
@@ -1591,7 +1597,7 @@ models:
           source system location identifier. For claims-derived organization
           locations, this is the organization NPI.
         tests:
-          - unique
+          - not_null
         config:
           meta:
             data_type: varchar
@@ -1668,12 +1674,15 @@ models:
           meta:
             data_type: timestamp
       - name: data_source
-        description: User-defined name that identifies the clinical source system for
-          the location data, when populated. Claims-derived organization
-          locations may have a null data_source.
+        description: User-defined name that identifies the clinical or claims source
+          system from which the location was derived. Claims-derived organization
+          locations retain the data source of the medical or pharmacy claim.
+        tests:
+          - not_null
         config:
           meta:
             data_type: varchar
+            is_primary_key: true
   - name: core__medical_claim
     description: |-
       The medical claim table stores final adjudicated medical claim lines for healthcare services or supplies billed by a provider and adjudicated by a payer. A single claim may have multiple claim lines, so claim_id identifies the claim and claim_line_number identifies the specific line within that claim.
@@ -3243,9 +3252,15 @@ models:
     description: |-
       The practitioner table stores provider records from clinical and claims sources, including source-system practitioner identifiers, NPIs when available, provider names, practice affiliation, specialty, and sub-specialty.
 
-      When clinical data is enabled, this table pulls practitioner records from input_layer__practitioner. When claims data is enabled, Tuva derives practitioner records from provider identifiers that appear on medical and pharmacy claims. Clinical practitioner records should use practitioner_id to preserve the source-system provider identifier; claims-derived records generally use provider identifiers from claims and provider terminology.
+      When clinical data is enabled, this table pulls practitioner records from input_layer__practitioner. When claims data is enabled, Tuva derives one practitioner record per provider identifier and claims data source from medical and pharmacy claims. Clinical practitioner records should use practitioner_id to preserve the source-system provider identifier; claims-derived records generally use provider identifiers from claims and provider terminology. When both paths produce the same practitioner_id and data_source, the clinical record takes precedence.
 
-      Primary key: practitioner_id.
+      Primary key: practitioner_id, data_source.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - practitioner_id
+              - data_source
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_core
@@ -3260,7 +3275,7 @@ models:
           clinical tables. For claims-derived rows, this is generally derived
           from the provider identifier on the claim.
         tests:
-          - unique
+          - not_null
         config:
           meta:
             data_type: varchar
@@ -3323,9 +3338,12 @@ models:
         description: User-defined name that identifies the source of the practitioner
           data, for example a claims payer data source or a clinical system such
           as Epic, Athena Health, or Cerner.
+        tests:
+          - not_null
         config:
           meta:
             data_type: varchar
+            is_primary_key: true
   - name: core__procedure
     description: |-
       The procedure table stores procedures performed for patients from claims and clinical sources.

--- a/models/core/final/core__location.sql
+++ b/models/core/final/core__location.sql
@@ -31,7 +31,7 @@
 {%- endset -%}
 
 with loc as (
-    {{ smart_union([ref('core__stg_claims_location'), ref('normalized__location')], source_index=none) }}
+    {{ smart_union([ref('core__stg_claims_location'), ref('normalized__location')], source_index='_record_source') }}
 )
 
 select
@@ -39,6 +39,14 @@ select
     {{ tuva_extension_columns }}
     {{ tuva_metadata_columns }}
 from loc
+where loc._record_source = 2
+   or not exists (
+        select 1
+        from loc as clinical_location
+        where clinical_location._record_source = 2
+          and clinical_location.location_id = loc.location_id
+          and clinical_location.data_source = loc.data_source
+   )
 
 {% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 

--- a/models/core/final/core__practitioner.sql
+++ b/models/core/final/core__practitioner.sql
@@ -27,7 +27,7 @@
 {%- endset -%}
 
 with prac as (
-    {{ smart_union([ref('core__stg_claims_practitioner'), ref('normalized__practitioner')], source_index=none) }}
+    {{ smart_union([ref('core__stg_claims_practitioner'), ref('normalized__practitioner')], source_index='_record_source') }}
 )
 
 select
@@ -35,6 +35,14 @@ select
     {{ tuva_extension_columns }}
     {{ tuva_metadata_columns }}
 from prac
+where prac._record_source = 2
+   or not exists (
+        select 1
+        from prac as clinical_practitioner
+        where clinical_practitioner._record_source = 2
+          and clinical_practitioner.practitioner_id = prac.practitioner_id
+          and clinical_practitioner.data_source = prac.data_source
+   )
 
 {% elif the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true -%}
 

--- a/models/core/practitioner_location_unit_tests.yml
+++ b/models/core/practitioner_location_unit_tests.yml
@@ -1,0 +1,288 @@
+version: 2
+
+unit_tests:
+  - name: test_claims_location_preserves_source_grain
+    description: >-
+      Verifies that one organization NPI used in two claim sources produces one
+      claims-derived location per source while repeated roles in one source
+      collapse to a single row.
+    model: core__stg_claims_location
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        tuva_last_run: '2024-04-01 00:00:00'
+    given:
+      - input: ref('core__medical_claim')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select
+              '1111111111' as facility_npi
+            , cast(null as {{ string_type }}) as rendering_npi
+            , '1111111111' as billing_npi
+            , 'source_a' as data_source
+          union all
+          select '1111111111', null, '1111111111', 'source_b'
+      - input: ref('core__pharmacy_claim')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select
+              cast(null as {{ string_type }}) as prescribing_provider_id
+            , '1111111111' as dispensing_provider_id
+            , 'source_a' as data_source
+      - input: ref('provider_data__provider')
+        format: sql
+        rows: |
+          select
+              '1111111111' as npi
+            , 'Organization' as entity_type_description
+            , 'Source Health' as provider_organization_name
+            , 'Parent Health' as parent_organization_name
+            , '1 Main Street' as practice_address_line_1
+            , 'Denver' as practice_city
+            , 'CO' as practice_state
+            , '80202' as practice_zip_code
+    expect:
+      rows:
+        - location_id: '1111111111'
+          data_source: source_a
+        - location_id: '1111111111'
+          data_source: source_b
+
+  - name: test_claims_practitioner_preserves_source_grain
+    description: >-
+      Verifies that one individual NPI used in two claim sources produces one
+      claims-derived practitioner per source while repeated roles in one source
+      collapse to a single row.
+    model: core__stg_claims_practitioner
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        tuva_last_run: '2024-04-01 00:00:00'
+    given:
+      - input: ref('core__medical_claim')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select
+              cast(null as {{ string_type }}) as facility_npi
+            , '2222222222' as rendering_npi
+            , '2222222222' as billing_npi
+            , 'source_a' as data_source
+          union all
+          select null, '2222222222', '2222222222', 'source_b'
+      - input: ref('core__pharmacy_claim')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select
+              '2222222222' as prescribing_provider_id
+            , cast(null as {{ string_type }}) as dispensing_provider_id
+            , 'source_a' as data_source
+      - input: ref('provider_data__provider')
+        format: sql
+        rows: |
+          select
+              '2222222222' as npi
+            , 'Individual' as entity_type_description
+            , 'Pat' as provider_first_name
+            , 'Practitioner' as provider_last_name
+            , 'Source Medical Group' as parent_organization_name
+            , 'Family Medicine' as primary_specialty_description
+    expect:
+      rows:
+        - practitioner_id: '2222222222'
+          data_source: source_a
+        - practitioner_id: '2222222222'
+          data_source: source_b
+
+  - name: test_core_location_prefers_clinical_on_source_key_overlap
+    description: >-
+      Verifies that hybrid execution preserves source-native claims and clinical
+      rows while selecting the clinical record when both paths produce the same
+      location_id and data_source.
+    model: core__location
+    config:
+      enabled: "{{ (var('claims_enabled', false) and var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        clinical_enabled: true
+        _extension_columns_override: []
+        _smart_union_columns_override:
+          - location_id
+          - npi
+          - name
+          - facility_type
+          - parent_organization
+          - address
+          - city
+          - state
+          - zip_code
+          - latitude
+          - longitude
+          - ingest_datetime
+          - tuva_last_run
+          - data_source
+    given:
+      - input: ref('core__stg_claims_location')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+              'shared_location' as location_id
+            , '1111111111' as npi
+            , 'Claims location' as name
+            , cast(null as {{ string_type }}) as facility_type
+            , 'Claims parent' as parent_organization
+            , '1 Claims Way' as address
+            , 'Denver' as city
+            , 'CO' as state
+            , '80202' as zip_code
+            , cast(null as decimal(18, 4)) as latitude
+            , cast(null as decimal(18, 4)) as longitude
+            , cast(null as {{ timestamp_type }}) as ingest_datetime
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+            , 'source_a' as data_source
+          union all
+          select
+              'shared_location', '3333333333', 'Claims source B', null, null, null
+            , null, null, null, null, null, null
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'source_b'
+          union all
+          select
+              'claims_only', '5555555555', 'Claims only', null, null, null
+            , null, null, null, null, null, null
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'source_a'
+      - input: ref('normalized__location')
+        format: sql
+        rows: |
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+              'shared_location' as location_id
+            , '1111111111' as npi
+            , 'Clinical location' as name
+            , 'Clinic' as facility_type
+            , 'Clinical parent' as parent_organization
+            , '1 Clinical Way' as address
+            , 'Denver' as city
+            , 'CO' as state
+            , '80202' as zip_code
+            , cast(39.7 as decimal(18, 4)) as latitude
+            , cast(-104.9 as decimal(18, 4)) as longitude
+            , cast('2024-03-01 00:00:00' as {{ timestamp_type }}) as ingest_datetime
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+            , 'source_a' as data_source
+          union all
+          select
+              'clinical_only', null, 'Clinical only', 'Clinic', null, null
+            , null, null, null, null, null
+            , cast('2024-03-01 00:00:00' as {{ timestamp_type }})
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'source_c'
+    expect:
+      rows:
+        - location_id: shared_location
+          name: Clinical location
+          data_source: source_a
+        - location_id: shared_location
+          name: Claims source B
+          data_source: source_b
+        - location_id: claims_only
+          name: Claims only
+          data_source: source_a
+        - location_id: clinical_only
+          name: Clinical only
+          data_source: source_c
+
+  - name: test_core_practitioner_prefers_clinical_on_source_key_overlap
+    description: >-
+      Verifies that hybrid execution preserves source-native claims and clinical
+      rows while selecting the clinical record when both paths produce the same
+      practitioner_id and data_source.
+    model: core__practitioner
+    config:
+      enabled: "{{ (var('claims_enabled', false) and var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        clinical_enabled: true
+        _extension_columns_override: []
+        _smart_union_columns_override:
+          - practitioner_id
+          - npi
+          - first_name
+          - last_name
+          - practice_affiliation
+          - specialty
+          - sub_specialty
+          - ingest_datetime
+          - tuva_last_run
+          - data_source
+    given:
+      - input: ref('core__stg_claims_practitioner')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+              'shared_practitioner' as practitioner_id
+            , '2222222222' as npi
+            , 'Claims' as first_name
+            , 'Practitioner' as last_name
+            , 'Claims group' as practice_affiliation
+            , 'Claims specialty' as specialty
+            , cast(null as {{ string_type }}) as sub_specialty
+            , cast(null as {{ timestamp_type }}) as ingest_datetime
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+            , 'source_a' as data_source
+          union all
+          select
+              'shared_practitioner', '4444444444', 'ClaimsSourceB', 'Practitioner'
+            , null, null, null, null
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'source_b'
+          union all
+          select
+              'claims_only', '5555555555', 'ClaimsOnly', 'Practitioner'
+            , null, null, null, null
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'source_a'
+      - input: ref('normalized__practitioner')
+        format: sql
+        rows: |
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+              'shared_practitioner' as practitioner_id
+            , '2222222222' as npi
+            , 'Clinical' as first_name
+            , 'Practitioner' as last_name
+            , 'Clinical group' as practice_affiliation
+            , 'Clinical specialty' as specialty
+            , 'Clinical sub-specialty' as sub_specialty
+            , cast('2024-03-01 00:00:00' as {{ timestamp_type }}) as ingest_datetime
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+            , 'source_a' as data_source
+          union all
+          select
+              'clinical_only', null, 'ClinicalOnly', 'Practitioner'
+            , null, null, null
+            , cast('2024-03-01 00:00:00' as {{ timestamp_type }})
+            , cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'source_c'
+    expect:
+      rows:
+        - practitioner_id: shared_practitioner
+          first_name: Clinical
+          data_source: source_a
+        - practitioner_id: shared_practitioner
+          first_name: ClaimsSourceB
+          data_source: source_b
+        - practitioner_id: claims_only
+          first_name: ClaimsOnly
+          data_source: source_a
+        - practitioner_id: clinical_only
+          first_name: ClinicalOnly
+          data_source: source_c

--- a/models/core/staging/core__stg_claims_location.sql
+++ b/models/core/staging/core__stg_claims_location.sql
@@ -5,7 +5,9 @@
 }}
 
 with all_providers_in_claims_dataset as (
-select distinct facility_npi as npi
+select distinct
+    facility_npi as npi
+    , data_source
 from {{ ref('core__medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -14,7 +16,9 @@ union
 union distinct
 {% endif %}
 
-select distinct rendering_npi as npi
+select distinct
+    rendering_npi as npi
+    , data_source
 from {{ ref('core__medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -23,7 +27,9 @@ union
 union distinct
 {% endif %}
 
-select distinct billing_npi as npi
+select distinct
+    billing_npi as npi
+    , data_source
 from {{ ref('core__medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -32,7 +38,9 @@ union
 union distinct
 {% endif %}
 
-select distinct prescribing_provider_id as npi
+select distinct
+    prescribing_provider_id as npi
+    , data_source
 from {{ ref('core__pharmacy_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -41,16 +49,20 @@ union
 union distinct
 {% endif %}
 
-select distinct dispensing_provider_id as npi
+select distinct
+    dispensing_provider_id as npi
+    , data_source
 from {{ ref('core__pharmacy_claim') }}
 )
 
 
 , provider as (
-select aa.*
+select
+    aa.*
+    , bb.data_source
 from {{ ref('provider_data__provider') }} as aa
 inner join all_providers_in_claims_dataset as bb
-on aa.npi = bb.npi
+    on aa.npi = bb.npi
 where lower(aa.entity_type_description) = 'organization'
 )
 
@@ -70,5 +82,5 @@ select
     , cast(null as {{ dbt.type_numeric() }}) as longitude
     , cast(null as {{ dbt.type_timestamp() }}) as ingest_datetime
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
-    , cast(null as {{ dbt.type_string() }}) as data_source
+    , cast(data_source as {{ dbt.type_string() }}) as data_source
 from provider

--- a/models/core/staging/core__stg_claims_practitioner.sql
+++ b/models/core/staging/core__stg_claims_practitioner.sql
@@ -12,7 +12,9 @@
 
 
 with all_providers_in_claims_dataset as (
-select distinct facility_npi as npi
+select distinct
+    facility_npi as npi
+    , data_source
 from {{ ref('core__medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -21,7 +23,9 @@ union
 union distinct
 {% endif %}
 
-select distinct rendering_npi as npi
+select distinct
+    rendering_npi as npi
+    , data_source
 from {{ ref('core__medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -30,7 +34,9 @@ union
 union distinct
 {% endif %}
 
-select distinct billing_npi as npi
+select distinct
+    billing_npi as npi
+    , data_source
 from {{ ref('core__medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -39,7 +45,9 @@ union
 union distinct
 {% endif %}
 
-select distinct prescribing_provider_id as npi
+select distinct
+    prescribing_provider_id as npi
+    , data_source
 from {{ ref('core__pharmacy_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -48,16 +56,20 @@ union
 union distinct
 {% endif %}
 
-select distinct dispensing_provider_id as npi
+select distinct
+    dispensing_provider_id as npi
+    , data_source
 from {{ ref('core__pharmacy_claim') }}
 )
 
 
 , provider as (
-select aa.*
+select
+    aa.*
+    , bb.data_source
 from {{ ref('provider_data__provider') }} as aa
 inner join all_providers_in_claims_dataset as bb
-on aa.npi = bb.npi
+    on aa.npi = bb.npi
 where lower(aa.entity_type_description) = 'individual'
 )
 
@@ -73,5 +85,5 @@ select
     , cast(null as {{ dbt.type_string() }}) as sub_specialty
     , cast(null as {{ dbt.type_timestamp() }}) as ingest_datetime
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
-    , cast(null as {{ dbt.type_string() }}) as data_source
+    , cast(data_source as {{ dbt.type_string() }}) as data_source
 from provider


### PR DESCRIPTION
## Summary

- retain claim data_source when deriving Core practitioner and location rows, producing one row per provider identifier and source
- define the public grain as the composite source key and prefer clinical records only on exact key collisions
- add focused staging and hybrid unit coverage, including same-ID cross-source cases

## Validation

- TUVA_DBT_PROFILE=snowflake-dev ../scripts/dbt-local parse --no-partial-parse
- TUVA_DBT_PROFILE=snowflake-dev ../scripts/dbt-local build --select core__stg_claims_location core__stg_claims_practitioner core__location core__practitioner
- TUVA_DBT_PROFILE=snowflake-dev ../scripts/dbt-local build --full-refresh --exclude resource_type:seed (476 passed)
- downstream source-scoped join cardinality check: pharmacy 291 to 291; medical 2075 to 2075

## Release note

breaking-change

Addresses #1393 and #1334.