### PR TITLE
Decouple CI from release version handling

### DIFF
--- a/.github/workflows/ci-all-warehouses.yml
+++ b/.github/workflows/ci-all-warehouses.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Internal version-changing pull request number to validate
+        description: Internal pull request number to validate
         required: true
         type: string
 
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   resolve:
-    name: Resolve release pull request and package sources
+    name: Resolve pull request and package sources
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,7 +30,7 @@ jobs:
       concurrency_key: ${{ steps.resolve.outputs.concurrency_key }}
       source_lock: ${{ steps.resolve.outputs.source_lock }}
     steps:
-      - name: Pin the release candidate and package mains
+      - name: Pin the pull request and package mains
         id: resolve
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -52,7 +52,7 @@ jobs:
             const baseRepository =
               `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
             const exactSha = /^[0-9a-f]{40}$/i;
-            const releasePackages = [
+            const standalonePackageDefinitions = [
               {
                 repository: "ahrq_quality_indicators",
                 dbtPackage: "ahrq_quality_indicators",
@@ -149,136 +149,32 @@ jobs:
               return mergeCommit;
             }
 
-            async function projectVersion(ref) {
-              const { data } = await github.rest.repos.getContent({
-                ...context.repo,
-                path: "dbt_project.yml",
-                ref
-              });
-              if (Array.isArray(data) || data.type !== "file" || !data.content) {
-                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
-              }
-              const text = Buffer.from(
-                data.content.replace(/\n/g, ""),
-                data.encoding || "base64"
-              ).toString("utf8");
-              const versionPattern =
-                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
-              const matches = [...text.matchAll(versionPattern)];
-              if (matches.length !== 1) {
-                throw new Error(
-                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
-                );
-              }
-              return matches[0][2];
-            }
-
-            function parseSemver(version) {
-              const numeric = "(?:0|[1-9][0-9]*)";
-              const nonNumeric = "(?:[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)";
-              const prereleaseIdentifier = `(?:${numeric}|${nonNumeric})`;
-              const prerelease =
-                `(${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)`;
-              const buildIdentifier = "[0-9A-Za-z-]+";
-              const pattern = new RegExp(
-                `^(${numeric})\\.(${numeric})\\.(${numeric})` +
-                `(?:-${prerelease})?` +
-                `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))?$`
-              );
-              const match = version.match(pattern);
-              if (!match) {
-                throw new Error(`invalid SemVer version: ${version}`);
-              }
-              return {
-                core: match.slice(1, 4).map((item) => BigInt(item)),
-                prerelease: match[4] ? match[4].split(".") : null
-              };
-            }
-
-            function compareSemverPrecedence(leftVersion, rightVersion) {
-              const left = parseSemver(leftVersion);
-              const right = parseSemver(rightVersion);
-              for (let index = 0; index < 3; index += 1) {
-                if (left.core[index] !== right.core[index]) {
-                  return left.core[index] > right.core[index] ? 1 : -1;
-                }
-              }
-              if (left.prerelease === null && right.prerelease === null) {
-                return 0;
-              }
-              if (left.prerelease === null) {
-                return 1;
-              }
-              if (right.prerelease === null) {
-                return -1;
-              }
-              const length = Math.max(
-                left.prerelease.length,
-                right.prerelease.length
-              );
-              for (let index = 0; index < length; index += 1) {
-                const leftPart = left.prerelease[index];
-                const rightPart = right.prerelease[index];
-                if (leftPart === undefined) {
-                  return -1;
-                }
-                if (rightPart === undefined) {
-                  return 1;
-                }
-                if (leftPart === rightPart) {
-                  continue;
-                }
-                const leftIsNumeric = /^[0-9]+$/.test(leftPart);
-                const rightIsNumeric = /^[0-9]+$/.test(rightPart);
-                if (leftIsNumeric && rightIsNumeric) {
-                  return BigInt(leftPart) > BigInt(rightPart) ? 1 : -1;
-                }
-                if (leftIsNumeric !== rightIsNumeric) {
-                  return leftIsNumeric ? -1 : 1;
-                }
-                return leftPart > rightPart ? 1 : -1;
-              }
-              return 0;
-            }
-
             try {
               const pr = await getPullRequest();
               validatePullRequest(pr);
               const mergeCommit = await getTestMerge(pr);
 
-              const [baseVersion, releaseVersion, standalonePackages] =
-                await Promise.all([
-                  projectVersion(pr.base.sha),
-                  projectVersion(mergeCommit.sha),
-                  Promise.all(
-                    releasePackages.map(async (item) => {
-                      const { data: commit } = await github.rest.repos.getCommit({
-                        owner: context.repo.owner,
-                        repo: item.repository,
-                        ref: "main"
-                      });
-                      if (!exactSha.test(commit.sha)) {
-                        throw new Error(
-                          `Could not resolve ${item.repository} main to an exact commit.`
-                        );
-                      }
-                      return {
-                        repository: `${context.repo.owner}/${item.repository}`,
-                        dbt_package: item.dbtPackage,
-                        branch: "main",
-                        revision: commit.sha.toLowerCase(),
-                        env_var: item.envVar
-                      };
-                    })
-                  )
-                ]);
-
-              if (compareSemverPrecedence(releaseVersion, baseVersion) <= 0) {
-                throw new Error(
-                  `PR #${prNumber} must increase the Tuva Core package version ` +
-                  `with greater SemVer precedence (${baseVersion} -> ${releaseVersion}).`
-                );
-              }
+              const standalonePackages = await Promise.all(
+                standalonePackageDefinitions.map(async (item) => {
+                  const { data: commit } = await github.rest.repos.getCommit({
+                    owner: context.repo.owner,
+                    repo: item.repository,
+                    ref: "main"
+                  });
+                  if (!exactSha.test(commit.sha)) {
+                    throw new Error(
+                      `Could not resolve ${item.repository} main to an exact commit.`
+                    );
+                  }
+                  return {
+                    repository: `${context.repo.owner}/${item.repository}`,
+                    dbt_package: item.dbtPackage,
+                    branch: "main",
+                    revision: commit.sha.toLowerCase(),
+                    env_var: item.envVar
+                  };
+                })
+              );
 
               const currentPr = await getPullRequest();
               validatePullRequest(currentPr);
