### PR TITLE
Add cross-database function layer

### DIFF
--- a/integration_tests/models/_cross_db_macro_expectations.yml
+++ b/integration_tests/models/_cross_db_macro_expectations.yml
@@ -1,0 +1,79 @@
+version: 2
+
+models:
+  - name: cross_db_macro_expectations
+    description: >
+      One row holding the rendered result of every macro in the Tuva Core
+      cross-database function layer applied to literal inputs. Each column is
+      asserted against the value the macro is documented to return, so a build
+      on any adapter fails loudly when that adapter's spelling drifts.
+    config:
+      tags: [cross_database_utils]
+    tests:
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_trim_strips_surrounding_whitespace
+          arguments:
+            expression: "trim_result = 'padded'"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_left_takes_leading_characters
+          arguments:
+            expression: "left_result = 'abc'"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_greatest_returns_larger_value
+          arguments:
+            expression: "greatest_result = 7"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_greatest_ignores_null_argument
+          arguments:
+            expression: "greatest_null_result = 3"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_safe_divide_returns_quotient
+          arguments:
+            expression: "safe_divide_result = 2.5"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_safe_divide_by_zero_is_null
+          arguments:
+            expression: "safe_divide_by_zero_result is null"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_round_honors_precision
+          arguments:
+            expression: "round_result = 3.14"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_round_defaults_to_whole_numbers
+          arguments:
+            expression: "round_default_precision_result = 4"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_bool_and_agg_is_false_when_any_row_is_false
+          arguments:
+            expression: "bool_and_agg_result = 0"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_bool_or_agg_is_true_when_any_row_is_true
+          arguments:
+            expression: "bool_or_agg_result = 1"
+      - dbt_utils.expression_is_true:
+          name: cross_db_macro_expectations_string_agg_joins_in_order
+          arguments:
+            expression: "string_agg_result = 'a,b,c'"
+    columns:
+      - name: trim_result
+        description: "the_tuva_project.trim('  padded  ')"
+      - name: left_result
+        description: "the_tuva_project.left('abcdef', 3)"
+      - name: greatest_result
+        description: "the_tuva_project.greatest(7, 3)"
+      - name: greatest_null_result
+        description: "the_tuva_project.greatest(null, 3)"
+      - name: safe_divide_result
+        description: "the_tuva_project.safe_divide(10, 4)"
+      - name: safe_divide_by_zero_result
+        description: "the_tuva_project.safe_divide(10, 0)"
+      - name: round_result
+        description: "the_tuva_project.round(3.14159, 2)"
+      - name: round_default_precision_result
+        description: "the_tuva_project.round(3.6)"
+      - name: bool_and_agg_result
+        description: "the_tuva_project.bool_and_agg over (true, false, true), cast to int"
+      - name: bool_or_agg_result
+        description: "the_tuva_project.bool_or_agg over (true, false, true), cast to int"
+      - name: string_agg_result
+        description: "the_tuva_project.string_agg over ('a', 'b', 'c') ordered by ordinal"

