### PR TITLE
Add a portability linter for non-portable SQL in models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,29 @@ env:
     {"MAX_GROUPING_DEPTH": 100, "MAX_GROUPING_TOKENS": 100000}
 
 jobs:
+  portability_lint:
+    name: Portability lint
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Test the portability linter
+        run: python3 scripts/test_portability_lint.py
+
+      - name: Lint models for non-portable SQL
+        run: python3 scripts/portability_lint.py
+
   resolve:
     name: Resolve request
     runs-on: ubuntu-latest

--- a/scripts/portability_baseline.txt
+++ b/scripts/portability_baseline.txt
@@ -1,0 +1,40 @@
+# Known non-portable SQL, written by scripts/portability_lint.py
+# --update-baseline. Format: <relpath>:<rule>:<count>. A file and
+# rule pair at or under its count passes; anything above fails.
+# This file only shrinks -- never raise a count to land a change.
+models/claims_preprocessing/member_month/member_month__member_month.sql:dbt_utils:1
+models/claims_preprocessing/member_month/member_month_models.yml:dbt_utils:1
+models/claims_preprocessing/provider_attribution/final/provider_attribution__provider_ranking.sql:trim:1
+models/claims_preprocessing/provider_attribution/final/provider_attribution__tuva_member_month_attribution.sql:left:1
+models/claims_preprocessing/provider_attribution/final/provider_attribution__tuva_member_month_attribution.sql:substr:1
+models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_person_years.sql:left:2
+models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_person_years.sql:substr:2
+models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__int_primary_care_claims.sql:trim:1
+models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__provider_classification.sql:right:2
+models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__provider_classification.sql:substr:2
+models/claims_preprocessing/provider_attribution/intermediate/provider_attribution__provider_classification.sql:trim:7
+models/claims_preprocessing/provider_attribution/provider_attribution_models.yml:dbt_utils:5
+models/claims_preprocessing/service_category/intermediate/service_category__combined_institutional_header_level.sql:dbt_utils:1
+models/claims_preprocessing/service_category/intermediate/service_category__combined_institutional_line_level.sql:dbt_utils:1
+models/claims_preprocessing/service_category/intermediate/service_category__combined_professional.sql:dbt_utils:1
+models/claims_preprocessing/service_category/service_category_models.yml:dbt_utils:1
+models/core/core_models.yml:dbt_utils:17
+models/core/intermediate/int_cost_service_category_1_allowed_pivot.sql:dbt_utils:1
+models/core/intermediate/int_cost_service_category_1_paid_pivot.sql:dbt_utils:1
+models/core/intermediate/int_cost_service_category_2_allowed_pivot.sql:dbt_utils:1
+models/core/intermediate/int_cost_service_category_2_paid_pivot.sql:dbt_utils:1
+models/core/staging/core__stg_claims_encounter.sql:dbt_utils:1
+models/data_quality/data_quality_models.yml:dbt_utils:16
+models/data_quality/rollups/data_quality_rollup_models.yml:dbt_utils:7
+models/normalized_layer/intermediate/int_eligibility_state_normalized.sql:trim:6
+models/normalized_layer/intermediate/normalized_input__int_place_of_service_normalize.sql:right:1
+models/normalized_layer/intermediate/normalized_input__int_revenue_center_normalize.sql:right:1
+models/normalized_layer/normalized_layer_models.yml:dbt_utils:4
+models/parity/parity__metrics.sql:trim:6
+seeds/value_sets/cms_provider_attribution/cms_provider_attribution_seeds.yml:dbt_utils:1
+seeds/value_sets/condition_grouper/condition_grouper_seeds.yml:dbt_utils:2
+seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml:dbt_utils:2
+tests/claims_preprocessing/provider_attribution/test_tuva_attribution_member_month_traceability.sql:left:1
+tests/claims_preprocessing/provider_attribution/test_tuva_attribution_member_month_traceability.sql:substr:1
+tests/claims_preprocessing/provider_attribution/test_tuva_attribution_member_month_year_consistency.sql:left:2
+tests/claims_preprocessing/provider_attribution/test_tuva_attribution_member_month_year_consistency.sql:substr:2