@@ -299,8 +195,6 @@ jobs:
                   source: "pull_request_test_merge",
                   revision: mergeCommit.sha.toLowerCase()
                 },
-                base_version: baseVersion,
-                release_version: releaseVersion,
                 standalone_packages: standalonePackages
               };
 
@@ -315,15 +209,15 @@ jobs:
               core.setOutput("concurrency_key", `all-worker-pr-${prNumber}`);
               core.setOutput("source_lock", JSON.stringify(sourceLock));
               core.notice(
-                `Pinned release CI ${baseVersion} -> ${releaseVersion} at ` +
-                `${mergeCommit.sha} with eight standalone package mains.`
+                `Pinned all-warehouse CI at ${mergeCommit.sha} with ` +
+                "eight standalone package mains."
               );
             } catch (error) {
-              core.setFailed(`Could not resolve release CI: ${error.message}`);
+              core.setFailed(`Could not resolve all-warehouse CI: ${error.message}`);
             }
 
   run_all_warehouses:
-    name: Run release candidate on all warehouses
+    name: Run locked source set on all warehouses
     needs: resolve
     permissions:
       contents: read

--- a/.github/workflows/ci-external-pr.yml
+++ b/.github/workflows/ci-external-pr.yml
@@ -97,49 +97,6 @@ jobs:
               return;
             }
 
