### PR TITLE
Add explicit package version contract for dbt v2

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify package version contract
+        run: python3 tests/unit/test_data_asset_contract.py
+
       - name: Verify release commit is current main
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ validation, CI, and release rules.
 
 - The repository is `tuva-health/tuva-core`.
 - The dbt project name remains `the_tuva_project` for package compatibility.
-- `dbt_project.yml` declares version `1.0.0` and requires dbt Core 1.10.5 or
-  newer. Do not claim dbt Core 2.0 or Fusion support until those runtimes have
-  been explicitly validated.
+- `dbt_project.yml` declares version `1.0.0` and requires dbt 1.10.5 through
+  2.x. The complete 1.0 package ecosystem is validated against dbt Core 2.0
+  and dbt Fusion on DuckDB.
 - Repository `main` is the active integration line. A version on `main` is not
   a formal release by itself. A release also requires an immutable `v<version>`
   tag, a GitHub release, and any required package data-asset receipt.
@@ -277,7 +277,10 @@ Standard commands from the repository root:
 ```bash
 scripts/dbt-local deps
 scripts/dbt-local debug
+# dbt Core v1
 scripts/dbt-local parse --no-partial-parse
+# dbt Core v2 or dbt Fusion
+scripts/dbt-local parse
 TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local build \
   --select <selector> \
   --exclude resource_type:seed
@@ -298,7 +301,8 @@ package data assets load from public object storage.
 
 - Core model, macro, test, or YAML changes:
   - Run `scripts/dbt-local deps` when dependencies may have changed.
-  - Run `scripts/dbt-local parse --no-partial-parse`.
+  - Run `scripts/dbt-local parse --no-partial-parse` with dbt Core v1, or
+    `scripts/dbt-local parse` with dbt Core v2 or dbt Fusion.
   - Run the narrowest useful Snowflake `dbt build`, excluding unchanged seeds.
   - Run the broader full-refresh build before a PR when feasible.
 - Core asset manifest, seed header, or loader changes:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tuva Core
 
 [![Apache License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-![dbt 1.10.5+](https://img.shields.io/static/v1?logo=dbt&label=dbt&message=1.10.5%2B&color=orange)
+![dbt 1.10.5 through 2.x](https://img.shields.io/static/v1?logo=dbt&label=dbt&message=1.10.5%20to%202.x&color=orange)
 
 Tuva Core is the dbt package that transforms claims, clinical, and other
 healthcare data into a common analytics- and AI-ready data model inside your
@@ -13,9 +13,9 @@ declares the Tuva Core 1.0.0 contract, but a version on `main` is not a formal
 release. Production projects should use an immutable version published in
 [GitHub Releases](https://github.com/tuva-health/tuva-core/releases).
 
-Tuva Core requires dbt Core 1.10.5 or newer and supports Snowflake, Databricks,
-BigQuery, Microsoft Fabric, Redshift, and DuckDB. dbt Core 2.0 and Fusion are
-not claimed as supported until they have been explicitly validated.
+Tuva Core requires dbt 1.10.5 through 2.x and supports Snowflake, Databricks,
+BigQuery, Microsoft Fabric, Redshift, and DuckDB. The 1.0 package ecosystem is
+validated against both dbt Core 2.0 and dbt Fusion on DuckDB.
 
 ## What Tuva Core Includes
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'the_tuva_project'
 version: '1.0.0'
 config-version: 2
-require-dbt-version: ">=1.10.5"
+require-dbt-version: ">=1.10.5,<3.0.0"
 
 profile: default
 

--- a/macros/cross_database_utils/versioned_seed_paths.sql
+++ b/macros/cross_database_utils/versioned_seed_paths.sql
@@ -109,7 +109,7 @@
 {% endmacro %}
 
 
-{% macro load_package_seed(package_name, package_slug, object_path, compression=true, headers=true, null_marker=true, bucket=none) %}
+{% macro load_package_seed(package_slug, package_version, object_path, compression=true, headers=true, null_marker=true, bucket=none) %}
   {% set normalized_object_path = object_path | string | trim | trim('/') %}
   {% if normalized_object_path == '' %}
     {% do exceptions.raise_compiler_error("Tuva package seed object_path must not be empty.") %}
@@ -122,7 +122,7 @@
   {{ return(the_tuva_project.load_seed(
       the_tuva_project.get_package_seed_uri(
           package_slug,
-          the_tuva_project.get_installed_package_version(package_name),
+          package_version,
           object_folder,
           bucket
       ),
@@ -161,8 +161,8 @@
 
   {% set object_path = the_tuva_project.get_seed_database_folder(database) ~ '/' ~ seed_object_name %}
   {{ return(the_tuva_project.load_package_seed(
-      'the_tuva_project',
       'tuva-core',
+      the_tuva_project.get_tuva_package_version(),
       object_path,
       compression,
       headers,
@@ -224,8 +224,8 @@
   {% endif %}
 
   {{ return(the_tuva_project.load_package_seed(
-      'the_tuva_project',
       'tuva-core',
+      the_tuva_project.get_tuva_package_version(),
       the_tuva_project.get_synthetic_seed_object_path(seed_name),
       compression,
       headers,

--- a/macros/system_utils/get_runtime_config.sql
+++ b/macros/system_utils/get_runtime_config.sql
@@ -1,3 +1,0 @@
-{% macro get_runtime_config() %}
-  {{ return(builtins.ref.config) }}
-{% endmacro %}

--- a/macros/system_utils/get_tuva_package_version.sql
+++ b/macros/system_utils/get_tuva_package_version.sql
@@ -1,18 +1,4 @@
-{% macro get_installed_package_version(package_name) %}
-  {% set conf = the_tuva_project.get_runtime_config() %}
-  {% set normalized_package_name = package_name | string | trim %}
-
-  {% if normalized_package_name == '' or normalized_package_name not in conf.dependencies %}
-    {% do exceptions.raise_compiler_error(
-        "Cannot resolve installed dbt package version for '" ~ package_name ~ "'."
-    ) %}
-  {% endif %}
-
-  {% do return(conf.dependencies[normalized_package_name].version) %}
-{% endmacro %}
-
-
-{# Backwards-compatible Tuva Core package-version helper. #}
+{# dbt has no supported Jinja API for package metadata; contract tests keep this literal aligned with dbt_project.yml. #}
 {% macro get_tuva_package_version() %}
-  {% do return(the_tuva_project.get_installed_package_version('the_tuva_project')) %}
+  {% do return('1.0.0') %}
 {% endmacro %}

--- a/models/core/coderx_unit_tests.yml
+++ b/models/core/coderx_unit_tests.yml
@@ -217,6 +217,7 @@ unit_tests:
         format: sql
         rows: |
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select
               'claim_medication' as medication_id
@@ -236,8 +237,8 @@ unit_tests:
             , 'Stale CodeRx Open source description' as source_description
             , '99999999999' as ndc_code
             , 'Stale CodeRx Open normalized description' as ndc_description
-            , null as rxnorm_code
-            , null as atc_code
+            , cast(null as {{ string_type }}) as rxnorm_code
+            , cast(null as {{ string_type }}) as atc_code
             , null as route
             , null as strength
             , 30 as quantity
@@ -250,9 +251,10 @@ unit_tests:
       - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
           select
               '11111111111' as ndc11
-            , null as ndc
+            , cast(null as {{ string_type }}) as ndc
             , '100' as drug_id
             , 'CodeRx Enterprise drug' as drug_name
       - input: ref('core__stg_coderx_drugs')
@@ -262,16 +264,17 @@ unit_tests:
       - input: ref('core__stg_coderx_classes')
         format: sql
         rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
           select
               'no_match' as drug_id
-            , null as atc_1_code
-            , null as atc_1_name
-            , null as atc_2_code
-            , null as atc_2_name
-            , null as atc_3_code
-            , null as atc_3_name
-            , null as atc_4_code
-            , null as atc_4_name
+            , cast(null as {{ string_type }}) as atc_1_code
+            , cast(null as {{ string_type }}) as atc_1_name
+            , cast(null as {{ string_type }}) as atc_2_code
+            , cast(null as {{ string_type }}) as atc_2_name
+            , cast(null as {{ string_type }}) as atc_3_code
+            , cast(null as {{ string_type }}) as atc_3_name
+            , cast(null as {{ string_type }}) as atc_4_code
+            , cast(null as {{ string_type }}) as atc_4_name
           where 1 = 0
     expect:
       rows:
@@ -302,6 +305,7 @@ unit_tests:
         format: sql
         rows: |
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select
               'enterprise_claim_medication' as medication_id
@@ -321,8 +325,8 @@ unit_tests:
             , 'CodeRx Enterprise package drug' as source_description
             , '99988877766' as ndc_code
             , 'CodeRx Enterprise package drug' as ndc_description
-            , null as rxnorm_code
-            , null as atc_code
+            , cast(null as {{ string_type }}) as rxnorm_code
+            , cast(null as {{ string_type }}) as atc_code
             , null as route
             , null as strength
             , 30 as quantity

--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -23,7 +23,7 @@ unit_tests:
         passthrough:
           prefix: 'x_'
           strip: false
-        _extension_columns_override: ['X_CONNECTOR_FIELD']
+        _extension_columns_override: ['X_TUVA_TEST_EXTENSION']
     given:
       - input: ref('normalized__appointment')
         format: sql
@@ -43,16 +43,14 @@ unit_tests:
             , 'Completed' as status
             , 'Follow-up' as reason
             , 'Not cancelled' as cancellation_reason
-            , 'default-prefix-value' as X_CONNECTOR_FIELD
-            , 'custom-prefix-value' as custom__connector_field
-            , 'stripped-value' as branded_connector_field
+            , 'default-prefix-value' as X_TUVA_TEST_EXTENSION
             , cast('2024-01-01 10:00:00' as {{ timestamp_type }}) as ingest_datetime
             , cast('2024-01-02 00:00:00' as {{ timestamp_type }}) as tuva_last_run
             , 'clinical_source' as data_source
     expect:
       rows:
         - appointment_id: appointment_1
-          X_CONNECTOR_FIELD: default-prefix-value
+          X_TUVA_TEST_EXTENSION: default-prefix-value
 
   - name: test_core_appointment_extension_custom_prefix_without_stripping
     description: >
@@ -65,9 +63,9 @@ unit_tests:
       vars:
         clinical_enabled: true
         passthrough:
-          prefix: 'custom__'
+          prefix: 'x_tuva_'
           strip: false
-        _extension_columns_override: ['custom__connector_field']
+        _extension_columns_override: ['x_tuva_test_extension']
     given:
       - input: ref('normalized__appointment')
         format: sql
@@ -87,16 +85,14 @@ unit_tests:
             , 'Completed' as status
             , 'Follow-up' as reason
             , 'Not cancelled' as cancellation_reason
-            , 'default-prefix-value' as X_CONNECTOR_FIELD
-            , 'custom-prefix-value' as custom__connector_field
-            , 'stripped-value' as branded_connector_field
+            , 'custom-prefix-value' as x_tuva_test_extension
             , cast('2024-01-01 10:00:00' as {{ timestamp_type }}) as ingest_datetime
             , cast('2024-01-02 00:00:00' as {{ timestamp_type }}) as tuva_last_run
             , 'clinical_source' as data_source
     expect:
       rows:
         - appointment_id: appointment_1
-          custom__connector_field: custom-prefix-value
+          x_tuva_test_extension: custom-prefix-value
 
   - name: test_core_appointment_extension_custom_prefix_with_stripping
     description: >
@@ -109,9 +105,9 @@ unit_tests:
       vars:
         clinical_enabled: true
         passthrough:
-          prefix: 'BRANDED_'
+          prefix: 'X_TUVA_'
           strip: true
-        _extension_columns_override: ['branded_connector_field']
+        _extension_columns_override: ['x_tuva_test_extension']
     given:
       - input: ref('normalized__appointment')
         format: sql
@@ -131,13 +127,11 @@ unit_tests:
             , 'Completed' as status
             , 'Follow-up' as reason
             , 'Not cancelled' as cancellation_reason
-            , 'default-prefix-value' as X_CONNECTOR_FIELD
-            , 'custom-prefix-value' as custom__connector_field
-            , 'stripped-value' as branded_connector_field
+            , 'stripped-value' as x_tuva_test_extension
             , cast('2024-01-01 10:00:00' as {{ timestamp_type }}) as ingest_datetime
             , cast('2024-01-02 00:00:00' as {{ timestamp_type }}) as tuva_last_run
             , 'clinical_source' as data_source
     expect:
       rows:
         - appointment_id: appointment_1
-          connector_field: stripped-value
+          test_extension: stripped-value

--- a/models/core/ingest_datetime_unit_tests.yml
+++ b/models/core/ingest_datetime_unit_tests.yml
@@ -71,6 +71,8 @@ unit_tests:
             , '555-0101' as phone
             , 'excluded@example.com' as email
             , 'N' as ethnicity
+            , 'clinical_claims_precedence' as x_temp_record_origin
+            , 'patient' as x_tuva_test_extension
             , cast('2024-02-03 04:05:06' as {{ timestamp_type }}) as ingest_datetime
             , cast('2024-04-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
             , 'source' as data_source
@@ -80,7 +82,7 @@ unit_tests:
             , cast('1990-01-01' as date), cast(null as date), 0, '222-22-2222'
             , '3 Clinical Way', 'Denver', 'CO', '80202', 'Denver'
             , cast(39.7 as decimal(18, 4)), cast(-104.9 as decimal(18, 4))
-            , '555-0102', 'clinical@example.com', 'N'
+            , '555-0102', 'clinical@example.com', 'N', 'clinical_only', 'patient'
             , cast('2024-03-04 05:06:07' as {{ timestamp_type }})
             , cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'source'
     expect:

--- a/models/data_quality/logical/clinical_semantic_unit_tests.yml
+++ b/models/data_quality/logical/clinical_semantic_unit_tests.yml
@@ -1430,27 +1430,33 @@ unit_tests:
       - input: ref('terminology__icd_10_cm')
         format: sql
         rows: |
-          select '__dq_no_match__' as icd_10_cm, null as short_description where 1 = 0
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select '__dq_no_match__' as icd_10_cm, cast(null as {{ string_type }}) as short_description where 1 = 0
       - input: ref('terminology__icd_9_cm')
         format: sql
         rows: |
-          select '__dq_no_match__' as icd_9_cm, null as short_description where 1 = 0
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select '__dq_no_match__' as icd_9_cm, cast(null as {{ string_type }}) as short_description where 1 = 0
       - input: ref('terminology__icd_10_pcs')
         format: sql
         rows: |
-          select '__dq_no_match__' as icd_10_pcs, null as description where 1 = 0
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select '__dq_no_match__' as icd_10_pcs, cast(null as {{ string_type }}) as description where 1 = 0
       - input: ref('terminology__icd_9_pcs')
         format: sql
         rows: |
-          select '__dq_no_match__' as icd_9_pcs, null as short_description where 1 = 0
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select '__dq_no_match__' as icd_9_pcs, cast(null as {{ string_type }}) as short_description where 1 = 0
       - input: ref('terminology__hcpcs_level_2')
         format: sql
         rows: |
-          select '__dq_no_match__' as hcpcs, null as short_description where 1 = 0
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select '__dq_no_match__' as hcpcs, cast(null as {{ string_type }}) as short_description where 1 = 0
       - input: ref('terminology__snomed_ct')
         format: sql
         rows: |
-          select '__dq_no_match__' as snomed_ct, null as description where 1 = 0
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select '__dq_no_match__' as snomed_ct, cast(null as {{ string_type }}) as description where 1 = 0
       - input: ref('terminology__loinc')
         format: sql
         rows: |
@@ -1489,6 +1495,7 @@ unit_tests:
         format: sql
         rows: |
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select
               'ndc_case' as medication_id
@@ -1506,8 +1513,8 @@ unit_tests:
             , 'NDC' as source_code_type
             , '12345-6789-01' as source_code
             , 'Raw NDC description' as source_description
-            , null as ndc_code
-            , null as ndc_description
+            , cast(null as {{ string_type }}) as ndc_code
+            , cast(null as {{ string_type }}) as ndc_description
             , null as rxnorm_code
             , null as atc_code
             , null as route

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: "1.0.0"
+    version: "1.2.1"
 
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,10 @@ Use `scripts/dbt-local` from the Tuva Core repo root to run dbt against the
 
 ```bash
 scripts/dbt-local deps