--- a/scripts/portability_lint.py
+++ b/scripts/portability_lint.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+"""Flag raw SQL in dbt models that does not compile on every warehouse Tuva supports.
+
+Rules live in scripts/portability_rules.yml, in five kinds:
+
+  forbidden             a function that must never appear as raw SQL in a model.
+  forbidden_keywords    the same, for a bare word rather than a call.
+  forbidden_syntax      a non-portable operator, named here and patterned below.
+  forbidden_references  a macro namespace that must not be called.
+  wrap_required         a function whose spelling is owned by a macro in
+                        macros/cross_database_utils/, and which is therefore
+                        allowed inside that directory and nowhere else.
+
+A model file is read as two complementary views that both keep their original
+line and column positions: the SQL outside Jinja, and the Jinja itself. The
+SQL-shaped rules are matched against the SQL view, so a call already routed
+through a macro is not a violation. `forbidden_references` is matched against
+the Jinja view instead, and against schema files whole, because that is where
+a namespaced macro or generic test actually appears.
+
+Files under macros/cross_database_utils/ are the dialect layer: per-adapter
+spellings are supposed to live there, so the SQL-shaped rules are waived.
+`forbidden_references` still applies, since nothing in that layer has any
+business calling another package's macros.
+
+A single occurrence can be waived with a same-line pragma::
+
+    select nvl(a, b) as x  -- tuva-lint: allow(nvl)
+
+Known violations are recorded in scripts/portability_baseline.txt as
+``<relpath>:<rule>:<count>`` lines. The file is a ratchet: anything above its
+count fails with the file, line and suggestion, and anything *below* it fails
+too, asking for ``--update-baseline`` so the recorded debt comes down in the
+same change and cannot grow back later.
+
+Exit status is 0 when clean, 1 when there are violations above baseline, and 2
+when the rules or baseline file cannot be read. Standard library only, so every
+repo can carry a copy without a virtualenv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RULES_PATH = ROOT / "scripts" / "portability_rules.yml"
+BASELINE_PATH = ROOT / "scripts" / "portability_baseline.txt"
+DIALECT_LAYER_DIR = Path("macros") / "cross_database_utils"
+DEFAULT_SCAN_DIRS = ("models", "macros", "tests", "seeds", "snapshots", "analyses")
+# Installed packages and build output are never ours to lint.
+EXCLUDED_DIR_NAMES = frozenset({"dbt_packages", "dbt_internal_packages", "target", "logs"})
+SQL_SUFFIXES = (".sql",)
+SCHEMA_SUFFIXES = (".yml", ".yaml")
+
+PRAGMA_PATTERN = re.compile(r"tuva-lint:\s*allow\(([^)]*)\)", re.IGNORECASE)
+
+# Operators cannot be expressed as a bare name in the rules file, so the rules
+# file names them and the pattern lives here.
+SYNTAX_PATTERNS = {
+    "double_colon_cast": re.compile(r"::\s*[A-Za-z_]"),
+    "pipe_concat": re.compile(r"\|\|"),
+}
+
+MAPPING_SECTIONS = (
+    "forbidden",
+    "forbidden_keywords",
+    "forbidden_syntax",
+    "forbidden_references",
+)
+SEQUENCE_SECTIONS = ("wrap_required",)
+
+JINJA_COMMENT = re.compile(r"\{#.*?#\}", re.DOTALL)
+JINJA_TAG = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.DOTALL)
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+LINE_COMMENT = re.compile(r"--[^\n]*")
+
+
+class RulesError(Exception):
+    """Raised when a rules or baseline file cannot be read as written."""
+
+
+class Rules:
+    """The parsed rules file."""
+
+    __slots__ = MAPPING_SECTIONS + SEQUENCE_SECTIONS
+
+    def __init__(self, forbidden, forbidden_keywords, forbidden_syntax,
+                 forbidden_references, wrap_required):
+        self.forbidden = forbidden
+        self.forbidden_keywords = forbidden_keywords
+        self.forbidden_syntax = forbidden_syntax
+        self.forbidden_references = forbidden_references
+        self.wrap_required = wrap_required
+
+
+class Violation:
+    """One rule match that is not allowed at this location."""
+
+    __slots__ = ("relpath", "line", "rule", "count", "suggestion", "kind")
+
+    def __init__(self, relpath, line, rule, count, suggestion, kind):
+        self.relpath = relpath
+        self.line = line
+        self.rule = rule
+        self.count = count
+        self.suggestion = suggestion
+        self.kind = kind
+
+    @property
+    def key(self):
+        return (self.relpath, self.rule)
+
+    def describe(self):
+        occurrences = f" ({self.count} occurrences)" if self.count > 1 else ""
+        return (
+            f"{self.relpath}:{self.line}: {self.rule}{occurrences} "
+            f"-- {self.suggestion}"
+        )
+
+
+def _strip_yaml_comment(line):
+    """Drop a trailing ``#`` comment, ignoring ``#`` inside a quoted scalar."""
+    quote = None
+    for index, char in enumerate(line):
+        if quote is not None:
+            if char == quote:
+                quote = None
+            continue
+        if char in "'\"":
+            quote = char
+            continue
+        if char == "#":
+            return line[:index]
+    return line
+
+
+def _unquote(value):
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+        return value[1:-1]
+    return value
+
+
+def _parse_flow_sequence(text, path):
+    start = text.find("[")
+    end = text.find("]")
+    if start == -1 or end == -1 or end < start:
+        raise RulesError(f"{path}: wrap_required must be a [a, b, c] sequence")
+    items = []
+    for item in text[start + 1 : end].split(","):
+        item = _unquote(item.strip())
+        if not item:
+            continue
+        items.append(item.lower())
+    if not items:
+        raise RulesError(f"{path}: wrap_required must name at least one entry")
+    return items
+
+
+def load_rules(path=RULES_PATH):
+    """Read the rules file.
+
+    A hand-rolled reader for the small fixed shape of this file, so the linter
+    stays standard-library only. Anything unexpected raises rather than being
+    silently skipped: a rule that quietly fails to load is worse than no linter
+    at all.
+    """
+    mappings = {section: {} for section in MAPPING_SECTIONS}
+    wrap_required = []
+    seen_sections = set()
+    seen_names = {}
+    section = None
+    pending = None
+
+    for number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = _strip_yaml_comment(raw_line)
+        if pending is not None:
+            pending += " " + line.strip()
+            if "]" in pending:
+                wrap_required = _parse_flow_sequence(pending, path)
+                for name in wrap_required:
+                    _claim_name(seen_names, name, "wrap_required", path, number)
+                pending = None
+                section = None
+            continue
+        if not line.strip():
+            continue
+
+        if not line[:1].isspace():
+            key, separator, remainder = line.partition(":")
+            key = key.strip()
+            if not separator or key not in MAPPING_SECTIONS + SEQUENCE_SECTIONS:
+                raise RulesError(
+                    f"{path}:{number}: unknown top-level key {line.strip()!r}"
+                )
+            if key in seen_sections:
+                raise RulesError(f"{path}:{number}: duplicate section {key!r}")
+            seen_sections.add(key)
+            section = key
+            remainder = remainder.strip()
+            if remainder:
+                if section not in SEQUENCE_SECTIONS:
+                    raise RulesError(
+                        f"{path}:{number}: {key!r} takes a nested mapping"
+                    )
+                pending = remainder
+                if "]" in pending:
+                    wrap_required = _parse_flow_sequence(pending, path)
+                    for name in wrap_required:
+                        _claim_name(seen_names, name, "wrap_required", path, number)
+                    pending = None
+                    section = None
+            continue
+
+        if section in SEQUENCE_SECTIONS:
+            pending = line.strip()
+            if "]" in pending:
+                wrap_required = _parse_flow_sequence(pending, path)
+                for name in wrap_required:
+                    _claim_name(seen_names, name, "wrap_required", path, number)
+                pending = None
+                section = None
+            continue
+
+        if section in MAPPING_SECTIONS:
+            name, separator, suggestion = line.strip().partition(":")
+            name = name.strip().lower()
+            suggestion = _unquote(suggestion.strip())
+            if not separator or not name or not suggestion:
+                raise RulesError(f"{path}:{number}: expected 'name: \"suggestion\"'")
+            _claim_name(seen_names, name, section, path, number)
+            mappings[section][name] = suggestion
+            continue
+
+        raise RulesError(f"{path}:{number}: value outside any section")
+
+    if pending is not None:
+        raise RulesError(f"{path}: unterminated wrap_required sequence")
+
+    unknown_syntax = set(mappings["forbidden_syntax"]) - set(SYNTAX_PATTERNS)
+    if unknown_syntax:
+        raise RulesError(
+            f"{path}: forbidden_syntax names without a pattern in the linter: "
+            f"{sorted(unknown_syntax)}"
+        )
+    for section in MAPPING_SECTIONS + SEQUENCE_SECTIONS:
+        if section not in seen_sections:
+            raise RulesError(f"{path}: missing section {section!r}")
+    if not any(mappings[section] for section in MAPPING_SECTIONS):
+        raise RulesError(f"{path}: no rules defined")
+    if not wrap_required:
+        raise RulesError(f"{path}: no wrap_required rules defined")
+
+    return Rules(
+        mappings["forbidden"],
+        mappings["forbidden_keywords"],
+        mappings["forbidden_syntax"],
+        mappings["forbidden_references"],
+        wrap_required,
+    )
+
+
+def _claim_name(seen_names, name, section, path, number):
+    if name in seen_names:
+        raise RulesError(
+            f"{path}:{number}: {name!r} is already declared in "
+            f"{seen_names[name]!r}"
+        )
+    seen_names[name] = section
+
+
+def _blank(segment):
+    return re.sub(r"[^\n]", " ", segment)
+
+
+def split_sql_and_jinja(text):
+    """Split a model into its SQL and Jinja views.
+
+    Both views are the same length as the input, with the other view's regions
+    blanked out, so line and column positions are preserved in each. Jinja
+    comments and SQL comments belong to neither view.
+    """
+    text = JINJA_COMMENT.sub(lambda match: _blank(match.group(0)), text)
+
+    jinja_characters = ["\n" if char == "\n" else " " for char in text]
+
+    def hide_jinja(match):
+        start = match.start()
+        for offset, char in enumerate(match.group(0)):
+            jinja_characters[start + offset] = char
+        return _blank(match.group(0))
+
+    sql = JINJA_TAG.sub(hide_jinja, text)
+    sql = BLOCK_COMMENT.sub(lambda match: _blank(match.group(0)), sql)
+    sql = LINE_COMMENT.sub(lambda match: _blank(match.group(0)), sql)
+    return sql, "".join(jinja_characters)
+
+
+def strip_non_sql(text):
+    """The SQL view alone, with Jinja and comments blanked."""
+    return split_sql_and_jinja(text)[0]
+
+
+def allowed_by_pragma(line):
+    """Rule names waived by ``-- tuva-lint: allow(...)`` on this line."""
+    allowed = set()
+    for group in PRAGMA_PATTERN.findall(line):
+        for name in group.split(","):
+            name = name.strip().lower()
+            if name:
+                allowed.add(name)
+    return allowed
+
+
+def _call_pattern(name):
+    return re.compile(rf"\b{re.escape(name)}\s*\(", re.IGNORECASE)
+
+
+def _word_pattern(name):
+    return re.compile(rf"\b{re.escape(name)}\b", re.IGNORECASE)
+
+
+def _reference_pattern(name):
+    return re.compile(rf"\b{re.escape(name)}\s*\.", re.IGNORECASE)
+
+
+def is_dialect_layer(relpath):
+    """True for files inside a macros/cross_database_utils/ directory.
+
+    That directory is where per-adapter spellings are supposed to live, so the
+    SQL-shaped rules are waived there. Reference rules are not: nothing in the
+    dialect layer has any business calling another package's macros.
+    """
+    parts = Path(relpath).parent.parts
+    wanted = DIALECT_LAYER_DIR.parts
+    return any(
+        parts[index : index + len(wanted)] == wanted
+        for index in range(len(parts) - len(wanted) + 1)
+    )
+
+
+def _collect(view_lines, source_lines, checks, relpath):
+    violations = []
+    for index, view_line in enumerate(view_lines):
+        if not view_line.strip():
+            continue
+        waived = allowed_by_pragma(source_lines[index])
+        for name, pattern, suggestion, kind in checks:
+            if name in waived:
+                continue
+            count = len(pattern.findall(view_line))
+            if count:
+                violations.append(
+                    Violation(relpath, index + 1, name, count, suggestion, kind)
+                )
+    return violations
+
+
+def scan_text(text, relpath, rules, dialect_layer=False):
+    """Find every disallowed match in one model file's contents."""
+    source_lines = text.splitlines()
+    sql, jinja = split_sql_and_jinja(text)
+    sql_lines = sql.splitlines()
+    jinja_lines = jinja.splitlines()
+    for lines in (sql_lines, jinja_lines):
+        lines += [""] * (len(source_lines) - len(lines))
+
+    sql_checks = []
+    if not dialect_layer:
+        sql_checks += [
+            (name, _call_pattern(name), suggestion, "forbidden")
+            for name, suggestion in rules.forbidden.items()
+        ]
+        sql_checks += [
+            (name, _word_pattern(name), suggestion, "forbidden_keywords")
+            for name, suggestion in rules.forbidden_keywords.items()
+        ]
+        sql_checks += [
+            (name, SYNTAX_PATTERNS[name], suggestion, "forbidden_syntax")
+            for name, suggestion in rules.forbidden_syntax.items()
+        ]
+        suggestion = "call the the_tuva_project wrapper in macros/cross_database_utils/"
+        sql_checks += [
+            (name, _call_pattern(name), suggestion, "wrap_required")
+            for name in rules.wrap_required
+        ]
+
+    jinja_checks = [
+        (name, _reference_pattern(name), suggestion, "forbidden_references")
+        for name, suggestion in rules.forbidden_references.items()
+    ]
+
+    return (
+        _collect(sql_lines, source_lines, sql_checks, relpath)
+        + _collect(jinja_lines, source_lines, jinja_checks, relpath)
+    )
+
+
+def scan_schema_text(text, relpath, rules):
+    """Find disallowed namespace references in a schema file.
+
+    Generic tests are referenced by namespace in schema files rather than in
+    Jinja, so the whole file is the reference view.
+    """
+    source_lines = text.splitlines()
+    checks = [
+        (name, _reference_pattern(name), suggestion, "forbidden_references")
+        for name, suggestion in rules.forbidden_references.items()
+    ]
+    return _collect(source_lines, source_lines, checks, relpath)
+
+
+def _relpath(path, root):
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def scan_paths(directories, rules, root=ROOT, required=True):
+    """Scan every model and schema file under each directory, in a stable order.
+
+    With ``required`` false a directory that does not exist is skipped, which is
+    what the defaults need: not every package has a snapshots or analyses path.
+    """
+    violations = []
+    for directory in directories:
+        directory = Path(directory)
+        if not directory.exists():
+            if required:
+                raise FileNotFoundError(f"no such directory: {directory}")
+            continue
+        candidates = sorted(
+            path
+            for path in directory.rglob("*")
+            if path.is_file()
+            and path.suffix.lower() in SQL_SUFFIXES + SCHEMA_SUFFIXES
+            and EXCLUDED_DIR_NAMES.isdisjoint(path.parts)
+        )
+        for path in candidates:
+            relpath = _relpath(path, root)
+            text = path.read_text(encoding="utf-8")
+            if path.suffix.lower() in SQL_SUFFIXES:
+                violations.extend(
+                    scan_text(text, relpath, rules, is_dialect_layer(relpath))
+                )
+            else:
+                violations.extend(scan_schema_text(text, relpath, rules))
+    return violations
+
+
+def load_baseline(path=BASELINE_PATH):
+    """Read ``<relpath>:<rule>:<count>`` lines into a count per file and rule."""
+    baseline = Counter()
+    if not path.exists():
+        return baseline
+    for number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        relpath, separator, remainder = line.rpartition(":")
+        if not separator:
+            raise RulesError(f"{path}:{number}: expected '<relpath>:<rule>:<count>'")
+        relpath, _, rule = relpath.rpartition(":")
+        if not relpath or not rule:
+            raise RulesError(f"{path}:{number}: expected '<relpath>:<rule>:<count>'")
+        try:
+            count = int(remainder)
+        except ValueError:
+            raise RulesError(f"{path}:{number}: count must be an integer") from None
+        baseline[(relpath, rule.lower())] += count
+    return baseline
+
+
+def format_baseline(counts):
+    header = (
+        "# Known non-portable SQL, written by scripts/portability_lint.py\n"
+        "# --update-baseline. Format: <relpath>:<rule>:<count>. A file and\n"
+        "# rule pair at or under its count passes; anything above fails.\n"
+        "# This file only shrinks -- never raise a count to land a change.\n"
+    )
+    body = "".join(
+        f"{relpath}:{rule}:{count}\n"
+        for (relpath, rule), count in sorted(counts.items())
+    )
+    return header + body
+
+
+def _print_report(violations, baseline, stream):
+    if not violations:
+        print("portability lint: no non-portable SQL found", file=stream)
+        return
+    by_file = defaultdict(list)
+    for violation in violations:
+        by_file[violation.relpath].append(violation)
+    print("portability lint report", file=stream)
+    for relpath in sorted(by_file):
+        print(f"  {relpath}", file=stream)
+        for violation in sorted(by_file[relpath], key=lambda item: item.line):
+            print(f"    {violation.describe()}", file=stream)
+    counts = Counter()
+    for violation in violations:
+        counts[violation.key] += violation.count
+    baselined = sum(min(count, baseline.get(key, 0)) for key, count in counts.items())
+    total = sum(counts.values())
+    print(
+        f"  {total} occurrence(s) across {len(by_file)} file(s); "
+        f"{baselined} at or under baseline",
+        file=stream,
+    )
+
+
+def main(argv=None, stdout=None, stderr=None):
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--models-dir",
+        action="append",
+        dest="models_dirs",
+        metavar="DIR",
+        help=(
+            "directory to scan for model and schema files; repeatable, "
+            f"defaults to {' '.join(DEFAULT_SCAN_DIRS)}"
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="print every occurrence, including ones at or under baseline",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="rewrite the baseline from what is in the tree right now",
+    )
+    args = parser.parse_args(argv)
+
+    explicit = bool(args.models_dirs)
+    directories = [
+        ROOT / directory for directory in (args.models_dirs or DEFAULT_SCAN_DIRS)
+    ]
+
+    try:
+        rules = load_rules()
+        violations = scan_paths(directories, rules, required=explicit)
+    except (RulesError, FileNotFoundError) as error:
+        print(f"portability lint: {error}", file=stderr)
+        return 2
+
+    counts = Counter()
+    for violation in violations:
+        counts[violation.key] += violation.count
+
+    if args.update_baseline:
+        BASELINE_PATH.write_text(format_baseline(counts), encoding="utf-8")
+        print(
+            f"portability lint: wrote {len(counts)} baseline entr(y|ies) to "
+            f"{_relpath(BASELINE_PATH, ROOT)}",
+            file=stdout,
+        )
+        return 0
+
+    try:
+        baseline = load_baseline()
+    except RulesError as error:
+        print(f"portability lint: {error}", file=stderr)
+        return 2
+
+    if args.report:
+        _print_report(violations, baseline, stdout)
+        # Keep the report ahead of the failure list when the two streams are
+        # redirected to the same place.
+        stdout.flush()
+
+    failing_keys = {key for key, count in counts.items() if count > baseline.get(key, 0)}
+    # The baseline is a ratchet, not a ceiling. When the tree is cleaner than
+    # the baseline says, the baseline has to come down in the same change,
+    # otherwise the debt it records can silently grow back later.
+    stale_keys = {
+        key for key, count in baseline.items() if counts.get(key, 0) < count
+    }
+
+    if not failing_keys and not stale_keys:
+        if not args.report:
+            print("portability lint: clean", file=stdout)
+        return 0
+
+    if failing_keys:
+        print("portability lint: non-portable SQL above baseline", file=stderr)
+        for violation in sorted(violations, key=lambda item: (item.relpath, item.line)):
+            if violation.key in failing_keys:
+                print(f"  {violation.describe()}", file=stderr)
+        print(
+            "Route the call through a the_tuva_project macro, or waive one "
+            "occurrence with a same-line '-- tuva-lint: allow(<rule>)' pragma.",
+            file=stderr,
+        )
+
+    if stale_keys:
+        if failing_keys:
+            print("", file=stderr)
+        print("portability lint: the baseline is above what the tree contains", file=stderr)
+        for relpath, rule in sorted(stale_keys):
+            was = baseline[(relpath, rule)]
+            now = counts.get((relpath, rule), 0)
+            print(f"  {relpath}:{rule}: baseline {was}, tree {now}", file=stderr)
+        print(
+            "Run 'python3 scripts/portability_lint.py --update-baseline' and "
+            "commit the result so the debt cannot grow back.",
+            file=stderr,
+        )
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/portability_rules.yml
+++ b/scripts/portability_rules.yml
@@ -1,0 +1,63 @@
+# Rules for scripts/portability_lint.py.
+#
+# `forbidden` names SQL functions that must never appear as raw SQL in a model,
+# because at least one warehouse Tuva supports spells them differently or does
+# not have them at all. The value is the suggestion printed with the violation.
+#
+# `forbidden_keywords` is the same idea for bare words rather than calls.
+#
+# `forbidden_syntax` names non-portable operators. The patterns themselves live
+# in the linter, keyed by these names, so the rules file stays readable.
+#
+# `forbidden_references` names macro namespaces that must not be called. These
+# are matched inside Jinja and in schema files, which is where a namespaced
+# macro or generic test actually appears.
+#
+# `wrap_required` names functions whose one true spelling is asserted by a macro
+# in macros/cross_database_utils/. They are allowed inside that directory and
+# nowhere else, so every call site goes through the wrapper.
+
+forbidden:            # fn: suggestion
+  iff: "use case when ... end"
+  decode: "use case when ... end"
+  nvl: "use coalesce()"
+  isnull: "use coalesce()"
+  ifnull: "use coalesce()"
+  charindex: "use {{ dbt.position() }}"
+  position: "use {{ dbt.position() }}"
+  getdate: "use {{ dbt.current_timestamp() }}"
+  datediff: "use {{ dbt.datediff() }}"
+  dateadd: "use {{ dbt.dateadd() }}"
+  date_trunc: "use {{ dbt.date_trunc() }}"
+  extract: "use the_tuva_project.date_part(datepart, date)"
+  to_char: "use a cast through {{ dbt.type_string() }}"
+  to_date: "use the_tuva_project.try_to_cast_date()"
+  try_cast: "use the_tuva_project.try_to_cast_*"
+  safe_cast: "use the_tuva_project.try_to_cast_*"
+  listagg: "use the_tuva_project.string_agg()"
+  string_agg: "use the_tuva_project.string_agg()"
+  group_concat: "use the_tuva_project.string_agg()"
+  array_agg: "no portable equivalent on Fabric; restructure the query"
+  substr: "use the_tuva_project.substring()"
+  len: "use the_tuva_project.length()"
+  regexp_replace: "use the_tuva_project.apply_regex()"
+  regexp_substr: "use the_tuva_project.apply_regex()"
+  regexp_like: "use the_tuva_project.apply_regex()"
+  regexp_count: "use the_tuva_project.apply_regex()"
+  regexp_extract: "use the_tuva_project.apply_regex()"
+
+forbidden_keywords:   # bare word: suggestion
+  qualify: "not in Redshift, Postgres or Fabric; use a row_number() subquery"
+  ilike: "not in BigQuery or Fabric; use lower() with like"
+  current_date: "not in Fabric; cast {{ dbt.current_timestamp() }} to date"
+  current_timestamp: "use {{ dbt.current_timestamp() }}"
+
+forbidden_syntax:     # named pattern: suggestion
+  double_colon_cast: "not in BigQuery or Fabric; use cast(x as <type>)"
+  pipe_concat: "not in Fabric; use the_tuva_project.concat_custom()"
+
+forbidden_references: # namespace: suggestion
+  dbt_utils: "use the vendored the_tuva_project equivalent"
+
+wrap_required:        # allowed only inside macros/cross_database_utils/
+  [trim, left, right, greatest, least, round]