-            async function projectVersion(ref) {
-              const { data } = await github.rest.repos.getContent({
-                ...context.repo,
-                path: "dbt_project.yml",
-                ref
-              });
-              if (Array.isArray(data) || data.type !== "file" || !data.content) {
-                throw new Error(`dbt_project.yml is not a readable file at ${ref}`);
-              }
-              const text = Buffer.from(
-                data.content.replace(/\n/g, ""),
-                data.encoding || "base64"
-              ).toString("utf8");
-              const versionPattern =
-                /^version:\s*(['"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$/gm;
-              const matches = [...text.matchAll(versionPattern)];
-              if (matches.length !== 1) {
-                throw new Error(
-                  `expected exactly one top-level version at ${ref}; found ${matches.length}`
-                );
-              }
-              return matches[0][2];
-            }
-
-            let baseVersion;
-            let mergeVersion;
-            try {
-              [baseVersion, mergeVersion] = await Promise.all([
-                projectVersion(pr.base.sha),
-                projectVersion(mergeCommit.sha)
-              ]);
-            } catch (error) {
-              core.setFailed(`Could not inspect PR #${prNumber}'s version: ${error.message}`);
-              return;
-            }
-            if (baseVersion !== mergeVersion) {
-              core.setFailed(
-                "Version-changing pull requests must use an internal branch and " +
-                "Tuva CI -- All Warehouses."
-              );
-              return;
-            }
-
             core.setOutput("pr_number", String(prNumber));
             core.setOutput("base_sha", pr.base.sha);
             core.setOutput("head_sha", pr.head.sha);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,9 +358,6 @@ jobs:
                     `${context.repo.owner}/${context.repo.repo}` ||
                   parsedLock?.core?.source !== "pull_request_test_merge" ||
                   parsedLock?.core?.revision !== checkoutRef.toLowerCase() ||
-                  typeof parsedLock?.base_version !== "string" ||
-                  typeof parsedLock?.release_version !== "string" ||
-                  parsedLock.base_version === parsedLock.release_version ||
                   !Array.isArray(packages) ||
                   packages.length !== expectedStandalonePackages.length ||
                   actualTriples.size !== expectedTriples.size ||
@@ -394,7 +391,7 @@ jobs:
                 fail("PR number and exact base, head, and merge commits are required.");
               }
               if (checkoutRef !== mergeSha) {
-                fail("The required status must describe the exact test-merge commit being built.");
+                fail("The published status must describe the exact test-merge commit being built.");
               }
             }
 
@@ -507,7 +504,7 @@ jobs:
             }
 
             const description = process.env.CI_SCOPE === "all-packages"
-              ? "All-warehouse release CI is running"
+              ? "All-warehouse CI is running"
               : "Snowflake Core CI is running";
             await Promise.all(
               statusRefs.map((sha) =>
@@ -522,185 +519,16 @@ jobs:
               )
             );
 