+# dbt Core v1
 scripts/dbt-local parse --no-partial-parse
+# dbt Core v2 or dbt Fusion
+scripts/dbt-local parse
 scripts/dbt-local build --full-refresh
 ```
 

--- a/tests/check_public_flag_contract.sql
+++ b/tests/check_public_flag_contract.sql
@@ -79,7 +79,12 @@
 
         {% for flag_name in contract_relation['flags'] %}
             {% set documented_column = model_node.columns.get(flag_name) if model_node is not none else none %}
-            {% set declared_type = documented_column.meta.get('data_type') if documented_column is not none else none %}
+            {% set column_meta = documented_column.config.meta
+                if documented_column is not none
+                and documented_column.config is not none
+                and documented_column.config.meta is not none
+                else {} %}
+            {% set declared_type = column_meta.get('data_type') %}
 
             {% if declared_type != 'integer' %}
                 {% set metadata_query %}

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -112,8 +112,59 @@ class DataAssetContractTest(unittest.TestCase):
 
     def test_package_version_is_the_only_asset_version(self):
         project_text = (ROOT / "dbt_project.yml").read_text()
+        version_macro_path = (
+            ROOT / "macros" / "system_utils" / "get_tuva_package_version.sql"
+        )
+        version_macro = version_macro_path.read_text()
         obsolete_version_var = "tuva_seed_" + "versions"
-        self.assertRegex(project_text, r"(?m)^version: '[1-9][0-9]*\.[0-9]+\.[0-9]+'$")
+        project_version_match = re.search(
+            r"(?m)^version: '([1-9][0-9]*\.[0-9]+\.[0-9]+"
+            r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)'$",
+            project_text,
+        )
+        macro_version_match = re.search(
+            r"return\('([1-9][0-9]*\.[0-9]+\.[0-9]+"
+            r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)'\)",
+            version_macro,
+        )
+        self.assertIsNotNone(project_version_match)
+        self.assertIsNotNone(macro_version_match)
+        self.assertEqual(project_version_match.group(1), macro_version_match.group(1))
+        self.assertIn(
+            'require-dbt-version: ">=1.10.5,<3.0.0"',
+            project_text,
+        )
+        self.assertIn(
+            'version: "1.2.1"',
+            (ROOT / "packages.yml").read_text(),
+        )
+        runtime_config_path = (
+            ROOT / "macros" / "system_utils" / ("get_runtime_" + "config.sql")
+        )
+        self.assertFalse(runtime_config_path.exists())
+        macro_text = "\n".join(
+            path.read_text() for path in sorted((ROOT / "macros").rglob("*.sql"))
+        )
+        for forbidden_runtime_access in (
+            "builtins." + "ref.config",
+            "config." + "dependencies",
+            "get_installed_" + "package_version",
+        ):
+            self.assertNotIn(forbidden_runtime_access, macro_text)
+
+        release_workflow = (
+            ROOT / ".github" / "workflows" / "create-release.yml"
+        ).read_text()
+        contract_command = "run: python3 tests/unit/test_data_asset_contract.py"
+        self.assertEqual(release_workflow.count(contract_command), 1)
+        self.assertLess(
+            release_workflow.index("uses: actions/checkout@"),
+            release_workflow.index(contract_command),
+        )
+        self.assertLess(
+            release_workflow.index(contract_command),
+            release_workflow.index("- name: Verify release commit is current main"),
+        )
 
         searchable_files = [
             ROOT / "dbt_project.yml",
@@ -137,9 +188,10 @@ class DataAssetContractTest(unittest.TestCase):
             ROOT / "macros" / "cross_database_utils" / "load_seed.sql"
         ).read_text()
 
-        self.assertIn("macro get_installed_package_version(package_name)", version_macro)
+        self.assertIn("macro get_tuva_package_version()", version_macro)
+        self.assertNotIn("get_installed_" + "package_version", version_macro)
         self.assertIn(
-            "macro load_package_seed(package_name, package_slug, object_path",
+            "macro load_package_seed(package_slug, package_version, object_path",
             path_macro,
         )
         self.assertIn(
@@ -156,7 +208,10 @@ class DataAssetContractTest(unittest.TestCase):
         )
         self.assertIn("version overrides were removed in 1.0", path_macro)
         self.assertIn("macro get_seed_bucket(database, package_slug=none)", path_macro)
-        self.assertIn("'the_tuva_project',\n      'tuva-core'", path_macro)
+        self.assertIn(
+            "'tuva-core',\n      the_tuva_project.get_tuva_package_version()",
+            path_macro,
+        )
         self.assertIn("var('custom_bucket_name', 'tuva-public-resources')", path_macro)
         self.assertIn("var('tuva_seed_buckets', {})", path_macro)
 


### PR DESCRIPTION
## Summary

- replace the unsupported dbt runtime dependency lookup with an explicit Tuva Core 1.0.0 package-version macro
- pass package versions explicitly through the shared seed loader and enforce the version contract before release
- require dbt 1.10.5 through 2.x, update dbt-utils, and align unit fixtures and manifest metadata access with Core 2 and Fusion

## Validation

- dbt Core 1.10.5 combined DuckDB build: all seeds and models materialized; final 315 data tests and 50 unit tests passed
- dbt Core 2.0.0-beta.2 combined DuckDB build: 976 successes, 34 no-ops, zero errors; 50 of 50 unit tests passed
- dbt Fusion 2.0.0-preview.218 combined DuckDB build: 976 successes, 34 no-ops, zero errors; 50 of 50 unit tests passed
- dbt Core 1.11.2 combined build and 50 of 50 unit tests passed
- python3 -m unittest discover -s tests/unit -p test_*.py
- git diff --check

## Release note

enhancement

## Linked issue

None