--- a/integration_tests/models/cross_db_macro_expectations.sql
+++ b/integration_tests/models/cross_db_macro_expectations.sql
@@ -1,0 +1,72 @@
+{#
+
+    Renders every macro in the cross-database function layer against literal
+    inputs, so a single build proves on the target adapter that each macro
+    compiles and returns its documented value. The companion schema file
+    asserts those values.
+
+    Two adapter-shaped decisions:
+
+    - Fabric spells booleans `bit` and has no boolean literal, so the literal
+      rows below pick their boolean type and literals from `target.type`, the
+      same way the Core unit tests pick their timestamp type.
+    - The boolean aggregates are cast to int in the output so one assertion
+      covers both the boolean-returning adapters and Fabric's bit.
+
+#}
+
+{{ config(materialized='table') }}
+
+{%- set boolean_type = 'bit' if target.type in ['fabric', 'sqlserver'] else 'boolean' -%}
+{%- set true_literal = '1' if target.type in ['fabric', 'sqlserver'] else 'true' -%}
+{%- set false_literal = '0' if target.type in ['fabric', 'sqlserver'] else 'false' -%}
+{%- set decimal_type = 'numeric' if target.type == 'bigquery' else 'decimal(18, 6)' -%}
+
+with literal_rows as (
+
+    select
+        1 as ordinal
+      , cast({{ true_literal }} as {{ boolean_type }}) as flag
+      , cast('a' as {{ dbt.type_string() }}) as token
+
+    union all
+    select
+        2 as ordinal
+      , cast({{ false_literal }} as {{ boolean_type }}) as flag
+      , cast('b' as {{ dbt.type_string() }}) as token
+
+    union all
+    select
+        3 as ordinal
+      , cast({{ true_literal }} as {{ boolean_type }}) as flag
+      , cast('c' as {{ dbt.type_string() }}) as token
+
+)
+
+, scalar_expectations as (
+
+    select
+        {{ the_tuva_project.trim("'  padded  '") }} as trim_result
+      , {{ the_tuva_project.left("'abcdef'", 3) }} as left_result
+      , {{ the_tuva_project.greatest(7, 3) }} as greatest_result
+      , {{ the_tuva_project.greatest('cast(null as int)', 3) }} as greatest_null_result
+      , {{ the_tuva_project.safe_divide('cast(10 as ' ~ decimal_type ~ ')', 'cast(4 as ' ~ decimal_type ~ ')') }} as safe_divide_result
+      , {{ the_tuva_project.safe_divide('cast(10 as ' ~ decimal_type ~ ')', 'cast(0 as ' ~ decimal_type ~ ')') }} as safe_divide_by_zero_result
+      , {{ the_tuva_project.round('cast(3.14159 as ' ~ decimal_type ~ ')', 2) }} as round_result
+      , {{ the_tuva_project.round('cast(3.6 as ' ~ decimal_type ~ ')') }} as round_default_precision_result
+
+)
+
+, aggregate_expectations as (
+
+    select
+        cast({{ the_tuva_project.bool_and_agg('flag') }} as int) as bool_and_agg_result
+      , cast({{ the_tuva_project.bool_or_agg('flag') }} as int) as bool_or_agg_result
+      , {{ the_tuva_project.string_agg('token', "','", 'order by ordinal') }} as string_agg_result
+    from literal_rows
+
+)
+
+select *
+from scalar_expectations
+cross join aggregate_expectations

--- a/integration_tests/profiles/duckdb/profiles.yml
+++ b/integration_tests/profiles/duckdb/profiles.yml
@@ -1,0 +1,7 @@
+default:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: "{{ env_var('TUVA_DUCKDB_PATH', '/tmp/tuva_core.duckdb') }}"
+      threads: 1

--- a/macros/cross_database_utils/bool_and_agg.sql
+++ b/macros/cross_database_utils/bool_and_agg.sql
@@ -1,0 +1,28 @@
+{#
+
+    Aggregate that is true when every non-null input row is true.
+
+    Fabric has no boolean aggregate, so it takes the minimum of the bit
+    column widened to int and narrows the result back to bit.
+
+#}
+
+{% macro bool_and_agg(expression) %}
+  {{ return(adapter.dispatch('bool_and_agg', 'the_tuva_project')(expression)) }}
+{% endmacro %}
+
+{% macro default__bool_and_agg(expression) %}
+  bool_and( {{ expression }} )
+{% endmacro %}
+
+{% macro snowflake__bool_and_agg(expression) %}
+  booland_agg( {{ expression }} )
+{% endmacro %}
+
+{% macro bigquery__bool_and_agg(expression) %}
+  logical_and( {{ expression }} )
+{% endmacro %}
+
+{% macro fabric__bool_and_agg(expression) %}
+  cast( min( cast( {{ expression }} as int) ) as bit)
+{% endmacro %}

--- a/macros/cross_database_utils/bool_or_agg.sql
+++ b/macros/cross_database_utils/bool_or_agg.sql
@@ -1,0 +1,28 @@
+{#
+
+    Aggregate that is true when at least one non-null input row is true.
+
+    Fabric has no boolean aggregate, so it takes the maximum of the bit
+    column widened to int and narrows the result back to bit.
+
+#}
+
+{% macro bool_or_agg(expression) %}
+  {{ return(adapter.dispatch('bool_or_agg', 'the_tuva_project')(expression)) }}
+{% endmacro %}
+
+{% macro default__bool_or_agg(expression) %}
+  bool_or( {{ expression }} )
+{% endmacro %}
+
+{% macro snowflake__bool_or_agg(expression) %}
+  boolor_agg( {{ expression }} )
+{% endmacro %}
+
+{% macro bigquery__bool_or_agg(expression) %}
+  logical_or( {{ expression }} )
+{% endmacro %}
+
+{% macro fabric__bool_or_agg(expression) %}
+  cast( max( cast( {{ expression }} as int) ) as bit)
+{% endmacro %}

--- a/macros/cross_database_utils/greatest.sql
+++ b/macros/cross_database_utils/greatest.sql
@@ -1,0 +1,25 @@
+{#
+
+    Returns the larger of two expressions.
+
+    This mirrors `least` exactly, including its null handling: warehouses
+    disagree about whether a null argument makes the whole call null
+    (Snowflake, BigQuery and Redshift propagate it; DuckDB, Postgres and
+    Databricks ignore it), so both macros express the comparison with a
+    case expression and treat null as "no value" rather than "unknown".
+
+#}
+
+{% macro greatest(a, b) %}
+  {{ return(adapter.dispatch('greatest', 'the_tuva_project')(a, b)) }}
+{% endmacro %}
+
+{% macro default__greatest(a, b) %}
+  case
+    when {{ a }} is null and {{ b }} is null then null
+    when {{ a }} is null then {{ b }}
+    when {{ b }} is null then {{ a }}
+    when {{ a }} >= {{ b }} then {{ a }}
+    else {{ b }}
+  end
+{% endmacro %}

--- a/macros/cross_database_utils/left.sql
+++ b/macros/cross_database_utils/left.sql
@@ -1,0 +1,17 @@
+{#
+
+    Returns the leftmost `length` characters of a string expression.
+
+    Every dialect Tuva targets today spells this the same way. The wrapper
+    exists so a future adapter that does not can be handled in one place
+    instead of at every call site.
+
+#}
+
+{% macro left(expression, length) %}
+  {{ return(adapter.dispatch('left', 'the_tuva_project')(expression, length)) }}
+{% endmacro %}
+
+{% macro default__left(expression, length) %}
+  left( {{ expression }}, {{ length }} )
+{% endmacro %}

--- a/macros/cross_database_utils/round.sql
+++ b/macros/cross_database_utils/round.sql
@@ -1,0 +1,17 @@
+{#
+
+    Rounds a numeric expression to `precision` decimal places.
+
+    Every dialect Tuva targets today spells this the same way. The wrapper
+    exists so a future adapter that does not can be handled in one place
+    instead of at every call site.
+
+#}
+
+{% macro round(expression, precision=0) %}
+  {{ return(adapter.dispatch('round', 'the_tuva_project')(expression, precision)) }}
+{% endmacro %}
+
+{% macro default__round(expression, precision=0) %}
+  round( {{ expression }}, {{ precision }} )
+{% endmacro %}

--- a/macros/cross_database_utils/safe_divide.sql
+++ b/macros/cross_database_utils/safe_divide.sql
@@ -1,0 +1,18 @@
+{#
+
+    Divides `numerator` by `denominator`, returning null instead of raising
+    when the denominator is zero.
+
+#}
+
+{% macro safe_divide(numerator, denominator) %}
+  {{ return(adapter.dispatch('safe_divide', 'the_tuva_project')(numerator, denominator)) }}
+{% endmacro %}
+
+{% macro default__safe_divide(numerator, denominator) %}
+  ( {{ numerator }} ) / nullif( {{ denominator }}, 0 )
+{% endmacro %}
+
+{% macro bigquery__safe_divide(numerator, denominator) %}
+  safe_divide( {{ numerator }}, {{ denominator }} )
+{% endmacro %}

--- a/macros/cross_database_utils/string_agg.sql
+++ b/macros/cross_database_utils/string_agg.sql
@@ -1,0 +1,18 @@
+{#
+
+    Concatenates a string expression across a group.
+
+    A thin wrapper over `dbt.listagg`, which already carries the per-adapter
+    spellings. The arguments are passed through unchanged, so `delimiter` is
+    a quoted SQL literal ("','") and `order_by` is a full clause
+    ("order by ordinal"), exactly as `dbt.listagg` expects them.
+
+#}
+
+{% macro string_agg(expression, delimiter, order_by=none) %}
+  {{ return(adapter.dispatch('string_agg', 'the_tuva_project')(expression, delimiter, order_by)) }}
+{% endmacro %}
+
+{% macro default__string_agg(expression, delimiter, order_by=none) %}
+  {{ dbt.listagg(measure=expression, delimiter_text=delimiter, order_by_clause=order_by) }}
+{% endmacro %}

--- a/macros/cross_database_utils/trim.sql
+++ b/macros/cross_database_utils/trim.sql
@@ -1,0 +1,17 @@
+{#
+
+    Removes leading and trailing whitespace from a string expression.
+
+    Every dialect Tuva targets today spells this the same way. The wrapper
+    exists so a future adapter that does not can be handled in one place
+    instead of at every call site.
+
+#}
+
+{% macro trim(expression) %}
+  {{ return(adapter.dispatch('trim', 'the_tuva_project')(expression)) }}
+{% endmacro %}
+
+{% macro default__trim(expression) %}
+  trim( {{ expression }} )
+{% endmacro %}


### PR DESCRIPTION
Adds a shared cross-database macro set. Every macro lives in `macros/cross_database_utils/`, one file per macro, dispatched as `adapter.dispatch('<name>', 'the_tuva_project')`, with `default__` emitting plain ANSI and adapter overrides only where the dialect actually diverges.

| Macro | `default__` emits | Overrides |
|---|---|---|
| `trim(expression)` | `trim(expr)` | none |
| `left(expression, length)` | `left(expr, n)` | none |
| `round(expression, precision=0)` | `round(expr, p)` | none |
| `greatest(a, b)` | null-tolerant `case` (mirrors `least`) | none |
| `safe_divide(numerator, denominator)` | `(num) / nullif(den, 0)` | bigquery: native `safe_divide` |
| `bool_and_agg(expression)` | `bool_and(expr)` | snowflake `booland_agg`, bigquery `logical_and`, fabric `min` over `cast(expr as int)` |
| `bool_or_agg(expression)` | `bool_or(expr)` | snowflake `boolor_agg`, bigquery `logical_or`, fabric `max` over `cast(expr as int)` |
| `string_agg(expression, delimiter, order_by=none)` | thin wrapper over `dbt.listagg` | none |

No existing macro's signature changes.

Also adds `integration_tests/profiles/duckdb/profiles.yml` (the README's local DuckDB example, with the database path env-overridable) and `integration_tests/models/cross_db_macro_expectations`, one row with one column per macro applied to literals, plus a schema file asserting each documented value.

### Two judgment calls worth a look

1. **`greatest` emits a `case` expression, not native `greatest(...)`.** `least` has no adapter overrides precisely because it is written as a null-tolerant `case`, and warehouses disagree about native `GREATEST`/`LEAST` null semantics: Snowflake, BigQuery and Redshift propagate null, while DuckDB, Postgres and Databricks ignore it. Emitting native `greatest(...)` would reintroduce exactly the divergence this layer exists to remove, so `greatest` mirrors `least`'s body as well as its signature. `greatest_null_result` in the expectation model pins that behavior.
2. **No `fabric__round` override.** T-SQL's `ROUND(x, n)` matches ANSI, and Fabric cannot be exercised without credentials, so none is shipped. The expectation model will catch it on the next all-warehouses run if that turns out to be wrong.

The boolean aggregates are cast to `int` in the expectation model so one assertion covers both the boolean-returning adapters and Fabric's `bit`. The literal rows pick their boolean type from `target.type`, the same way the Core unit tests pick their timestamp type.

### Verification (run locally on dbt-core 1.11.14 / dbt-duckdb 1.10.1)

- `cd integration_tests && dbt deps && dbt build --full-refresh --profiles-dir profiles/duckdb --select cross_db_macro_expectations`: exit 0, `PASS=13 WARN=0 ERROR=0`.
- `dbt parse` clean at repo root with a dummy DuckDB profile: exit 0.
- `git diff --stat` touches only `macros/cross_database_utils/` and `integration_tests/`.
- `expression_is_true` passes vacuously on an empty table, so the materialized row was inspected directly: exactly 1 row, every value as documented. A negative control, flipping the expected `string_agg` value, was confirmed to fail the build.
- The three existing `tests/unit/*.py` contract tests still pass.
- Cross-checked on the Fusion engine (2.0.0-preview.218): `dbt parse` is clean at the repo root, and the same expectation build is `13 total | 13 success`.