-  preflight_assets:
-    name: Verify future-version data assets
-    needs: resolve
-    if: >-
-      needs.resolve.result == 'success' &&
-      needs.resolve.outputs.should_run == 'true' &&
-      needs.resolve.outputs.scope == 'all-packages'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout exact release candidate
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          ref: ${{ needs.resolve.outputs.checkout_ref }}
-          persist-credentials: false
-
-      - name: Verify every declared asset exists in all public clouds
-        env:
-          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
-        run: |
-          python3 - <<'PY'
-          import concurrent.futures
-          import json
-          import os
-          import re
-          import time
-          import urllib.error
-          import urllib.parse
-          import urllib.request
-          from pathlib import Path
-
-          version_pattern = re.compile(
-              r"^version:\s*(['\"]?)([0-9A-Za-z.+-]+)\1\s*(?:#.*)?$",
-              re.MULTILINE,
-          )
-          project_text = Path("dbt_project.yml").read_text(encoding="utf-8")
-          versions = version_pattern.findall(project_text)
-          if len(versions) != 1:
-              raise SystemExit(
-                  f"expected exactly one top-level version; found {len(versions)}"
-              )
-          package_version = versions[0][1]
-
-          source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
-          if source_lock.get("release_version") != package_version:
-              raise SystemExit(
-                  "source lock release version does not match dbt_project.yml"
-              )
-
-          catalog_text = Path("data_assets.yml").read_text(encoding="utf-8")
-          catalog_code = "\n".join(
-              line.split("#", 1)[0] for line in catalog_text.splitlines()
-          )
-          asset_paths = re.findall(r"^    path: (\S+)$", catalog_code, re.MULTILINE)
-          canonical_seeds = re.findall(
-              r"^  - seed: (\S+)$", catalog_code, re.MULTILINE
-          )
-          declared_path_keys = len(
-              re.findall(r"(?<![A-Za-z0-9_-])path\s*:", catalog_code)
-          )
-          declared_seed_keys = len(
-              re.findall(r"(?<![A-Za-z0-9_-])seed\s*:", catalog_code)
-          )
-          if not asset_paths:
-              raise SystemExit("data_assets.yml does not declare any asset paths")
-          if (
-              declared_path_keys != len(asset_paths)
-              or declared_seed_keys != len(canonical_seeds)
-              or len(canonical_seeds) != len(asset_paths)
-          ):
-              raise SystemExit(
-                  "data_assets.yml must use one canonical seed/path mapping per asset; "
-                  "release preflight refuses to skip unrecognized YAML declarations"
-              )
-          if len(asset_paths) != len(set(asset_paths)):
-              raise SystemExit("data_assets.yml contains duplicate asset paths")
-
-          providers = {
-              "s3": "https://tuva-public-resources.s3.amazonaws.com",
-              "gcs": "https://storage.googleapis.com/tuva-public-resources",
-              "azure": (
-                  "https://tuvapublicresources.blob.core.windows.net/"
-                  "tuva-public-resources"
-              ),
-          }
-          version_component = urllib.parse.quote(package_version, safe="")
-
-          def head_status(url):
-              last_error = None
-              for attempt in range(3):
-                  request = urllib.request.Request(
-                      url,
-                      method="HEAD",
-                      headers={"User-Agent": "tuva-core-release-ci"},
-                  )
-                  try:
-                      with urllib.request.urlopen(request, timeout=30) as response:
-                          return response.status, None
-                  except urllib.error.HTTPError as exc:
-                      return exc.code, None
-                  except (urllib.error.URLError, TimeoutError) as exc:
-                      last_error = str(exc)
-                  if attempt < 2:
-                      time.sleep(1 + attempt)
-              return None, last_error
-
-          def probe_payload(item):
-              provider, asset_path = item
-              encoded_path = urllib.parse.quote(asset_path, safe="/")
-              url = (
-                  f"{providers[provider]}/tuva-core/{version_component}/"
-                  f"{encoded_path}"
-              )
-              status, error = head_status(url)
-              if status is not None and 200 <= status < 300:
-                  return None
-              detail = f"HTTP {status}" if status is not None else error
-              return f"{provider}: {asset_path}: {detail}"
-
-          probes = [
-              (provider, asset_path)
-              for provider in providers
-              for asset_path in asset_paths
-          ]
-          with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
-              failures = [
-                  failure for failure in executor.map(probe_payload, probes) if failure
-              ]
-
-          if failures:
-              preview = "\n".join(failures[:50])
-              remainder = len(failures) - min(len(failures), 50)
-              if remainder:
-                  preview += f"\n... and {remainder} more missing objects"
-              raise SystemExit(
-                  f"future-version data asset preflight failed:\n{preview}"
-              )
-
-          receipt_failures = []
-          for provider, base_url in providers.items():
-              receipt_url = (
-                  f"{base_url}/tuva-core/{version_component}/_release.json"
-              )
-              status, error = head_status(receipt_url)
-              if status != 404:
-                  detail = f"HTTP {status}" if status is not None else error
-                  receipt_failures.append(f"{provider}: {detail}")
-          if receipt_failures:
-              raise SystemExit(
-                  "future-version snapshots must not have _release.json before merge:\n"
-                  + "\n".join(receipt_failures)
-              )
-
-          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
-          with summary.open("a", encoding="utf-8") as output:
-              output.write("## Data asset preflight\n\n")
-              output.write(f"- Version: `{package_version}`\n")
-              output.write(f"- Declared objects per cloud: {len(asset_paths)}\n")
-              output.write(f"- Verified object paths: {len(probes)}\n")
-              output.write("- `_release.json` absent from all clouds: yes\n")
-          print(
-              f"Verified {len(asset_paths)} future-version assets across "
-              f"{len(providers)} clouds"
-          )
-          PY
-
   build:
     name: Build / ${{ matrix.warehouse }}
     needs:
       - resolve
       - mark_pending