--- a/scripts/test_portability_lint.py
+++ b/scripts/test_portability_lint.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/portability_lint.py. Standard library only."""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import portability_lint  # noqa: E402
+
+
+SCRIPTS = Path(__file__).resolve().parent
+RULES = SCRIPTS / "portability_rules.yml"
+
+
+def rules():
+    return portability_lint.load_rules(RULES)
+
+
+def scan(text, relpath="models/example.sql", dialect_layer=False):
+    return portability_lint.scan_text(
+        textwrap.dedent(text), relpath, rules(), dialect_layer
+    )
+
+
+def scan_schema(text, relpath="models/example.yml"):
+    return portability_lint.scan_schema_text(textwrap.dedent(text), relpath, rules())
+
+
+def names(violations):
+    return sorted(violation.rule for violation in violations)
+
+
+class RulesFileTest(unittest.TestCase):
+    def test_shipped_rules_cover_every_documented_kind(self):
+        loaded = rules()
+
+        for name in ("iff", "nvl", "datediff", "substr", "len", "array_agg"):
+            self.assertIn(name, loaded.forbidden)
+        self.assertEqual(loaded.forbidden["iff"], "use case when ... end")
+        self.assertEqual(loaded.forbidden["nvl"], "use coalesce()")
+        self.assertEqual(loaded.forbidden["charindex"], "use {{ dbt.position() }}")
+
+        self.assertIn("qualify", loaded.forbidden_keywords)
+        self.assertIn("ilike", loaded.forbidden_keywords)
+        self.assertEqual(
+            sorted(loaded.forbidden_syntax), ["double_colon_cast", "pipe_concat"]
+        )
+        self.assertEqual(sorted(loaded.forbidden_references), ["dbt_utils"])
+        self.assertEqual(
+            sorted(loaded.wrap_required),
+            ["greatest", "least", "left", "right", "round", "trim"],
+        )
+
+    def test_every_forbidden_syntax_name_has_a_pattern_in_the_linter(self):
+        for name in rules().forbidden_syntax:
+            self.assertIn(name, portability_lint.SYNTAX_PATTERNS)
+
+    def test_a_rules_file_it_cannot_read_raises_instead_of_parsing_to_nothing(self):
+        complete = RULES.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "rules.yml"
+
+            path.write_text('forbidden:\n  iff: "use case"\n', encoding="utf-8")
+            with self.assertRaises(portability_lint.RulesError):
+                portability_lint.load_rules(path)  # sections missing
+
+            path.write_text('bogus:\n  iff: "x"\n', encoding="utf-8")
+            with self.assertRaises(portability_lint.RulesError):
+                portability_lint.load_rules(path)
+
+            path.write_text(
+                complete + '\nforbidden_syntax:\n  made_up: "x"\n', encoding="utf-8"
+            )
+            with self.assertRaises(portability_lint.RulesError):
+                portability_lint.load_rules(path)  # duplicate section
+
+            path.write_text(
+                complete.replace(
+                    '  double_colon_cast: "not in BigQuery or Fabric; '
+                    'use cast(x as <type>)"',
+                    '  made_up_operator: "x"',
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(portability_lint.RulesError):
+                portability_lint.load_rules(path)  # no pattern for that name
+
+    def test_a_name_cannot_be_declared_in_two_sections(self):
+        source = RULES.read_text(encoding="utf-8").replace(
+            "  qualify:", "  iff:", 1
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "rules.yml"
+            path.write_text(source, encoding="utf-8")
+            with self.assertRaises(portability_lint.RulesError):
+                portability_lint.load_rules(path)
+
+    def test_a_quoted_hash_is_not_treated_as_a_yaml_comment(self):
+        self.assertEqual(
+            portability_lint._strip_yaml_comment('  iff: "a # b"  # tail'),
+            '  iff: "a # b"  ',
+        )
+
+
+class MatchingTest(unittest.TestCase):
+    def test_forbidden_and_wrap_required_calls_are_both_flagged(self):
+        violations = scan("select nvl(a, b), iff(x, 1, 0), trim(c) from t")
+        self.assertEqual(names(violations), ["iff", "nvl", "trim"])
+        kinds = {violation.rule: violation.kind for violation in violations}
+        self.assertEqual(kinds["nvl"], "forbidden")
+        self.assertEqual(kinds["trim"], "wrap_required")
+
+    def test_matching_is_case_insensitive_and_tolerates_space_before_the_paren(self):
+        self.assertEqual(names(scan("select NVL (a, b) from t")), ["nvl"])
+        self.assertEqual(names(scan("select IfF(x, 1, 0) from t")), ["iff"])
+
+    def test_a_bare_word_without_a_call_is_not_a_match(self):
+        self.assertEqual(scan("select a left join b on true"), [])
+        self.assertEqual(scan("select nvl_total from t"), [])
+        self.assertEqual(scan("select t.round_number from t"), [])
+
+    def test_repeat_calls_on_one_line_are_counted(self):
+        violations = scan("select trim(a), trim(b), trim(c) from t")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].count, 3)
+        self.assertEqual(violations[0].line, 1)
+
+    def test_line_numbers_survive_stripping(self):
+        violations = scan(
+            """\
+            select
+                {{ dbt.dateadd('day', 1, 'x') }} as a
+              , nvl(b, c) as b
+            from t
+            """
+        )
+        self.assertEqual([violation.line for violation in violations], [3])
+
+
+class KeywordRuleTest(unittest.TestCase):
+    def test_a_bare_keyword_is_flagged_without_a_call(self):
+        violations = scan(
+            """\
+            select a
+            from t
+            qualify row_number() over (partition by a order by b) = 1
+            """
+        )
+        self.assertEqual(names(violations), ["qualify"])
+        self.assertEqual(violations[0].kind, "forbidden_keywords")
+
+    def test_keywords_are_flagged_case_insensitively(self):
+        self.assertEqual(names(scan("select a from t where b ILIKE 'x%'")), ["ilike"])
+
+    def test_a_keyword_inside_a_word_is_not_a_match(self):
+        self.assertEqual(scan("select qualifying_event from t"), [])
+        self.assertEqual(scan("select current_date_flag from t"), [])
+
+    def test_a_keyword_routed_through_jinja_is_not_flagged(self):
+        self.assertEqual(scan("select {{ dbt.current_timestamp() }} as a"), [])
+
+
+class SyntaxRuleTest(unittest.TestCase):
+    def test_the_double_colon_cast_operator_is_flagged(self):
+        violations = scan("select a::int as a from t")
+        self.assertEqual(names(violations), ["double_colon_cast"])
+        self.assertEqual(violations[0].kind, "forbidden_syntax")
+
+    def test_the_concatenation_operator_is_flagged(self):
+        self.assertEqual(names(scan("select a || b as ab from t")), ["pipe_concat"])
+
+    def test_a_portable_cast_is_not_flagged(self):
+        self.assertEqual(scan("select cast(a as date) as a from t"), [])
+
+    def test_syntax_rules_respect_the_pragma(self):
+        self.assertEqual(
+            scan("select a::int -- tuva-lint: allow(double_colon_cast)"), []
+        )
+
+
+class ReferenceRuleTest(unittest.TestCase):
+    def test_a_namespaced_macro_call_inside_jinja_is_flagged(self):
+        violations = scan("select {{ dbt_utils.generate_surrogate_key(['a']) }} as k")
+        self.assertEqual(names(violations), ["dbt_utils"])
+        self.assertEqual(violations[0].kind, "forbidden_references")
+
+    def test_a_namespaced_call_inside_a_statement_tag_is_flagged(self):
+        self.assertEqual(
+            names(scan("{% set columns = dbt_utils.get_column_values(ref('t'), 'c') %}")),
+            ["dbt_utils"],
+        )
+
+    def test_the_replacement_namespace_is_not_flagged(self):
+        self.assertEqual(
+            scan("select {{ the_tuva_project.generate_surrogate_key(['a']) }} as k"), []
+        )
+
+    def test_a_namespaced_call_inside_a_jinja_comment_is_not_flagged(self):
+        self.assertEqual(scan("{# {{ dbt_utils.pretty_time() }} #}\nselect 1"), [])
+
+    def test_a_generic_test_reference_in_a_schema_file_is_flagged(self):
+        violations = scan_schema(
+            """\
+            version: 2
+            models:
+              - name: example
+                tests:
+                  - dbt_utils.unique_combination_of_columns:
+                      arguments:
+                        combination_of_columns: [a, b]
+            """
+        )
+        self.assertEqual(names(violations), ["dbt_utils"])
+        self.assertEqual(violations[0].line, 5)
+
+    def test_a_schema_file_without_the_namespace_is_clean(self):
+        self.assertEqual(
+            scan_schema("version: 2\nmodels:\n  - name: example\n    tests:\n      - not_null\n"),
+            [],
+        )
+
+
+class StrippingTest(unittest.TestCase):
+    def test_calls_routed_through_jinja_are_not_flagged(self):
+        self.assertEqual(scan("select {{ dbt.datediff('a', 'b', 'day') }} from t"), [])
+        self.assertEqual(
+            scan("select {{ the_tuva_project.string_agg('a', \"','\") }} from t"), []
+        )
+        self.assertEqual(scan("{% set x = dbt.dateadd('day', 1, 'y') %}"), [])
+
+    def test_multi_line_jinja_is_stripped_whole(self):
+        self.assertEqual(
+            scan(
+                """\
+                select {{ dbt.safe_cast(
+                    'a',
+                    api.Column.translate_type('string')
+                ) }} as a
+                from t
+                """
+            ),
+            [],
+        )
+
+    def test_sql_and_jinja_comments_are_stripped(self):
+        self.assertEqual(scan("-- nvl(a, b)\nselect 1"), [])
+        self.assertEqual(scan("/* nvl(a, b)\n   iff(x, 1, 0) */\nselect 1"), [])
+        self.assertEqual(scan("{# trim(a) #}\nselect 1"), [])
+
+    def test_a_comment_after_real_sql_hides_only_the_comment(self):
+        violations = scan("select nvl(a, b) from t -- iff(x, 1, 0)")
+        self.assertEqual(names(violations), ["nvl"])
+
+    def test_stripping_preserves_line_count_and_column_positions(self):
+        text = "select {{ a }} /* x\ny */ trim(c)\n"
+        stripped = portability_lint.strip_non_sql(text)
+        self.assertEqual(len(stripped.splitlines()), len(text.splitlines()))
+        self.assertEqual(stripped.index("trim("), text.index("trim("))
+
+    def test_the_two_views_are_complementary_and_position_preserving(self):
+        text = "select {{ dbt_utils.pretty_time() }}, trim(a) from t\n"
+        sql, jinja = portability_lint.split_sql_and_jinja(text)
+
+        self.assertEqual(len(sql), len(text))
+        self.assertEqual(len(jinja), len(text))
+        self.assertNotIn("dbt_utils", sql)
+        self.assertIn("trim(", sql)
+        self.assertIn("dbt_utils", jinja)
+        self.assertNotIn("trim(", jinja)
+        self.assertEqual(jinja.index("dbt_utils"), text.index("dbt_utils"))
+
+
+class PragmaTest(unittest.TestCase):
+    def test_a_same_line_pragma_waives_that_rule(self):
+        self.assertEqual(scan("select nvl(a, b) -- tuva-lint: allow(nvl)"), [])
+
+    def test_a_pragma_waives_only_the_rule_it_names(self):
+        violations = scan("select nvl(a, b), iff(x, 1, 0) -- tuva-lint: allow(nvl)")
+        self.assertEqual(names(violations), ["iff"])
+
+    def test_a_pragma_does_not_leak_to_other_lines(self):
+        violations = scan(
+            """\
+            select nvl(a, b) -- tuva-lint: allow(nvl)
+              , nvl(c, d)
+            from t
+            """
+        )
+        self.assertEqual([violation.line for violation in violations], [2])
+
+    def test_a_pragma_may_name_several_rules(self):
+        self.assertEqual(
+            scan("select nvl(a, b), trim(c) -- tuva-lint: allow(nvl, trim)"), []
+        )
+
+    def test_the_pragma_is_case_insensitive(self):
+        self.assertEqual(scan("select NVL(a, b) -- TUVA-LINT: ALLOW(NVL)"), [])
+
+    def test_a_pragma_waives_a_reference_on_the_same_line(self):
+        self.assertEqual(
+            scan("select {{ dbt_utils.pretty_time() }} -- tuva-lint: allow(dbt_utils)"),
+            [],
+        )
+
+
+class DialectLayerScopeTest(unittest.TestCase):
+    def test_wrap_required_calls_are_allowed_inside_the_dialect_layer(self):
+        text = "select trim(a), least(b, c), round(d, 2) from t"
+        self.assertEqual(
+            names(scan(text, "macros/cross_database_utils/trim.sql", dialect_layer=True)),
+            [],
+        )
+        self.assertEqual(
+            names(scan(text, "models/example.sql", dialect_layer=False)),
+            ["least", "round", "trim"],
+        )
+
+    def test_adapter_spellings_are_allowed_inside_the_dialect_layer(self):
+        # That directory exists to hold them: try_cast on Snowflake, len on
+        # Fabric, listagg behind string_agg, and so on.
+        text = "select try_cast(a as date), len(b), c::int, d || e from t"
+        self.assertEqual(
+            names(
+                scan(
+                    text,
+                    "macros/cross_database_utils/try_to_cast_date.sql",
+                    dialect_layer=True,
+                )
+            ),
+            [],
+        )
+        self.assertEqual(
+            sorted(set(names(scan(text, "models/example.sql", dialect_layer=False)))),
+            ["double_colon_cast", "len", "pipe_concat", "try_cast"],
+        )
+
+    def test_references_are_still_forbidden_inside_the_dialect_layer(self):
+        violations = scan(
+            "select {{ dbt_utils.generate_surrogate_key(['a']) }} as k",
+            "macros/cross_database_utils/stable_id_hash.sql",
+            dialect_layer=True,
+        )
+        self.assertEqual(names(violations), ["dbt_utils"])
+
+    def test_the_dialect_layer_is_matched_by_path_segments(self):
+        self.assertTrue(
+            portability_lint.is_dialect_layer("macros/cross_database_utils/trim.sql")
+        )
+        self.assertTrue(
+            portability_lint.is_dialect_layer(
+                "dbt_packages/the_tuva_project/macros/cross_database_utils/trim.sql"
+            )
+        )
+        self.assertFalse(portability_lint.is_dialect_layer("models/trim.sql"))
+        self.assertFalse(
+            portability_lint.is_dialect_layer("macros/cross_database_utils_extra/x.sql")
+        )
+
+
+class BaselineFormatTest(unittest.TestCase):
+    def test_a_baseline_round_trips_through_write_and_read(self):
+        counts = {("models/a.sql", "trim"): 3, ("models/b.sql", "nvl"): 1}
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "baseline.txt"
+            path.write_text(portability_lint.format_baseline(counts), encoding="utf-8")
+            self.assertEqual(dict(portability_lint.load_baseline(path)), counts)
+
+    def test_a_missing_baseline_reads_as_empty(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "absent.txt"
+            self.assertEqual(dict(portability_lint.load_baseline(path)), {})
+
+    def test_a_malformed_baseline_line_raises(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "baseline.txt"
+            path.write_text("models/a.sql:trim:not-a-number\n", encoding="utf-8")
+            with self.assertRaises(portability_lint.RulesError):
+                portability_lint.load_baseline(path)
+
+
+class CommandLineTest(unittest.TestCase):
+    """Drive the real entry point inside a throwaway repo laid out like this one."""
+
+    def setUp(self):
+        self._directory = tempfile.TemporaryDirectory()
+        self.root = Path(self._directory.name)
+        (self.root / "scripts").mkdir()
+        (self.root / "models").mkdir()
+        (self.root / "macros" / "cross_database_utils").mkdir(parents=True)
+        shutil.copy(SCRIPTS / "portability_lint.py", self.root / "scripts")
+        shutil.copy(RULES, self.root / "scripts")
+        self.addCleanup(self._directory.cleanup)
+
+    def run_lint(self, *arguments):
+        return subprocess.run(
+            [sys.executable, str(self.root / "scripts" / "portability_lint.py"), *arguments],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def write_model(self, name, text):
+        (self.root / "models" / name).write_text(textwrap.dedent(text), encoding="utf-8")
+
+    @property
+    def baseline(self):
+        return self.root / "scripts" / "portability_baseline.txt"
+
+    def test_a_clean_tree_exits_zero(self):
+        self.write_model("clean.sql", "select {{ dbt.current_timestamp() }} as a\n")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("clean", result.stdout)
+
+    def test_a_violation_exits_one_and_names_file_line_and_suggestion(self):
+        self.write_model("bad.sql", "select 1\nselect iff(1=1,'a','b')\n")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("models/bad.sql:2", result.stderr)
+        self.assertIn("iff", result.stderr)
+        self.assertIn("use case when ... end", result.stderr)
+
+    def test_a_schema_file_is_scanned_alongside_models(self):
+        self.write_model("clean.sql", "select 1\n")
+        (self.root / "models" / "schema.yml").write_text(
+            "version: 2\nmodels:\n  - name: clean\n    tests:\n"
+            "      - dbt_utils.unique_combination_of_columns\n",
+            encoding="utf-8",
+        )
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("models/schema.yml:5", result.stderr)
+        self.assertIn("dbt_utils", result.stderr)
+
+    def test_update_baseline_then_lint_passes_at_the_recorded_count(self):
+        self.write_model("bad.sql", "select nvl(a, b), nvl(c, d) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        self.assertIn("models/bad.sql:nvl:2", self.baseline.read_text())
+        self.assertEqual(self.run_lint().returncode, 0)
+
+    def test_one_more_occurrence_than_the_baseline_fails(self):
+        self.write_model("bad.sql", "select nvl(a, b) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        self.write_model("bad.sql", "select nvl(a, b), nvl(c, d) from t\n")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("models/bad.sql:1", result.stderr)
+
+    def test_a_baseline_for_one_rule_does_not_cover_another(self):
+        self.write_model("bad.sql", "select nvl(a, b) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        self.write_model("bad.sql", "select nvl(a, b) from t qualify x = 1\n")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("qualify", result.stderr)
+
+    def test_a_baseline_for_one_file_does_not_cover_another(self):
+        self.write_model("bad.sql", "select nvl(a, b) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        self.write_model("other.sql", "select nvl(a, b) from t\n")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("models/other.sql", result.stderr)
+        self.assertNotIn("models/bad.sql", result.stderr)
+
+    def test_report_lists_occurrences_that_are_at_or_under_baseline(self):
+        self.write_model("bad.sql", "select nvl(a, b) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        result = self.run_lint("--report")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("models/bad.sql:1", result.stdout)
+        self.assertIn("1 at or under baseline", result.stdout)
+
+    def test_models_dir_is_repeatable_and_scopes_the_wrapper_exemption(self):
+        self.write_model("clean.sql", "select 1\n")
+        (self.root / "macros" / "cross_database_utils" / "trim.sql").write_text(
+            "{% macro default__trim(expression) %} trim( {{ expression }} ) {% endmacro %}\n",
+            encoding="utf-8",
+        )
+        (self.root / "macros" / "other.sql").write_text(
+            "{% macro helper() %} select trim(a) from t {% endmacro %}\n",
+            encoding="utf-8",
+        )
+        result = self.run_lint("--models-dir", "models", "--models-dir", "macros")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("macros/other.sql", result.stderr)
+        self.assertNotIn("cross_database_utils/trim.sql", result.stderr)
+
+    def test_a_missing_models_dir_is_an_error_not_a_silent_pass(self):
+        result = self.run_lint("--models-dir", "nope")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("no such directory", result.stderr)
+
+    def test_absent_default_directories_are_skipped_rather_than_failing(self):
+        # This throwaway repo has no seeds, snapshots or analyses path.
+        self.write_model("clean.sql", "select 1\n")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_the_default_scan_covers_the_whole_project_not_just_models(self):
+        self.write_model("clean.sql", "select 1\n")
+        (self.root / "seeds").mkdir()
+        (self.root / "seeds" / "seeds.yml").write_text(
+            "version: 2\nseeds:\n  - name: s\n    tests:\n"
+            "      - dbt_utils.unique_combination_of_columns\n",
+            encoding="utf-8",
+        )
+        (self.root / "tests").mkdir()
+        (self.root / "tests" / "singular.sql").write_text(
+            "select substr(a, 1, 2) from t\n", encoding="utf-8"
+        )
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("seeds/seeds.yml", result.stderr)
+        self.assertIn("tests/singular.sql", result.stderr)
+
+    def test_installed_packages_and_build_output_are_never_scanned(self):
+        self.write_model("clean.sql", "select 1\n")
+        for excluded in ("dbt_packages", "target"):
+            path = self.root / "models" / excluded / "vendor.sql"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("select nvl(a, b), iff(c, 1, 0) from t\n", encoding="utf-8")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_a_tree_cleaner_than_the_baseline_fails_as_stale(self):
+        self.write_model("bad.sql", "select nvl(a, b), nvl(c, d) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        self.write_model("bad.sql", "select coalesce(a, b), nvl(c, d) from t\n")
+
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("baseline is above what the tree contains", result.stderr)
+        self.assertIn("baseline 2, tree 1", result.stderr)
+        self.assertIn("--update-baseline", result.stderr)
+
+    def test_the_ratchet_stops_a_fixed_violation_coming_back(self):
+        self.write_model("bad.sql", "select nvl(a, b), nvl(c, d) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+
+        # Fix both, and bring the baseline down in the same change.
+        self.write_model("bad.sql", "select coalesce(a, b), coalesce(c, d) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        self.assertEqual(self.run_lint().returncode, 0)
+
+        # Now the old code cannot return.
+        self.write_model("bad.sql", "select nvl(a, b), nvl(c, d) from t\n")
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("above baseline", result.stderr)
+
+    def test_a_baseline_entry_for_a_deleted_file_is_reported_as_stale(self):
+        self.write_model("bad.sql", "select nvl(a, b) from t\n")
+        self.assertEqual(self.run_lint("--update-baseline").returncode, 0)
+        (self.root / "models" / "bad.sql").unlink()
+
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("models/bad.sql:nvl: baseline 1, tree 0", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`scripts/portability_lint.py` scans the dbt project for anything that does not compile on every warehouse Tuva supports. Standard library only, so every repo can carry a copy without a virtualenv.

Each file is read as **two complementary views** that both keep their original line and column positions: the SQL outside Jinja, and the Jinja itself. That is what lets a call already routed through a macro pass while a raw one fails, and it is also what makes namespaced macro calls visible at all.

### Rules

| Kind | Matched against | Rules |
|---|---|---|
| `forbidden` | SQL outside Jinja, as `name(` | `iff`, `decode`, `nvl`, `isnull`, `ifnull`, `charindex`, `position`, `getdate`, `datediff`, `dateadd`, `date_trunc`, `extract`, `to_char`, `to_date`, `try_cast`, `safe_cast`, `listagg`, `string_agg`, `group_concat`, `array_agg`, `substr`, `len`, `regexp_replace`, `regexp_substr`, `regexp_like`, `regexp_count`, `regexp_extract` |
| `forbidden_keywords` | SQL outside Jinja, as a bare word | `qualify`, `ilike`, `current_date`, `current_timestamp` |
| `forbidden_syntax` | SQL outside Jinja, by named pattern | `double_colon_cast` (`::`), `pipe_concat` (`\|\|`) |
| `forbidden_references` | the Jinja view, and schema files whole | `dbt_utils` |
| `wrap_required` | SQL outside Jinja | `trim`, `left`, `right`, `greatest`, `least`, `round` |

`QUALIFY` works on Snowflake, BigQuery, Databricks and DuckDB and is absent from Redshift, Postgres and Fabric. `::` is absent from BigQuery and Fabric, `||` from Fabric. None of them appear anywhere in the nine packages today, so they cost nothing now and block the next person reaching for them.

One occurrence can be waived in place: `select nvl(a, b) as x  -- tuva-lint: allow(nvl)`.

### Scope

The scan covers `models`, `macros`, `tests`, `seeds`, `snapshots` and `analyses`, minus installed packages and build output. Scanning only `models` would have missed **5 of the 65 `dbt_utils` references in this repo**, which sit on seed schema files, and would miss macro-level use in the other packages entirely.

Files under `macros/cross_database_utils/` are the **dialect layer**: per-adapter spellings are supposed to live there, so the SQL-shaped rules are waived. Every forbidden-function match under `macros/` today is in that directory and is correct (`try_cast` in the Snowflake cast macros, `len` on Fabric, `listagg` behind `string_agg`, and so on). `forbidden_references` still applies there, since nothing in the dialect layer should be calling another package's macros.

### `dbt_utils` is tracked, with a ratchet behind it

The first version of this linter was structurally blind to it: `dbt_utils.` only ever appears inside `{{ }}` or in a schema file, and both were discarded before matching. Matching the Jinja view and scanning schema files closes that.

Cross-checked against a plain grep: 68 raw occurrences in the project, 65 caught, and the 3 misses are all inside comments (one `--` line, two in a `{# #}` block in `smart_union.sql` that documents the difference from `dbt_utils.union_relations`). So coverage of real call sites is complete.

### The baseline is a ratchet, not a ceiling

`scripts/portability_baseline.txt` records what is in the tree as `<relpath>:<rule>:<count>`.

- A count **above** baseline fails with the file, line and suggestion.
- A count **below** baseline fails too, asking for `--update-baseline`.

The second half is the part that matters. Without it the file never shrinks, so once a violation is fixed nothing stops it coming back to the old count later. With it, the recorded debt comes down in the same change as the fix.

Core's baseline is **104 occurrences across 36 entries**: 65 `dbt_utils`, 21 `trim`, 8 `substr`, 6 `left`, 4 `right`. Every other rule is at zero. `right` is on `wrap_required` but has no wrapper macro yet, so its 4 call sites need one added alongside the sweep.

### Deliberately not a rule: raw cast target types

Casting is a real hazard, but a naive rule would be mostly false positives here. Measured across all nine packages:

| Raw cast type | Count | Inside a `target.type` branch |
|---|---|---|
| `date` | 220 | ANSI, portable everywhere |
| `integer` | 86 | 0 |
| `int` | 16 | 0 |
| `boolean` | 20 | 20 |
| `bit` | 20 | 20 |

Every `bit` and `boolean` cast, and all 18 `select top 0`, sit inside `{% if target.type == 'fabric' %}` and are correct. The 102 `integer` / `int` casts that should be `{{ dbt.type_int() }}` are real debt, but the linter cannot tell the two apart without becoming branch-aware, and baselining correct code would make the baseline mean two different things. Left for the call-site sweep. Happy to add branch awareness and turn this on if you want it.

### CI

Adds a credential-free `Portability lint` job to `.github/workflows/ci.yml` on `pull_request`, gated to that event so it does not also fire on the `workflow_call` path used by the all-warehouses workflow. No existing job changes: 23 added lines, nothing removed. The linter runs in 0.4s locally and 7s on the runner.

### Verification

- `python3 scripts/test_portability_lint.py`: **59 tests, OK**. Covers all five rule kinds, the pragma, the baseline in both directions (growth fails, shrinkage fails as stale, a deleted file is reported, and a fixed violation cannot come back once the baseline is regenerated), dialect-layer scoping including that references are still caught there, the two-view split being complementary and position-preserving, the excluded directories, and multi-line Jinja and comment stripping. The command-line tests drive the real entry point inside a throwaway repo laid out like this one.
- `python3 scripts/portability_lint.py`: exit 0 on the repo.
- Negative control for every rule kind, each appended to a model then reverted: `qualify`, `a::int`, `a || b`, `{{ dbt_utils.pretty_time() }}`, `ilike`, `substr(` all exit 1 with the right rule and suggestion. `ilike_test` as an identifier is correctly not matched.
- Ratchet exercised in anger: replacing one real `trim(` in `parity__metrics.sql` produces `baseline 6, tree 4` and exit 1, pointing at `--update-baseline`.
- `actionlint .github/workflows/ci.yml`: one finding, the pre-existing SC2046 in the ODBC install step, present unchanged on `main`.
- The three existing `tests/unit/*.py` contract tests still pass.
- Rebased onto current `main` so CI runs against the merged cross-database macro layer.