-      - preflight_assets
     if: >-
       always() &&
       needs.resolve.result == 'success' &&
       needs.resolve.outputs.should_run == 'true' &&
-      (needs.mark_pending.result == 'success' || needs.mark_pending.result == 'skipped') &&
-      (needs.preflight_assets.result == 'success' || needs.preflight_assets.result == 'skipped')
+      (needs.mark_pending.result == 'success' || needs.mark_pending.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1102,7 +930,6 @@ jobs:
     needs:
       - resolve
       - mark_pending
-      - preflight_assets
       - build
     if: >-
       always() &&
@@ -1125,7 +952,6 @@ jobs:
           CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
           STATUS_CONTEXT: ${{ needs.resolve.outputs.status_context }}
           RESOLVE_RESULT: ${{ needs.resolve.result }}
-          PREFLIGHT_RESULT: ${{ needs.preflight_assets.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           PENDING_RESULT: ${{ needs.mark_pending.result }}
         with:
@@ -1138,7 +964,6 @@ jobs:
             const sourceLock = process.env.CI_SOURCE_LOCK;
             const statusContext = process.env.STATUS_CONTEXT;
             const resolveResult = process.env.RESOLVE_RESULT;
-            const preflightResult = process.env.PREFLIGHT_RESULT;
             const buildResult = process.env.BUILD_RESULT;
             const pendingResult = process.env.PENDING_RESULT;
             const runUrl =
@@ -1206,18 +1031,15 @@ jobs:
                 description = "CI could not publish its pending status";
               } else if (resolveResult !== "success") {
                 description = "CI request resolution failed";
-              } else if (preflightResult === "failure") {
-                state = "failure";
-                description = "Future-version data asset preflight failed";
               } else if (buildResult === "success") {
                 state = "success";
                 description = scope === "all-packages"
-                  ? "All-warehouse release CI passed"
+                  ? "All-warehouse CI passed"
                   : "Snowflake Core build passed";
               } else if (buildResult === "failure") {
                 state = "failure";
                 description = scope === "all-packages"
-                  ? "All-warehouse release CI failed"
+                  ? "All-warehouse CI failed"
                   : "Snowflake Core build failed";
               } else {
                 description = `CI ended with ${buildResult}`;
@@ -1247,7 +1069,7 @@ jobs:
               )
             ) {
               core.notice(
-                "A newer CI run owns the required status; " +
+                "A newer CI run owns the published status; " +
                 "this run will not overwrite it."
               );
               return;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,28 +385,36 @@ passing build on one warehouse is not evidence of portability to the others.
   dataset. It builds Tuva Core and the integration project, runs unit and data
   tests, enables Data Quality and its optional failure-key relation, and keeps
   parity disabled. A package-version change does not alter this automatic path.
+  The Snowflake status is informational and is not required for merge.
 - Run `Tuva CI -- All Warehouses` manually for the final release PR. Its only
-  input is the pull-request number. It accepts only an open, mergeable,
-  same-repository PR into `main` whose test merge changes the Core version.
+  input is the pull-request number. It accepts any open, mergeable,
+  same-repository PR into `main`; CI does not inspect or compare package
+  versions.
 - The all-warehouse workflow resolves the PR test merge and all eight
   standalone package `main` branches once to exact commits. It builds that one
   source lock on Snowflake, BigQuery, Databricks, Fabric, and Redshift with the
   small synthetic dataset and complete Data Quality surface.
-- Before release-CI warehouse credentials are used, the workflow verifies that
-  every Core candidate asset exists under the future version in S3, GCS, and
-  Azure and that `_release.json` has not been finalized.
+- Version selection and comparison, candidate-asset checks, receipt handling,
+  tagging, and draft-release creation do not belong to CI.
 - There is no individual-warehouse dispatcher. Troubleshoot one warehouse
   locally; validate DuckDB portability locally as needed.
 - Pull-request comments do not trigger CI, and CI does not accept arbitrary
   dbt commands, selectors, or flags.
 - Automatic secrets-backed CI never executes fork code. After review, a
   maintainer runs `External PR Snowflake CI` and supplies only the PR number.
-  External version changes are rejected because release CI requires an
-  internal branch.
+  That workflow validates code only and does not inspect package versions.
 - Routine Snowflake CI does not install standalone packages. Only manual
-  release CI snapshots all eight package `main` branches before building.
+  all-warehouse CI snapshots all eight package `main` branches before building.
 - Parity comparison is a separate manually initiated Snowflake release
   validation.
+
+For a release, finish ordinary implementation first, then open the small
+manual PR that changes the Core package version declarations. Snowflake starts
+automatically and may be canceled because it is not a merge gate. Manually run
+`Tuva CI -- All Warehouses` for that PR, merge only after the matrix passes,
+then use the separate data-asset and release workflows to finalize receipts,
+create the tag, and open the draft release. Version selection and editing stay
+in the manual pull request.
 
 Two similarly named release files have different required jobs:
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -85,22 +85,22 @@ It tests the exact pull-request merge commit on Snowflake using Tuva Core, the
 integration project, and the small synthetic dataset. Structural and Logical
 Input Data Quality, Output Data Quality rollups, and the optional Logical
 failure-key relation are enabled so the complete Core test surface runs. A
-package version change does not change this automatic path.
+package version change does not change this automatic path. The Snowflake
+status is informational and is not required for merge.
 
 For the final release pull request, dispatch `Tuva CI -- All Warehouses` from
 the Actions tab and enter only its pull-request number. The workflow accepts an
-open, mergeable, same-repository pull request into `main` only when its exact
-test merge changes the Tuva Core package version. It resolves all eight
-standalone package `main` branches once to exact commits, then uses that single
-source lock for Snowflake, BigQuery, Databricks, Fabric, and Redshift.
+open, mergeable, same-repository pull request into `main`. It does not inspect
+or compare package versions. The workflow resolves all eight standalone
+package `main` branches once to exact commits, then uses that single source lock
+for Snowflake, BigQuery, Databricks, Fabric, and Redshift.
 
 The manual release build selects the integration project, Tuva Core, AHRQ
 Quality Indicators, CCSR, CMS Chronic Conditions, CMS HCC, FHIR Preprocessing,
-NYU ED Classification, Quality Measures, and Semantic Layer. Before any
-warehouse job receives credentials, CI verifies that every Core asset declared
-by the release candidate exists under its future version in S3, GCS, and Azure
-and that `_release.json` is absent. The receipt is finalized against the merged
-`main` commit later; candidate payloads alone are sufficient for PR validation.
+NYU ED Classification, Quality Measures, and Semantic Layer. CI validates the
+locked code and dbt graph only. Version selection and editing stay in the
+manual pull request; candidate-asset, receipt, tag, and draft-release work
+remain in the separate data-asset and release workflows.
 
 Both workflows keep the small synthetic dataset and Data Quality failure-key
 coverage enabled while parity remains disabled. The all-warehouse workflow
@@ -111,8 +111,8 @@ locally, and use DuckDB locally for portability checks.
 
 Reviewed fork pull requests use the separate `External PR Snowflake CI`
 workflow. Its only input is the pull-request number. CI does not accept
-pull-request comment commands or arbitrary dbt commands. External version
-changes are rejected because the release matrix requires an internal branch.
+pull-request comment commands or arbitrary dbt commands, and it does not
+inspect package versions.
 
 ## Data Asset Loading
 


### PR DESCRIPTION
## Summary

- keep automatic same-repository Snowflake CI fixed and advisory rather than a merge requirement
- make the manual all-warehouse/all-package dispatcher accept any qualifying internal PR without reading or comparing package versions
- remove candidate-asset and release-receipt preflight from CI while preserving the exact PR test merge, eight-package source lock, five-warehouse matrix, and stale-source protections
- make reviewed-fork Snowflake CI version-agnostic and document the manual final-version-PR sequence

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/ci-all-warehouses.yml .github/workflows/ci-external-pr.yml .github/workflows/create-release.yml`
- `python3 tests/unit/test_data_asset_contract.py` (9 tests)
- `git diff --check`
- confirmed no CI references remain to version comparison, version-bearing source-lock fields, future-version asset preflight, or `_release.json`

## Release-note disposition

`ignore-for-release`