### PR TITLE
Verify mutable candidates in release CI

### DIFF
--- a/.github/workflows/ci-all-warehouses.yml
+++ b/.github/workflows/ci-all-warehouses.yml
@@ -28,7 +28,7 @@ jobs:
       merge_sha: ${{ steps.resolve.outputs.merge_sha }}
       schema_prefix: ${{ steps.resolve.outputs.schema_prefix }}
       concurrency_key: ${{ steps.resolve.outputs.concurrency_key }}
-      source_lock: ${{ steps.resolve.outputs.source_lock }}
+      source_lock: ${{ steps.candidate.outputs.source_lock }}
     steps:
       - name: Pin the pull request and package mains
         id: resolve
@@ -216,6 +216,48 @@ jobs:
               core.setFailed(`Could not resolve all-warehouse CI: ${error.message}`);
             }
 
+      - name: Check out the trusted workflow revision
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Copy the trusted candidate verifier outside the checkout
+        run: >-
+          cp scripts/verify_data_asset_candidate.py
+          "$RUNNER_TEMP/verify_data_asset_candidate.py"
+
+      - name: Check out the exact pull request test merge
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ steps.resolve.outputs.merge_sha }}
+          persist-credentials: false
+
+      - name: Pin the complete cross-cloud data-asset candidate
+        id: candidate
+        env:
+          EXPECTED_PACKAGE_COMMIT: ${{ steps.resolve.outputs.head_sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+          UNLOCKED_SOURCE_LOCK: ${{ steps.resolve.outputs.source_lock }}
+        run: >-
+          /usr/bin/python3 "$RUNNER_TEMP/verify_data_asset_candidate.py" resolve
+          --package-root .
+          --package tuva-core
+          --package-commit "$EXPECTED_PACKAGE_COMMIT"
+          --source-lock-json "$UNLOCKED_SOURCE_LOCK"
+
+      - name: Summarize the pinned data-asset candidate
+        env:
+          CANDIDATE_MARKER_SHA256: ${{ steps.candidate.outputs.candidate_marker_sha256 }}
+          PACKAGE_VERSION: ${{ steps.candidate.outputs.package_version }}
+        run: |
+          {
+            echo "## Data-asset candidate"
+            echo
+            echo "- Tuva Core version: \`$PACKAGE_VERSION\`"
+            echo "- Cross-cloud marker SHA-256: \`$CANDIDATE_MARKER_SHA256\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   run_all_warehouses:
     name: Run locked source set on all warehouses
     needs: resolve
@@ -226,6 +268,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       checkout_ref: ${{ needs.resolve.outputs.merge_sha }}
+      trusted_ref: ${{ github.workflow_sha }}
       warehouse: all
       scope: all-packages
       source_lock: ${{ needs.resolve.outputs.source_lock }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ on:
         description: Exact commit to validate
         required: true
         type: string
+      trusted_ref:
+        description: Exact trusted workflow commit for release-candidate verification
+        required: false
+        type: string
+        default: ""
       warehouse:
         description: Fixed warehouse set to validate (snowflake or all)
         required: true
@@ -175,12 +180,15 @@ jobs:
       base_sha: ${{ steps.resolve.outputs.base_sha }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       merge_sha: ${{ steps.resolve.outputs.merge_sha }}
+      trusted_ref: ${{ steps.resolve.outputs.trusted_ref }}
     steps:
       - name: Normalize request
         id: resolve
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref || '' }}
+          INPUT_TRUSTED_REF: ${{ inputs.trusted_ref || '' }}
+          EXPECTED_TRUSTED_REF: ${{ github.workflow_sha }}
           INPUT_WAREHOUSE: ${{ inputs.warehouse || '' }}
           INPUT_SCOPE: ${{ inputs.scope || '' }}
           INPUT_SOURCE_LOCK: ${{ inputs.source_lock || '' }}
@@ -257,6 +265,9 @@ jobs:
               ]
             ];
             const exactSha = /^[0-9a-f]{40}$/i;
+            const exactSha256 = /^[0-9a-f]{64}$/;
+            const exactSemver =
+              /^[1-9][0-9]*\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
             const calledCheckoutRef = process.env.INPUT_CHECKOUT_REF.trim();
             const isReusableCall = calledCheckoutRef !== "";
@@ -266,6 +277,7 @@ jobs:
             let scope = "core";
             let sourceLock = "";
             let checkoutRef = "";
+            let trustedRef = "";
             let schemaBase = "";
             let concurrencyKey = "";
             let publishStatus = false;
@@ -286,6 +298,7 @@ jobs:
               scope = process.env.INPUT_SCOPE.trim();
               sourceLock = process.env.INPUT_SOURCE_LOCK.trim();
               checkoutRef = calledCheckoutRef;
+              trustedRef = process.env.INPUT_TRUSTED_REF.trim();
               schemaBase = process.env.INPUT_SCHEMA_PREFIX.trim();
               concurrencyKey = process.env.INPUT_CONCURRENCY_KEY.trim();
               publishStatus = process.env.INPUT_PUBLISH_STATUS === "true";
@@ -329,7 +342,10 @@ jobs:
               fail(`Unsupported CI request: ${warehouse}:${scope}`);
             }
             if (scope === "core" && sourceLock) {
-              fail("Core-only CI must not receive a standalone package source lock.");
+              fail("Core-only CI must not receive a release source lock.");
+            }
+            if (scope === "core" && trustedRef) {
+              fail("Core-only CI must not receive a trusted release-CI ref.");
             }
             if (shouldRun && !checkoutRef) {
               fail("checkout_ref is required.");
@@ -338,9 +354,28 @@ jobs:
               fail("checkout_ref must be an exact 40-character commit SHA.");
             }
             if (scope === "all-packages") {
+              if (
+                !exactSha.test(trustedRef) ||
+                trustedRef !== process.env.EXPECTED_TRUSTED_REF.toLowerCase()
+              ) {
+                fail(
+                  "all-packages CI must use the exact trusted caller workflow commit"
+                );
+              }
               try {
                 const parsedLock = JSON.parse(sourceLock);
                 const packages = parsedLock?.standalone_packages;
+                const candidate = parsedLock?.data_asset_candidate;
+                const candidateKeys = [
+                  "bucket",
+                  "file_count",
+                  "marker_sha256",
+                  "object_identities",
+                  "package",
+                  "package_commit",
+                  "stores",
+                  "version"
+                ];
                 const expectedTriples = new Set(
                   expectedStandalonePackages.map((item) => item.join("|"))
                 );
@@ -358,6 +393,23 @@ jobs:
                     `${context.repo.owner}/${context.repo.repo}` ||
                   parsedLock?.core?.source !== "pull_request_test_merge" ||
                   parsedLock?.core?.revision !== checkoutRef.toLowerCase() ||
+                  Object.keys(parsedLock).sort().join("|") !==
+                    "core|data_asset_candidate|standalone_packages" ||
+                  !candidate ||
+                  Object.keys(candidate).sort().join("|") !==
+                    candidateKeys.sort().join("|") ||
+                  candidate.bucket !== "tuva-public-resources-candidates" ||
+                  candidate.package !== "tuva-core" ||
+                  candidate.package_commit !== headSha.toLowerCase() ||
+                  !exactSemver.test(candidate.version) ||
+                  !exactSha256.test(candidate.marker_sha256) ||
+                  !candidate.object_identities ||
+                  typeof candidate.object_identities !== "object" ||
+                  Array.isArray(candidate.object_identities) ||
+                  !Number.isInteger(candidate.file_count) ||
+                  candidate.file_count <= 0 ||
+                  JSON.stringify(candidate.stores) !==
+                    JSON.stringify(["s3", "gcs", "azure"]) ||
                   !Array.isArray(packages) ||
                   packages.length !== expectedStandalonePackages.length ||
                   actualTriples.size !== expectedTriples.size ||
@@ -368,7 +420,8 @@ jobs:
                 ) {
                   throw new Error(
                     "source lock must describe the checked-out Core revision and " +
-                    "the exact eight-package main-branch inventory"
+                    "head-bound cross-cloud asset candidate plus the exact " +
+                    "eight-package main-branch inventory"
                   );
                 }
               } catch (error) {
@@ -424,6 +477,7 @@ jobs:
             core.setOutput("base_sha", baseSha);
             core.setOutput("head_sha", headSha);
             core.setOutput("merge_sha", mergeSha);
+            core.setOutput("trusted_ref", trustedRef);
 
             if (resolutionError) {
               core.setFailed(resolutionError);
@@ -546,6 +600,21 @@ jobs:
         "enable_data_quality_failure_keys": true,
         "tuva_schema_prefix": "${{ needs.resolve.outputs.schema_prefix }}"}
     steps:
+      - name: Check out trusted candidate verifier source
+        if: env.CI_SCOPE == 'all-packages'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ needs.resolve.outputs.trusted_ref }}
+          persist-credentials: false
+
+      - name: Copy the trusted candidate verifier outside the checkout
+        id: trusted_verifier
+        if: env.CI_SCOPE == 'all-packages'
+        run: |
+          cp scripts/verify_data_asset_candidate.py "$RUNNER_TEMP/verify_data_asset_candidate.py"
+          verifier_sha256="$(/usr/bin/sha256sum "$RUNNER_TEMP/verify_data_asset_candidate.py")"
+          echo "sha256=${verifier_sha256%% *}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout exact commit
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -557,11 +626,25 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Verify source-locked candidate before using warehouse credentials
+        if: env.CI_SCOPE == 'all-packages'
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+          EXPECTED_VERIFIER_SHA256: ${{ steps.trusted_verifier.outputs.sha256 }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          verifier_sha256="$(/usr/bin/sha256sum "$RUNNER_TEMP/verify_data_asset_candidate.py")"
+          test "${verifier_sha256%% *}" = "$EXPECTED_VERIFIER_SHA256"
+          /usr/bin/python3 "$RUNNER_TEMP/verify_data_asset_candidate.py" verify \
+            --package-root . \
+            --source-lock-json "$CI_SOURCE_LOCK"
+
       - name: Install ODBC Driver 18 for SQL Server
         if: matrix.warehouse == 'fabric'
         run: |
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          curl "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list" | sudo tee /etc/apt/sources.list.d/msprod.list
+          ubuntu_release="$(lsb_release -rs)"
+          curl "https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/prod.list" | sudo tee /etc/apt/sources.list.d/msprod.list
           sudo apt-get update
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
 
@@ -607,8 +690,11 @@ jobs:
 
           source_lock = json.loads(os.environ["CI_SOURCE_LOCK"])
           packages = source_lock.get("standalone_packages")
+          candidate = source_lock.get("data_asset_candidate")
           if not isinstance(packages, list) or len(packages) != 8:
               raise SystemExit("source lock must contain eight standalone packages")
+          if not isinstance(candidate, dict):
+              raise SystemExit("source lock must contain a data-asset candidate")
 
           exact_sha = re.compile(r"^[0-9a-f]{40}$")
           owner = os.environ["GITHUB_REPOSITORY_OWNER"]
@@ -666,6 +752,19 @@ jobs:
                           f"invalid revision for {item.get('repository', 'unknown')}"
                       )
                   env_file.write(f"{item['env_var']}={revision}\n")
+              candidate_bucket = candidate.get("bucket")
+              if candidate_bucket != "tuva-public-resources-candidates":
+                  raise SystemExit("source lock candidate bucket is invalid")
+              dbt_vars = json.loads(os.environ["CI_DBT_VARS"])
+              dbt_vars["tuva_seed_buckets"] = {"tuva-core": candidate_bucket}
+              dbt_vars["expected_terminology_bucket"] = candidate_bucket
+              dbt_vars["expected_core_bucket"] = candidate_bucket
+              dbt_vars["expected_package_bucket"] = "tuva-public-resources"
+              env_file.write(
+                  "CI_DBT_VARS="
+                  + json.dumps(dbt_vars, separators=(",", ":"), sort_keys=True)
+                  + "\n"
+              )
 
           integration_dir = Path("integration_tests")
           release_manifest = ["packages:"]
@@ -807,6 +906,16 @@ jobs:
               lines.append(
                   f"- {package['repository']} `main`: `{package['revision']}`"
               )
+          candidate = source_lock["data_asset_candidate"]
+          lines.extend(
+              [
+                  f"- Tuva Core candidate: `{candidate['version']}`",
+                  (
+                      "- Candidate marker SHA-256: "
+                      f"`{candidate['marker_sha256']}`"
+                  ),
+              ]
+          )
           with Path(os.environ["GITHUB_STEP_SUMMARY"]).open(
               "a", encoding="utf-8"
           ) as summary:
@@ -923,6 +1032,19 @@ jobs:
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
 
+      - name: Recheck source-locked candidate after the warehouse build
+        if: always() && env.CI_SCOPE == 'all-packages'
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+          EXPECTED_VERIFIER_SHA256: ${{ steps.trusted_verifier.outputs.sha256 }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          verifier_sha256="$(/usr/bin/sha256sum "$RUNNER_TEMP/verify_data_asset_candidate.py")"
+          test "${verifier_sha256%% *}" = "$EXPECTED_VERIFIER_SHA256"
+          /usr/bin/python3 "$RUNNER_TEMP/verify_data_asset_candidate.py" verify \
+            --package-root . \
+            --source-lock-json "$CI_SOURCE_LOCK"
+
       - name: Prepare all-warehouse evidence
         if: always() && env.CI_SCOPE == 'all-packages'
         env:
@@ -1038,7 +1160,58 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
+      - name: Check out trusted candidate verifier for final recheck
+        id: final_trusted_checkout
+        if: always() && needs.resolve.outputs.scope == 'all-packages'
+        continue-on-error: true
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ needs.resolve.outputs.trusted_ref }}
+          persist-credentials: false
+
+      - name: Copy the final trusted verifier outside the checkout
+        id: final_verifier_copy
+        if: >-
+          always() &&
+          needs.resolve.outputs.scope == 'all-packages' &&
+          steps.final_trusted_checkout.outcome == 'success'
+        continue-on-error: true
+        run: |
+          cp scripts/verify_data_asset_candidate.py "$RUNNER_TEMP/verify_data_asset_candidate.py"
+          verifier_sha256="$(/usr/bin/sha256sum "$RUNNER_TEMP/verify_data_asset_candidate.py")"
+          echo "sha256=${verifier_sha256%% *}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out exact tested source for final recheck
+        id: final_source_checkout
+        if: always() && needs.resolve.outputs.scope == 'all-packages'
+        continue-on-error: true
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
+          persist-credentials: false
+
+      - name: Recheck every source-locked candidate identity before final status
+        id: final_candidate
+        if: >-
+          always() &&
+          needs.resolve.outputs.scope == 'all-packages' &&
+          steps.final_trusted_checkout.outcome == 'success' &&
+          steps.final_verifier_copy.outcome == 'success' &&
+          steps.final_source_checkout.outcome == 'success'
+        continue-on-error: true
+        env:
+          CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
+          EXPECTED_VERIFIER_SHA256: ${{ steps.final_verifier_copy.outputs.sha256 }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          verifier_sha256="$(/usr/bin/sha256sum "$RUNNER_TEMP/verify_data_asset_candidate.py")"
+          test "${verifier_sha256%% *}" = "$EXPECTED_VERIFIER_SHA256"
+          /usr/bin/python3 "$RUNNER_TEMP/verify_data_asset_candidate.py" verify \
+            --package-root . \
+            --source-lock-json "$CI_SOURCE_LOCK"
+
       - name: Publish result for the tested pull request revision
+        if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
@@ -1050,6 +1223,10 @@ jobs:
           STATUS_CONTEXT: ${{ needs.resolve.outputs.status_context }}
           RESOLVE_RESULT: ${{ needs.resolve.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+          FINAL_CANDIDATE_RESULT: ${{ steps.final_candidate.outcome }}
+          FINAL_SOURCE_CHECKOUT_RESULT: ${{ steps.final_source_checkout.outcome }}
+          FINAL_TRUSTED_CHECKOUT_RESULT: ${{ steps.final_trusted_checkout.outcome }}
+          FINAL_VERIFIER_COPY_RESULT: ${{ steps.final_verifier_copy.outcome }}
           PENDING_RESULT: ${{ needs.mark_pending.result }}
         with:
           script: |
@@ -1062,6 +1239,13 @@ jobs:
             const statusContext = process.env.STATUS_CONTEXT;
             const resolveResult = process.env.RESOLVE_RESULT;
             const buildResult = process.env.BUILD_RESULT;
+            const finalCandidateResult = process.env.FINAL_CANDIDATE_RESULT;
+            const finalSourceCheckoutResult =
+              process.env.FINAL_SOURCE_CHECKOUT_RESULT;
+            const finalTrustedCheckoutResult =
+              process.env.FINAL_TRUSTED_CHECKOUT_RESULT;
+            const finalVerifierCopyResult =
+              process.env.FINAL_VERIFIER_COPY_RESULT;
             const pendingResult = process.env.PENDING_RESULT;
             const runUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -1087,9 +1271,10 @@ jobs:
                 currentMerge.sha === expectedMerge;
 
               let packageSourcesAreCurrent = true;
+              let candidateIsCurrent = true;
               if (scope === "all-packages") {
-                const lockedPackages =
-                  JSON.parse(sourceLock).standalone_packages;
+                const lockedSource = JSON.parse(sourceLock);
+                const lockedPackages = lockedSource.standalone_packages;
                 const currentPackages = await Promise.all(
                   lockedPackages.map(async (packageSource) => {
                     const [, repository] = packageSource.repository.split("/");
@@ -1118,12 +1303,25 @@ jobs:
                     }
                   }
                 }
+                candidateIsCurrent =
+                  finalTrustedCheckoutResult === "success" &&
+                  finalVerifierCopyResult === "success" &&
+                  finalSourceCheckoutResult === "success" &&
+                  finalCandidateResult === "success";
+                if (!candidateIsCurrent) {
+                  core.warning(
+                    "The cross-cloud data-asset candidate or release state " +
+                    "changed during CI."
+                  );
+                }
               }
 
               if (!requestIsCurrent) {
                 description = "PR changed while CI was running; rerun required";
               } else if (!packageSourcesAreCurrent) {
                 description = "A standalone package main changed; rerun required";
+              } else if (!candidateIsCurrent) {
+                description = "Data-asset candidate changed; rerun required";
               } else if (pendingResult !== "success") {
                 description = "CI could not publish its pending status";
               } else if (resolveResult !== "success") {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ validation, CI, and release rules.
   and dbt Fusion on DuckDB.
 - Repository `main` is the active integration line. A version on `main` is not
   a formal release by itself. A release also requires an immutable `v<version>`
-  tag, a GitHub release, and any required package data-asset receipt.
+  tag, a published GitHub release, and any required package data-asset receipt.
 - Treat published model schemas, grains, identifiers, variables, selectors,
   and stable Data Quality interfaces as public contracts. Assume a change is
   breaking unless compatibility is demonstrated.
@@ -204,12 +204,20 @@ CodeRx Open is the default medication terminology. When
   object-storage payloads are the released data contents.
 - `data_assets.yml` must exactly inventory every Core payload path.
 - S3 is the released-content authority; GCS and Azure are verified mirrors.
-- A future-version payload prefix may be prepared before its version change
-  reaches `main`. It is a release candidate, is treated as reserved once
-  created, and must not contain `_release.json`.
+- A package-version snapshot may be prepared and polished iteratively in the
+  dedicated mutable candidate stores before release. Candidate synchronization
+  may add, replace, or remove payloads while preserving recoverable object
+  versions and must write `_candidate.json` last after all three clouds agree.
+- An exact `v<version>` tag or published GitHub release freezes the candidate;
+  a draft-only GitHub release does not. Release CI must fail closed when it
+  cannot prove that neither immutable release boundary exists.
+- The released S3, GCS, and Azure stores are a separate create-only boundary.
+  Promotion copies one exact verified candidate into `<package>/<version>/` and
+  the publisher writes `_release.json` last. Once a version tag or published
+  GitHub release exists, that public prefix is permanently immutable.
 - Finalize the snapshot only after the version reaches `main`. The publisher
-  writes `_release.json` last, after every payload verifies, and binds it to
-  the exact package version and 40-character package commit.
+  binds `_release.json` to the exact package version and 40-character package
+  commit after every promoted payload verifies.
 - dbt loaders do not read `_release.json` at runtime. Release automation does
   read it and must verify byte-identical receipts in S3, GCS, and Azure before
   tagging. Never weaken the exact-current-`main` commit gate.
@@ -389,15 +397,23 @@ passing build on one warehouse is not evidence of portability to the others.
   parity disabled. A package-version change does not alter this automatic path.
   The Snowflake status is informational and is not required for merge.
 - Run `Tuva CI -- All Warehouses` manually for the final release PR. Its only
-  input is the pull-request number. It accepts any open, mergeable,
-  same-repository PR into `main`; CI does not inspect or compare package
-  versions.
+  input is the pull-request number. It accepts an open, mergeable,
+  same-repository PR into `main`, resolves the package version from that exact
+  test merge, and requires a complete candidate bound to the PR head.
 - The all-warehouse workflow resolves the PR test merge and all eight
-  standalone package `main` branches once to exact commits. It builds that one
-  source lock on Snowflake, BigQuery, Databricks, Fabric, and Redshift with the
-  small synthetic dataset and complete Data Quality surface.
-- Version selection and comparison, candidate-asset checks, receipt handling,
-  tagging, and draft-release creation do not belong to CI.
+  standalone package `main` branches once to exact commits. Before warehouse
+  credentials are used, a verifier from the trusted workflow commit streams
+  and hashes every declared payload in S3, GCS, and Azure, verifies the
+  byte-identical candidate marker, and pins each provider-native object
+  identity in the source lock. Only Tuva Core is internally redirected to the
+  candidate stores; standalone package assets continue to use released
+  storage.
+- The candidate marker SHA-256 and all marker and payload object identities are
+  part of the source lock and evidence. Every warehouse rechecks them before
+  and after building, and the final status performs a fresh trusted recheck.
+  Any replacement, metadata change, tag, or published release makes the result
+  stale. Candidate editing, release receipt creation, promotion, tagging, and
+  GitHub release creation remain outside CI.
 - There is no individual-warehouse dispatcher. Troubleshoot one warehouse
   locally; validate DuckDB portability locally as needed.
 - Pull-request comments do not trigger CI, and CI does not accept arbitrary

--- a/README.md
+++ b/README.md
@@ -169,12 +169,22 @@ Checked-in seed CSVs are header-only loader contracts. `data_assets.yml`
 declares the exact Core payload inventory; users do not configure independent
 terminology, value-set, provider-data, or synthetic-data versions.
 
-Future-version payloads can be prepared before a version change reaches
-`main`, but that payload-only prefix is a release candidate and must not contain
-`_release.json`. After merge, the publisher writes the receipt only when the
-complete snapshot verifies. The receipt binds the snapshot to the exact package
-commit and must match across S3, GCS, and Azure before the package tag can be
-created. dbt loaders do not read the receipt at runtime.
+Payloads can be prepared and polished repeatedly before release in dedicated
+mutable candidate stores. Candidate synchronization converges S3, GCS, and
+Azure to one complete inventory and writes `_candidate.json` last. A verifier
+from the trusted release-CI workflow commit hashes every compressed payload in
+all three clouds and pins the marker SHA-256 plus each provider-native object
+identity. Release CI loads Tuva Core from those exact candidate objects on each
+hosted release-CI warehouse and rechecks them before, after, and at final
+status. After merge, the candidate marker is rebound to current `main`; the
+publisher then promotes those exact payloads into the separate create-only
+released stores and writes
+`_release.json` only when the complete snapshot verifies. The receipt binds the
+snapshot to the exact package commit and must match across all three clouds
+before the package tag can be created. An exact version tag or published GitHub
+release permanently freezes that version; a draft-only release does not.
+Normal dbt loaders continue to use released storage and do not read either
+control file at runtime.
 
 Redshift loading uses `IAM_ROLE default`; configure the cluster or serverless
 namespace with a default IAM role that can read the selected data-asset bucket.

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -91,16 +91,26 @@ required for merge.
 For the final release pull request, dispatch `Tuva CI -- All Warehouses` from
 the Actions tab and enter only its pull-request number. The workflow accepts an
 open, mergeable, same-repository pull request into `main`. It does not inspect
-or compare package versions. The workflow resolves all eight standalone
-package `main` branches once to exact commits, then uses that single source lock
-for Snowflake, BigQuery, Databricks, Fabric, and Redshift.
+or compare package versions, but it resolves the version in the exact test
+merge so it can pin the matching Tuva Core candidate. The workflow verifies
+every declared payload byte and the byte-identical candidate marker in S3,
+GCS, and Azure before using warehouse credentials. It records each cloud's
+provider-native marker and payload identities in the source lock. The verifier
+always runs from the trusted workflow commit, not from the pull request. The
+workflow also resolves all eight standalone package `main` branches once to
+exact commits, then uses that single source lock for Snowflake, BigQuery,
+Databricks, Fabric, and Redshift.
 
 The manual release build selects the integration project, Tuva Core, AHRQ
 Quality Indicators, CCSR, CMS Chronic Conditions, CMS HCC, FHIR Preprocessing,
-NYU ED Classification, Quality Measures, and Semantic Layer. CI validates the
-locked code and dbt graph only. Version selection and editing stay in the
-manual pull request; candidate-asset, receipt, tag, and draft-release work
-remain in the separate data-asset and release workflows.
+NYU ED Classification, Quality Measures, and Semantic Layer. Only Tuva Core's
+asset paths are redirected to the source-locked candidate; standalone package
+assets remain on released storage. Candidate editing stays in the maintenance
+workflow, while final receipt creation, promotion, tagging, and GitHub release
+creation remain in the separate release workflows. Each warehouse and the
+final status recheck every locked object identity, so any intervening payload
+or metadata edit requires a fresh run. An exact version tag or published
+GitHub release also blocks release CI; a draft-only release remains editable.
 
 Both workflows keep the small synthetic dataset and Data Quality failure-key
 coverage enabled while parity remains disabled. The all-warehouse workflow

--- a/scripts/verify_data_asset_candidate.py
+++ b/scripts/verify_data_asset_candidate.py
@@ -1,0 +1,725 @@
+#!/usr/bin/env python3
+
+"""Resolve and recheck the exact mutable data-asset candidate used by release CI."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+
+CANDIDATE_BUCKET = "tuva-public-resources-candidates"
+CANDIDATE_CACHE_CONTROL = "no-store,max-age=0,must-revalidate"
+CANDIDATE_MARKER = "_candidate.json"
+RELEASE_RECEIPT = "_release.json"
+GITHUB_API_BASE_URL = "https://api.github.com"
+PACKAGE_REPOSITORIES = {"tuva-core": "tuva-health/tuva-core"}
+STORE_BASE_URLS = {
+    "s3": f"https://{CANDIDATE_BUCKET}.s3.amazonaws.com",
+    "gcs": f"https://storage.googleapis.com/{CANDIDATE_BUCKET}",
+    "azure": (
+        "https://tuvapublicresources.blob.core.windows.net/"
+        f"{CANDIDATE_BUCKET}"
+    ),
+}
+RECEIPT_KEYS = {"schema_version", "package", "version", "package_commit", "files"}
+FILE_KEYS = {"path", "sha256", "bytes", "rows"}
+SEMVER_PATTERN = re.compile(
+    r"^[1-9][0-9]*\.[0-9]+\.[0-9]+"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CandidateError(RuntimeError):
+    """A candidate cannot be proven safe and current."""
+
+
+class HttpStatusError(CandidateError):
+    """An object-store request returned a non-success HTTP status."""
+
+    def __init__(self, method: str, url: str, status: int) -> None:
+        self.method = method
+        self.url = url
+        self.status = status
+        super().__init__(f"{method} {url} returned HTTP {status}.")
+
+
+@dataclass(frozen=True)
+class HttpResult:
+    body: bytes
+    headers: Mapping[str, str]
+    sha256: str | None = None
+    bytes_read: int | None = None
+
+
+Transport = Callable[[str, str], HttpResult]
+GithubFetch = Callable[[str], object | None]
+ReleaseGuard = Callable[[str, str], None]
+
+
+def _normalized_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {str(key).lower(): str(value).strip() for key, value in headers.items()}
+
+
+def _http_request(method: str, url: str) -> HttpResult:
+    if method not in {"GET", "HEAD", "HASH"}:
+        raise CandidateError(f"Unsupported HTTP method {method!r}.")
+    request = urllib.request.Request(
+        url,
+        method="GET" if method == "HASH" else method,
+        headers={
+            "Accept-Encoding": "gzip",
+            "Cache-Control": "no-cache",
+            "User-Agent": "tuva-core-release-candidate-verifier/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            if method == "HASH":
+                digest = hashlib.sha256()
+                bytes_read = 0
+                while True:
+                    chunk = response.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    bytes_read += len(chunk)
+                return HttpResult(
+                    body=b"",
+                    headers=dict(response.headers.items()),
+                    sha256=digest.hexdigest(),
+                    bytes_read=bytes_read,
+                )
+            body = response.read() if method == "GET" else b""
+            return HttpResult(body=body, headers=dict(response.headers.items()))
+    except urllib.error.HTTPError as exc:
+        raise HttpStatusError(method, url, exc.code) from exc
+    except urllib.error.URLError as exc:
+        raise CandidateError(f"{method} {url} failed: {exc.reason}.") from exc
+
+
+def _github_json_or_none(path: str) -> object | None:
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "tuva-core-release-candidate-verifier/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        f"{GITHUB_API_BASE_URL}/{path.lstrip('/')}",
+        method="GET",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise CandidateError(
+            f"GitHub release-state check returned HTTP {exc.code}."
+        ) from exc
+    except (urllib.error.URLError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CandidateError(f"GitHub release-state check failed: {exc}.") from exc
+
+
+def ensure_version_unreleased(
+    package: str,
+    version: str,
+    *,
+    github_fetch: GithubFetch = _github_json_or_none,
+) -> None:
+    repository = PACKAGE_REPOSITORIES.get(package)
+    if repository is None:
+        raise CandidateError(f"Unsupported candidate package {package!r}.")
+    if not SEMVER_PATTERN.fullmatch(version):
+        raise CandidateError("Expected candidate version is not canonical semver.")
+    tag = f"v{version}"
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    if github_fetch(f"repos/{repository}/git/ref/tags/{encoded_tag}") is not None:
+        raise CandidateError(f"Package tag already exists; candidate is frozen: {tag}.")
+    release = github_fetch(f"repos/{repository}/releases/tags/{encoded_tag}")
+    if release is None:
+        return
+    if not isinstance(release, dict) or not isinstance(release.get("draft"), bool):
+        raise CandidateError("GitHub release-state response has an invalid schema.")
+    if not release["draft"]:
+        raise CandidateError(
+            f"Published GitHub release already exists; candidate is frozen: {tag}."
+        )
+
+
+def _object_url(base_url: str, package: str, version: str, path: str) -> str:
+    key = "/".join((package, version, path))
+    return f"{base_url.rstrip('/')}/{urllib.parse.quote(key, safe='/')}"
+
+
+def _require_exact_string(value: object, expected: str, label: str) -> None:
+    if value != expected:
+        raise CandidateError(f"Candidate {label} must equal {expected!r}.")
+
+
+def _require_nonnegative_integer(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise CandidateError(f"Candidate {label} must be a nonnegative integer.")
+    return value
+
+
+def read_package_version(package_root: Path) -> str:
+    text = (package_root / "dbt_project.yml").read_text(encoding="utf-8")
+    match = re.search(
+        r"(?m)^version: '([1-9][0-9]*\.[0-9]+\.[0-9]+"
+        r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)'$",
+        text,
+    )
+    if match is None:
+        raise CandidateError("dbt_project.yml does not contain one canonical package version.")
+    return match.group(1)
+
+
+def read_catalog_paths(package_root: Path, expected_package: str) -> tuple[str, ...]:
+    text = (package_root / "data_assets.yml").read_text(encoding="utf-8")
+    schema_match = re.search(r"(?m)^schema_version: (\d+)$", text)
+    package_match = re.search(r"(?m)^package: (\S+)$", text)
+    if schema_match is None or int(schema_match.group(1)) != 1:
+        raise CandidateError("data_assets.yml must use schema_version 1.")
+    if package_match is None or package_match.group(1) != expected_package:
+        raise CandidateError("data_assets.yml package does not match the candidate package.")
+    paths = tuple(
+        re.findall(r"(?m)^  - seed: \S+\n    path: (\S+)$", text)
+    )
+    if not paths or len(paths) != len(set(paths)):
+        raise CandidateError("data_assets.yml paths must be nonempty and unique.")
+    return paths
+
+
+def parse_candidate_marker(
+    marker_bytes: bytes,
+    *,
+    expected_package: str,
+    expected_version: str,
+    expected_package_commit: str,
+    expected_paths: Sequence[str],
+) -> dict[str, object]:
+    try:
+        marker = json.loads(marker_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CandidateError("Candidate marker is not valid UTF-8 JSON.") from exc
+    if not isinstance(marker, dict) or set(marker) != RECEIPT_KEYS:
+        raise CandidateError("Candidate marker has an unsupported top-level schema.")
+    if marker.get("schema_version") != 1:
+        raise CandidateError("Candidate marker must use schema_version 1.")
+    _require_exact_string(marker.get("package"), expected_package, "package")
+    _require_exact_string(marker.get("version"), expected_version, "version")
+    _require_exact_string(
+        marker.get("package_commit"),
+        expected_package_commit,
+        "package_commit",
+    )
+    if not SHA_PATTERN.fullmatch(expected_package_commit):
+        raise CandidateError("Expected package commit must be a lowercase 40-character SHA.")
+
+    raw_files = marker.get("files")
+    if not isinstance(raw_files, list):
+        raise CandidateError("Candidate marker files must be a list.")
+    files_by_path: dict[str, dict[str, object]] = {}
+    for index, item in enumerate(raw_files):
+        if not isinstance(item, dict) or set(item) != FILE_KEYS:
+            raise CandidateError(f"Candidate file entry {index} has an invalid schema.")
+        path = item.get("path")
+        digest = item.get("sha256")
+        if (
+            not isinstance(path, str)
+            or not path
+            or path.startswith("/")
+            or ".." in path.split("/")
+            or path in files_by_path
+        ):
+            raise CandidateError(f"Candidate file entry {index} has an invalid path.")
+        if not isinstance(digest, str) or not SHA256_PATTERN.fullmatch(digest):
+            raise CandidateError(f"Candidate file {path} has an invalid SHA-256.")
+        _require_nonnegative_integer(item.get("bytes"), f"byte count for {path}")
+        _require_nonnegative_integer(item.get("rows"), f"row count for {path}")
+        files_by_path[path] = item
+
+    actual_paths = tuple(sorted(files_by_path))
+    if actual_paths != tuple(sorted(expected_paths)):
+        missing = sorted(set(expected_paths) - set(actual_paths))
+        extra = sorted(set(actual_paths) - set(expected_paths))
+        raise CandidateError(
+            f"Candidate inventory differs from data_assets.yml; missing={missing}, extra={extra}."
+        )
+    return marker
+
+
+def _cache_control_is_exact(value: str | None) -> bool:
+    if value is None:
+        return False
+    tokens = {token.strip().lower() for token in value.split(",") if token.strip()}
+    return tokens == {"no-store", "max-age=0", "must-revalidate"}
+
+
+def _verify_headers(
+    result: HttpResult,
+    *,
+    expected_bytes: int,
+    expected_content_type: str,
+    expected_content_encoding: str | None,
+    label: str,
+) -> None:
+    headers = _normalized_headers(result.headers)
+    try:
+        actual_bytes = int(headers.get("content-length", ""))
+    except ValueError as exc:
+        raise CandidateError(f"{label} has an invalid Content-Length.") from exc
+    if actual_bytes != expected_bytes:
+        raise CandidateError(
+            f"{label} Content-Length is {actual_bytes}; expected {expected_bytes}."
+        )
+    content_type = headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    if content_type != expected_content_type:
+        raise CandidateError(
+            f"{label} Content-Type is {content_type!r}; expected {expected_content_type!r}."
+        )
+    content_encoding = headers.get("content-encoding")
+    if content_encoding != expected_content_encoding:
+        raise CandidateError(
+            f"{label} Content-Encoding is {content_encoding!r}; "
+            f"expected {expected_content_encoding!r}."
+        )
+    if not _cache_control_is_exact(headers.get("cache-control")):
+        raise CandidateError(f"{label} must use {CANDIDATE_CACHE_CONTROL!r}.")
+
+
+def _require_absent(url: str, transport: Transport) -> None:
+    try:
+        transport("HEAD", url)
+    except HttpStatusError as exc:
+        if exc.status == 404:
+            return
+        raise
+    raise CandidateError(f"Candidate store contains forbidden {RELEASE_RECEIPT}: {url}.")
+
+
+def _object_identity(
+    store: str,
+    result: HttpResult,
+    *,
+    label: str,
+) -> dict[str, str]:
+    headers = _normalized_headers(result.headers)
+    if store == "s3":
+        version_id = headers.get("x-amz-version-id", "")
+        if not version_id or version_id.lower() == "null":
+            raise CandidateError(f"{label} has no immutable S3 version ID.")
+        return {"version_id": version_id}
+    if store == "gcs":
+        generation = headers.get("x-goog-generation", "")
+        metageneration = headers.get("x-goog-metageneration", "")
+        if not re.fullmatch(r"[1-9][0-9]*", generation):
+            raise CandidateError(f"{label} has no valid GCS generation.")
+        if not re.fullmatch(r"[1-9][0-9]*", metageneration):
+            raise CandidateError(f"{label} has no valid GCS metageneration.")
+        return {
+            "generation": generation,
+            "metageneration": metageneration,
+        }
+    if store == "azure":
+        etag = headers.get("etag", "")
+        if not etag:
+            raise CandidateError(f"{label} has no Azure ETag.")
+        return {"etag": etag}
+    raise CandidateError(f"Unsupported candidate store {store!r}.")
+
+
+def _validate_locked_identities(
+    value: object,
+    *,
+    expected_paths: Sequence[str],
+) -> Mapping[str, object]:
+    if not isinstance(value, dict) or set(value) != {"s3", "gcs", "azure"}:
+        raise CandidateError("Source lock candidate object identities are invalid.")
+    required_paths = {CANDIDATE_MARKER, *expected_paths}
+    identity_keys = {
+        "s3": {"version_id"},
+        "gcs": {"generation", "metageneration"},
+        "azure": {"etag"},
+    }
+    for store, expected_keys in identity_keys.items():
+        objects = value.get(store)
+        if not isinstance(objects, dict) or set(objects) != required_paths:
+            raise CandidateError(
+                f"Source lock candidate {store} object inventory is invalid."
+            )
+        for path, identity in objects.items():
+            if not isinstance(identity, dict) or set(identity) != expected_keys:
+                raise CandidateError(
+                    f"Source lock identity for {store} object {path} is invalid."
+                )
+            if any(not isinstance(item, str) or not item for item in identity.values()):
+                raise CandidateError(
+                    f"Source lock identity for {store} object {path} is invalid."
+                )
+            if store == "s3" and identity["version_id"].lower() == "null":
+                raise CandidateError(
+                    f"Source lock identity for {store} object {path} is invalid."
+                )
+            if store == "gcs" and any(
+                not re.fullmatch(r"[1-9][0-9]*", identity[key])
+                for key in expected_keys
+            ):
+                raise CandidateError(
+                    f"Source lock identity for {store} object {path} is invalid."
+                )
+    return value
+
+
+def verify_candidate(
+    *,
+    expected_package: str,
+    expected_version: str,
+    expected_package_commit: str,
+    expected_paths: Sequence[str],
+    expected_marker_sha256: str | None = None,
+    expected_object_identities: Mapping[str, object] | None = None,
+    full_payload_hashes: bool = False,
+    transport: Transport = _http_request,
+    store_base_urls: Mapping[str, str] = STORE_BASE_URLS,
+) -> tuple[dict[str, object], str, dict[str, dict[str, dict[str, str]]]]:
+    if not SEMVER_PATTERN.fullmatch(expected_version):
+        raise CandidateError("Expected candidate version is not canonical semver.")
+    if set(store_base_urls) != {"s3", "gcs", "azure"}:
+        raise CandidateError("Candidate verification requires exactly S3, GCS, and Azure.")
+
+    marker_urls = {
+        store: _object_url(base, expected_package, expected_version, CANDIDATE_MARKER)
+        for store, base in store_base_urls.items()
+    }
+    marker_results: dict[str, HttpResult] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {
+            executor.submit(transport, "GET", url): store
+            for store, url in marker_urls.items()
+        }
+        for future in concurrent.futures.as_completed(futures):
+            store = futures[future]
+            marker_results[store] = future.result()
+
+    baseline = marker_results["s3"].body
+    marker_sha256 = hashlib.sha256(baseline).hexdigest()
+    if expected_marker_sha256 is not None:
+        if (
+            not SHA256_PATTERN.fullmatch(expected_marker_sha256)
+            or marker_sha256 != expected_marker_sha256
+        ):
+            raise CandidateError("Candidate marker SHA-256 changed; rerun release CI.")
+    for store, result in sorted(marker_results.items()):
+        if result.body != baseline:
+            raise CandidateError(f"{store} candidate marker bytes differ from S3.")
+        _verify_headers(
+            result,
+            expected_bytes=len(baseline),
+            expected_content_type="application/json",
+            expected_content_encoding=None,
+            label=f"{store} candidate marker",
+        )
+
+    object_identities: dict[str, dict[str, dict[str, str]]] = {
+        store: {
+            CANDIDATE_MARKER: _object_identity(
+                store,
+                result,
+                label=f"{store} candidate marker",
+            )
+        }
+        for store, result in sorted(marker_results.items())
+    }
+
+    marker = parse_candidate_marker(
+        baseline,
+        expected_package=expected_package,
+        expected_version=expected_version,
+        expected_package_commit=expected_package_commit,
+        expected_paths=expected_paths,
+    )
+
+    absence_checks = [
+        _object_url(base, expected_package, expected_version, RELEASE_RECEIPT)
+        for base in store_base_urls.values()
+    ]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        list(executor.map(lambda url: _require_absent(url, transport), absence_checks))
+
+    files = {item["path"]: item for item in marker["files"]}  # type: ignore[index]
+    checks: list[tuple[str, str, str, int, str, str]] = []
+    for store, base in sorted(store_base_urls.items()):
+        for path in expected_paths:
+            checks.append(
+                (
+                    store,
+                    path,
+                    _object_url(base, expected_package, expected_version, path),
+                    int(files[path]["bytes"]),
+                    str(files[path]["sha256"]),
+                    f"{store} candidate payload {path}",
+                )
+            )
+
+    def check_payload(
+        check: tuple[str, str, str, int, str, str]
+    ) -> tuple[str, str, dict[str, str]]:
+        store, path, url, byte_count, expected_sha256, label = check
+        result = transport("HASH" if full_payload_hashes else "HEAD", url)
+        _verify_headers(
+            result,
+            expected_bytes=byte_count,
+            expected_content_type="text/csv",
+            expected_content_encoding="gzip",
+            label=label,
+        )
+        if full_payload_hashes:
+            if result.bytes_read != byte_count:
+                raise CandidateError(
+                    f"{label} yielded {result.bytes_read} bytes; expected {byte_count}."
+                )
+            if result.sha256 != expected_sha256:
+                raise CandidateError(f"{label} SHA-256 differs from the marker.")
+        return store, path, _object_identity(store, result, label=label)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=24) as executor:
+        checked_payloads = list(executor.map(check_payload, checks))
+    for store, path, identity in checked_payloads:
+        object_identities[store][path] = identity
+
+    if (
+        expected_object_identities is not None
+        and object_identities != expected_object_identities
+    ):
+        raise CandidateError(
+            "Candidate object identity changed in S3, GCS, or Azure; rerun release CI."
+        )
+    return marker, marker_sha256, object_identities
+
+
+def _candidate_lock(
+    marker: Mapping[str, object],
+    marker_sha256: str,
+    object_identities: Mapping[str, object],
+) -> dict[str, object]:
+    files = marker["files"]
+    assert isinstance(files, list)
+    return {
+        "bucket": CANDIDATE_BUCKET,
+        "file_count": len(files),
+        "marker_sha256": marker_sha256,
+        "object_identities": object_identities,
+        "package": marker["package"],
+        "package_commit": marker["package_commit"],
+        "stores": ["s3", "gcs", "azure"],
+        "version": marker["version"],
+    }
+
+
+def resolve_source_lock(
+    *,
+    package_root: Path,
+    package: str,
+    package_commit: str,
+    source_lock: Mapping[str, object],
+    transport: Transport = _http_request,
+    store_base_urls: Mapping[str, str] = STORE_BASE_URLS,
+    release_guard: ReleaseGuard = ensure_version_unreleased,
+) -> dict[str, object]:
+    if "data_asset_candidate" in source_lock:
+        raise CandidateError("Source lock already contains a data-asset candidate.")
+    version = read_package_version(package_root)
+    paths = read_catalog_paths(package_root, package)
+    release_guard(package, version)
+    marker, marker_sha256, object_identities = verify_candidate(
+        expected_package=package,
+        expected_version=version,
+        expected_package_commit=package_commit,
+        expected_paths=paths,
+        full_payload_hashes=True,
+        transport=transport,
+        store_base_urls=store_base_urls,
+    )
+    verify_candidate(
+        expected_package=package,
+        expected_version=version,
+        expected_package_commit=package_commit,
+        expected_paths=paths,
+        expected_marker_sha256=marker_sha256,
+        expected_object_identities=object_identities,
+        transport=transport,
+        store_base_urls=store_base_urls,
+    )
+    release_guard(package, version)
+    resolved = dict(source_lock)
+    resolved["data_asset_candidate"] = _candidate_lock(
+        marker,
+        marker_sha256,
+        object_identities,
+    )
+    return resolved
+
+
+def verify_source_lock_candidate(
+    *,
+    package_root: Path,
+    source_lock: Mapping[str, object],
+    transport: Transport = _http_request,
+    store_base_urls: Mapping[str, str] = STORE_BASE_URLS,
+    require_unreleased: bool = True,
+    release_guard: ReleaseGuard = ensure_version_unreleased,
+) -> None:
+    candidate = source_lock.get("data_asset_candidate")
+    required_keys = {
+        "bucket",
+        "file_count",
+        "marker_sha256",
+        "object_identities",
+        "package",
+        "package_commit",
+        "stores",
+        "version",
+    }
+    if not isinstance(candidate, dict) or set(candidate) != required_keys:
+        raise CandidateError("Source lock has an invalid data-asset candidate.")
+    package = candidate.get("package")
+    version = candidate.get("version")
+    package_commit = candidate.get("package_commit")
+    marker_sha256 = candidate.get("marker_sha256")
+    if not all(isinstance(value, str) for value in (
+        package,
+        version,
+        package_commit,
+        marker_sha256,
+    )):
+        raise CandidateError("Source lock candidate identifiers must be strings.")
+    if candidate.get("bucket") != CANDIDATE_BUCKET:
+        raise CandidateError("Source lock candidate bucket is invalid.")
+    if candidate.get("stores") != ["s3", "gcs", "azure"]:
+        raise CandidateError("Source lock candidate stores are invalid.")
+    if version != read_package_version(package_root):
+        raise CandidateError("Source lock candidate version differs from the checkout.")
+    paths = read_catalog_paths(package_root, package)
+    if candidate.get("file_count") != len(paths):
+        raise CandidateError("Source lock candidate file count differs from data_assets.yml.")
+    object_identities = _validate_locked_identities(
+        candidate.get("object_identities"),
+        expected_paths=paths,
+    )
+    if require_unreleased:
+        release_guard(package, version)
+    verify_candidate(
+        expected_package=package,
+        expected_version=version,
+        expected_package_commit=package_commit,
+        expected_paths=paths,
+        expected_marker_sha256=marker_sha256,
+        expected_object_identities=object_identities,
+        transport=transport,
+        store_base_urls=store_base_urls,
+    )
+    if require_unreleased:
+        release_guard(package, version)
+
+
+def _load_json_object(raw: str, label: str) -> dict[str, object]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CandidateError(f"{label} is not valid JSON.") from exc
+    if not isinstance(value, dict):
+        raise CandidateError(f"{label} must be a JSON object.")
+    return value
+
+
+def _write_github_output(path: Path, name: str, value: str) -> None:
+    if "\n" in value or "\r" in value:
+        raise CandidateError(f"GitHub output {name} must be one line.")
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"{name}={value}\n")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resolve = subparsers.add_parser(
+        "resolve", description="Validate all candidate stores and extend a source lock."
+    )
+    resolve.add_argument("--package-root", default=".")
+    resolve.add_argument("--package", default="tuva-core")
+    resolve.add_argument("--package-commit", required=True)
+    resolve.add_argument("--source-lock-json", required=True)
+    resolve.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+
+    verify = subparsers.add_parser(
+        "verify", description="Recheck the source-locked candidate in all clouds."
+    )
+    verify.add_argument("--package-root", default=".")
+    verify.add_argument("--source-lock-json", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        package_root = Path(args.package_root).resolve()
+        source_lock = _load_json_object(args.source_lock_json, "source lock")
+        if args.command == "resolve":
+            resolved = resolve_source_lock(
+                package_root=package_root,
+                package=args.package,
+                package_commit=args.package_commit,
+                source_lock=source_lock,
+            )
+            compact = json.dumps(resolved, separators=(",", ":"), sort_keys=True)
+            if args.github_output:
+                output_path = Path(args.github_output)
+                _write_github_output(output_path, "source_lock", compact)
+                candidate = resolved["data_asset_candidate"]
+                assert isinstance(candidate, dict)
+                _write_github_output(
+                    output_path,
+                    "candidate_marker_sha256",
+                    str(candidate["marker_sha256"]),
+                )
+                _write_github_output(
+                    output_path,
+                    "package_version",
+                    str(candidate["version"]),
+                )
+            else:
+                print(compact)
+            return 0
+        verify_source_lock_candidate(
+            package_root=package_root,
+            source_lock=source_lock,
+        )
+        print("verified source-locked data-asset candidate in S3, GCS, and Azure")
+        return 0
+    except (CandidateError, FileNotFoundError, OSError) as exc:
+        print(f"candidate verification failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -328,6 +328,120 @@ class DataAssetContractTest(unittest.TestCase):
         for action_ref in action_refs:
             self.assertRegex(action_ref, r"^[0-9a-f]{40}$")
 
+    def test_all_warehouse_ci_pins_and_rechecks_mutable_candidate(self):
+        dispatcher = (
+            ROOT / ".github" / "workflows" / "ci-all-warehouses.yml"
+        ).read_text()
+        reusable = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+        verifier = (ROOT / "scripts" / "verify_data_asset_candidate.py").read_text()
+
+        self.assertIn("pr_number:", dispatcher)
+        self.assertNotIn("candidate_marker_sha256:\n        description:", dispatcher)
+        self.assertIn(
+            "source_lock: ${{ steps.candidate.outputs.source_lock }}",
+            dispatcher,
+        )
+        self.assertIn(
+            '/usr/bin/python3 "$RUNNER_TEMP/verify_data_asset_candidate.py" resolve',
+            dispatcher,
+        )
+        self.assertIn("ref: ${{ github.workflow_sha }}", dispatcher)
+        self.assertIn("trusted_ref: ${{ github.workflow_sha }}", dispatcher)
+        self.assertIn("EXPECTED_TRUSTED_REF: ${{ github.workflow_sha }}", reusable)
+        self.assertIn(
+            'cp scripts/verify_data_asset_candidate.py\n'
+            '          "$RUNNER_TEMP/verify_data_asset_candidate.py"',
+            dispatcher,
+        )
+        self.assertIn("--package-root .", dispatcher)
+        self.assertNotIn(
+            "python3 scripts/verify_data_asset_candidate.py resolve",
+            dispatcher,
+        )
+        self.assertNotIn(".ci-trusted", dispatcher)
+        self.assertNotIn(".ci-source", dispatcher)
+        self.assertLess(
+            dispatcher.index("Check out the trusted workflow revision"),
+            dispatcher.index("Copy the trusted candidate verifier"),
+        )
+        self.assertLess(
+            dispatcher.index("Copy the trusted candidate verifier"),
+            dispatcher.index("Check out the exact pull request test merge"),
+        )
+        self.assertLess(
+            dispatcher.index("Pin the complete cross-cloud data-asset candidate"),
+            dispatcher.index("run_all_warehouses:"),
+        )
+        self.assertIn(
+            "Verify source-locked candidate before using warehouse credentials",
+            reusable,
+        )
+        self.assertIn(
+            "Recheck source-locked candidate after the warehouse build",
+            reusable,
+        )
+        self.assertIn(
+            "Recheck every source-locked candidate identity before final status",
+            reusable,
+        )
+        verifier_invocations = [
+            line.strip()
+            for line in reusable.splitlines()
+            if 'verify_data_asset_candidate.py" verify' in line
+        ]
+        self.assertEqual(len(verifier_invocations), 3)
+        self.assertTrue(
+            all(
+                line.startswith(
+                    '/usr/bin/python3 "$RUNNER_TEMP/verify_data_asset_candidate.py"'
+                )
+                for line in verifier_invocations
+            )
+        )
+        self.assertEqual(
+            reusable.count(
+                'cp scripts/verify_data_asset_candidate.py '
+                '"$RUNNER_TEMP/verify_data_asset_candidate.py"'
+            ),
+            2,
+        )
+        self.assertNotIn(".ci-trusted", reusable)
+        self.assertNotIn(".ci-source", reusable)
+        self.assertIn('"object_identities"', reusable)
+        self.assertNotIn(
+            "python3 scripts/verify_data_asset_candidate.py verify",
+            reusable,
+        )
+        self.assertIn(
+            'dbt_vars["tuva_seed_buckets"] = {"tuva-core": candidate_bucket}',
+            reusable,
+        )
+        self.assertNotIn(
+            'dbt_vars["custom_bucket_name"] = candidate_bucket',
+            reusable,
+        )
+        self.assertNotIn("candidateMarkerIsCurrent", reusable)
+        self.assertIn("Data-asset candidate changed; rerun required", reusable)
+        self.assertIn("STORE_BASE_URLS", verifier)
+        self.assertIn('"s3": f"https://{CANDIDATE_BUCKET}.s3.amazonaws.com"', verifier)
+        self.assertIn(
+            '"gcs": f"https://storage.googleapis.com/{CANDIDATE_BUCKET}"',
+            verifier,
+        )
+        self.assertIn("tuvapublicresources.blob.core.windows.net", verifier)
+        self.assertIn("expected_marker_sha256", verifier)
+        self.assertIn("expected_object_identities", verifier)
+        self.assertIn("full_payload_hashes=True", verifier)
+        self.assertIn('transport("HASH" if full_payload_hashes else "HEAD"', verifier)
+        self.assertIn('headers.get("x-amz-version-id"', verifier)
+        self.assertIn('headers.get("x-goog-generation"', verifier)
+        self.assertIn('headers.get("etag"', verifier)
+        self.assertIn("release_guard(package, version)", verifier)
+        self.assertIn(
+            'tokens == {"no-store", "max-age=0", "must-revalidate"}',
+            verifier,
+        )
+
     def test_release_recovery_is_main_only_and_uses_current_main_commit(self):
         workflow = (ROOT / ".github" / "workflows" / "create-release.yml").read_text()
         self.assertIn("workflow_dispatch:", workflow)

--- a/tests/unit/test_release_candidate_ci.py
+++ b/tests/unit/test_release_candidate_ci.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+
+import hashlib
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts" / "verify_data_asset_candidate.py"
+SPEC = importlib.util.spec_from_file_location("verify_data_asset_candidate", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeTransport:
+    def __init__(self, responses):
+        self.responses = dict(responses)
+        self.calls = []
+
+    def __call__(self, method, url):
+        self.calls.append((method, url))
+        value = self.responses.get((method, url))
+        if value is None:
+            raise MODULE.HttpStatusError(method, url, 404)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class ReleaseCandidateCiTest(unittest.TestCase):
+    package = "tuva-core"
+    version = "1.0.0"
+    package_commit = "a" * 40
+    paths = (
+        "terminology/terminology__example.csv.gz",
+        "provider-data/provider_data__example.csv.gz",
+    )
+    bases = {
+        "s3": "https://s3.example",
+        "gcs": "https://gcs.example",
+        "azure": "https://azure.example",
+    }
+    payloads = {
+        paths[0]: b"terminology-bytes",
+        paths[1]: b"provider-data-payload-bytes",
+    }
+
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.package_root = Path(self.temporary_directory.name)
+        (self.package_root / "dbt_project.yml").write_text(
+            "name: 'the_tuva_project'\nversion: '1.0.0'\n",
+            encoding="utf-8",
+        )
+        (self.package_root / "data_assets.yml").write_text(
+            "\n".join(
+                [
+                    "schema_version: 1",
+                    "package: tuva-core",
+                    "assets:",
+                    "  - seed: terminology__example",
+                    f"    path: {self.paths[0]}",
+                    "  - seed: provider_data__example",
+                    f"    path: {self.paths[1]}",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    @staticmethod
+    def allow_unreleased(_package, _version):
+        return None
+
+    def marker(self, *, commit=None):
+        return {
+            "schema_version": 1,
+            "package": self.package,
+            "version": self.version,
+            "package_commit": commit or self.package_commit,
+            "files": [
+                {
+                    "path": path,
+                    "sha256": hashlib.sha256(self.payloads[path]).hexdigest(),
+                    "bytes": len(self.payloads[path]),
+                    "rows": index + 2,
+                }
+                for index, path in enumerate(self.paths)
+            ],
+        }
+
+    def identity_headers(self, store, path):
+        index = (MODULE.CANDIDATE_MARKER, *self.paths).index(path) + 1
+        if store == "s3":
+            return {"x-amz-version-id": f"s3-version-{index}"}
+        if store == "gcs":
+            return {
+                "x-goog-generation": str(1000 + index),
+                "x-goog-metageneration": "1",
+            }
+        if store == "azure":
+            return {"ETag": f'"azure-etag-{index}"'}
+        raise AssertionError(f"unexpected store: {store}")
+
+    def headers(
+        self,
+        store,
+        path,
+        byte_count,
+        content_type,
+        content_encoding=None,
+    ):
+        headers = {
+            "Content-Length": str(byte_count),
+            "Content-Type": content_type,
+            "Cache-Control": " must-revalidate, MAX-AGE=0 , no-store ",
+            **self.identity_headers(store, path),
+        }
+        if content_encoding is not None:
+            headers["Content-Encoding"] = content_encoding
+        return headers
+
+    def transport(self, marker=None):
+        marker = marker or self.marker()
+        marker_bytes = json.dumps(marker, sort_keys=True).encode()
+        responses = {}
+        for store, base in self.bases.items():
+            marker_url = MODULE._object_url(
+                base, self.package, self.version, MODULE.CANDIDATE_MARKER
+            )
+            responses[("GET", marker_url)] = MODULE.HttpResult(
+                marker_bytes,
+                self.headers(
+                    store,
+                    MODULE.CANDIDATE_MARKER,
+                    len(marker_bytes),
+                    "application/json; charset=utf-8",
+                ),
+            )
+            for item in marker["files"]:
+                path = item["path"]
+                payload_url = MODULE._object_url(
+                    base, self.package, self.version, path
+                )
+                payload_headers = self.headers(
+                    store,
+                    path,
+                    item["bytes"],
+                    "text/csv",
+                    "gzip",
+                )
+                responses[("HASH", payload_url)] = MODULE.HttpResult(
+                    b"",
+                    payload_headers,
+                    sha256=hashlib.sha256(self.payloads[path]).hexdigest(),
+                    bytes_read=len(self.payloads[path]),
+                )
+                responses[("HEAD", payload_url)] = MODULE.HttpResult(
+                    b"",
+                    payload_headers,
+                )
+        return FakeTransport(responses), marker_bytes
+
+    def resolve(self, transport):
+        return MODULE.resolve_source_lock(
+            package_root=self.package_root,
+            package=self.package,
+            package_commit=self.package_commit,
+            source_lock={
+                "core": {"revision": "d" * 40},
+                "standalone_packages": [],
+            },
+            transport=transport,
+            store_base_urls=self.bases,
+            release_guard=self.allow_unreleased,
+        )
+
+    def test_resolve_hashes_and_pins_every_object_in_all_three_clouds(self):
+        transport, marker_bytes = self.transport()
+        resolved = self.resolve(transport)
+
+        candidate = resolved["data_asset_candidate"]
+        self.assertEqual(candidate["bucket"], MODULE.CANDIDATE_BUCKET)
+        self.assertEqual(candidate["file_count"], 2)
+        self.assertEqual(candidate["package_commit"], self.package_commit)
+        self.assertEqual(
+            candidate["marker_sha256"], hashlib.sha256(marker_bytes).hexdigest()
+        )
+        self.assertEqual(candidate["stores"], ["s3", "gcs", "azure"])
+        expected_objects = {MODULE.CANDIDATE_MARKER, *self.paths}
+        for store in self.bases:
+            self.assertEqual(
+                set(candidate["object_identities"][store]), expected_objects
+            )
+
+        payload_hash_calls = [
+            call for call in transport.calls if call[0] == "HASH"
+        ]
+        payload_head_calls = [
+            call
+            for call in transport.calls
+            if call[0] == "HEAD" and call[1].endswith(".csv.gz")
+        ]
+        self.assertEqual(len(payload_hash_calls), len(self.paths) * 3)
+        self.assertEqual(len(payload_head_calls), len(self.paths) * 3)
+
+    def test_recheck_uses_heads_and_never_redownloads_payloads(self):
+        transport, _ = self.transport()
+        source_lock = self.resolve(transport)
+        transport.calls.clear()
+
+        MODULE.verify_source_lock_candidate(
+            package_root=self.package_root,
+            source_lock=source_lock,
+            transport=transport,
+            store_base_urls=self.bases,
+            release_guard=self.allow_unreleased,
+        )
+
+        self.assertFalse(any(method == "HASH" for method, _url in transport.calls))
+        payload_head_calls = [
+            call
+            for call in transport.calls
+            if call[0] == "HEAD" and call[1].endswith(".csv.gz")
+        ]
+        self.assertEqual(len(payload_head_calls), len(self.paths) * 3)
+
+    def test_different_cloud_marker_fails_closed(self):
+        transport, _ = self.transport()
+        gcs_url = MODULE._object_url(
+            self.bases["gcs"], self.package, self.version, MODULE.CANDIDATE_MARKER
+        )
+        original = transport.responses[("GET", gcs_url)]
+        transport.responses[("GET", gcs_url)] = MODULE.HttpResult(
+            original.body + b" ",
+            self.headers(
+                "gcs",
+                MODULE.CANDIDATE_MARKER,
+                len(original.body) + 1,
+                "application/json",
+            ),
+        )
+        with self.assertRaisesRegex(MODULE.CandidateError, "differ from S3"):
+            self.resolve(transport)
+
+    def test_payload_metadata_mismatch_fails_closed(self):
+        transport, _ = self.transport()
+        url = MODULE._object_url(
+            self.bases["azure"], self.package, self.version, self.paths[1]
+        )
+        original = transport.responses[("HASH", url)]
+        bad_headers = dict(original.headers)
+        bad_headers["Content-Length"] = str(len(self.payloads[self.paths[1]]) - 1)
+        transport.responses[("HASH", url)] = MODULE.HttpResult(
+            b"",
+            bad_headers,
+            sha256=original.sha256,
+            bytes_read=original.bytes_read,
+        )
+        with self.assertRaisesRegex(MODULE.CandidateError, "Content-Length"):
+            self.resolve(transport)
+
+    def test_same_length_payload_with_wrong_bytes_fails_closed(self):
+        transport, _ = self.transport()
+        url = MODULE._object_url(
+            self.bases["gcs"], self.package, self.version, self.paths[0]
+        )
+        original = transport.responses[("HASH", url)]
+        transport.responses[("HASH", url)] = MODULE.HttpResult(
+            b"",
+            original.headers,
+            sha256="f" * 64,
+            bytes_read=original.bytes_read,
+        )
+        with self.assertRaisesRegex(MODULE.CandidateError, "SHA-256 differs"):
+            self.resolve(transport)
+
+    def test_candidate_must_be_bound_to_pull_request_head(self):
+        transport, _ = self.transport(self.marker(commit="e" * 40))
+        with self.assertRaisesRegex(MODULE.CandidateError, "package_commit"):
+            self.resolve(transport)
+
+    def test_candidate_store_must_not_contain_release_receipt(self):
+        transport, _ = self.transport()
+        release_url = MODULE._object_url(
+            self.bases["s3"], self.package, self.version, MODULE.RELEASE_RECEIPT
+        )
+        transport.responses[("HEAD", release_url)] = MODULE.HttpResult(
+            b"",
+            {
+                "Content-Length": "10",
+                "Content-Type": "application/json",
+            },
+        )
+        with self.assertRaisesRegex(MODULE.CandidateError, "forbidden _release.json"):
+            self.resolve(transport)
+
+    def test_release_receipt_403_is_not_treated_as_absent(self):
+        transport, _ = self.transport()
+        release_url = MODULE._object_url(
+            self.bases["s3"], self.package, self.version, MODULE.RELEASE_RECEIPT
+        )
+        transport.responses[("HEAD", release_url)] = MODULE.HttpStatusError(
+            "HEAD", release_url, 403
+        )
+        with self.assertRaisesRegex(MODULE.CandidateError, "HTTP 403"):
+            self.resolve(transport)
+
+    def test_cache_control_requires_exact_writer_token_set(self):
+        transport, _ = self.transport()
+        marker_url = MODULE._object_url(
+            self.bases["s3"], self.package, self.version, MODULE.CANDIDATE_MARKER
+        )
+        original = transport.responses[("GET", marker_url)]
+        bad_headers = dict(original.headers)
+        bad_headers["Cache-Control"] = "no-store,max-age=0"
+        transport.responses[("GET", marker_url)] = MODULE.HttpResult(
+            original.body, bad_headers
+        )
+        with self.assertRaisesRegex(MODULE.CandidateError, "must use"):
+            self.resolve(transport)
+
+    def test_payload_identity_drift_fails_recheck(self):
+        transport, _ = self.transport()
+        source_lock = self.resolve(transport)
+        url = MODULE._object_url(
+            self.bases["s3"], self.package, self.version, self.paths[0]
+        )
+        original = transport.responses[("HEAD", url)]
+        changed_headers = dict(original.headers)
+        changed_headers["x-amz-version-id"] = "replacement-version"
+        transport.responses[("HEAD", url)] = MODULE.HttpResult(b"", changed_headers)
+
+        with self.assertRaisesRegex(MODULE.CandidateError, "object identity changed"):
+            MODULE.verify_source_lock_candidate(
+                package_root=self.package_root,
+                source_lock=source_lock,
+                transport=transport,
+                store_base_urls=self.bases,
+                release_guard=self.allow_unreleased,
+            )
+
+    def test_marker_identity_drift_with_same_bytes_fails_recheck(self):
+        transport, _ = self.transport()
+        source_lock = self.resolve(transport)
+        marker_url = MODULE._object_url(
+            self.bases["azure"], self.package, self.version, MODULE.CANDIDATE_MARKER
+        )
+        original = transport.responses[("GET", marker_url)]
+        changed_headers = dict(original.headers)
+        changed_headers["ETag"] = '"replacement-etag"'
+        transport.responses[("GET", marker_url)] = MODULE.HttpResult(
+            original.body, changed_headers
+        )
+
+        with self.assertRaisesRegex(MODULE.CandidateError, "object identity changed"):
+            MODULE.verify_source_lock_candidate(
+                package_root=self.package_root,
+                source_lock=source_lock,
+                transport=transport,
+                store_base_urls=self.bases,
+                release_guard=self.allow_unreleased,
+            )
+
+    def test_source_lock_requires_exact_object_identity_inventory(self):
+        transport, _ = self.transport()
+        source_lock = self.resolve(transport)
+        del source_lock["data_asset_candidate"]["object_identities"]["gcs"][
+            self.paths[1]
+        ]
+        with self.assertRaisesRegex(MODULE.CandidateError, "inventory is invalid"):
+            MODULE.verify_source_lock_candidate(
+                package_root=self.package_root,
+                source_lock=source_lock,
+                transport=transport,
+                store_base_urls=self.bases,
+                release_guard=self.allow_unreleased,
+            )
+
+    def test_exact_tag_blocks_candidate_but_draft_release_does_not(self):
+        tag_path = "repos/tuva-health/tuva-core/git/ref/tags/v1.0.0"
+        release_path = "repos/tuva-health/tuva-core/releases/tags/v1.0.0"
+
+        with self.assertRaisesRegex(MODULE.CandidateError, "tag already exists"):
+            MODULE.ensure_version_unreleased(
+                self.package,
+                self.version,
+                github_fetch=lambda path: {"ref": "refs/tags/v1.0.0"}
+                if path == tag_path
+                else None,
+            )
+
+        MODULE.ensure_version_unreleased(
+            self.package,
+            self.version,
+            github_fetch=lambda path: {"draft": True}
+            if path == release_path
+            else None,
+        )
+
+    def test_published_release_blocks_candidate(self):
+        release_path = "repos/tuva-health/tuva-core/releases/tags/v1.0.0"
+        with self.assertRaisesRegex(MODULE.CandidateError, "Published GitHub release"):
+            MODULE.ensure_version_unreleased(
+                self.package,
+                self.version,
+                github_fetch=lambda path: {"draft": False}
+                if path == release_path
+                else None,
+            )
+
+    def test_release_appearing_after_resolution_blocks_recheck(self):
+        transport, _ = self.transport()
+        calls = 0
+
+        def evolving_guard(_package, _version):
+            nonlocal calls
+            calls += 1
+            if calls > 2:
+                raise MODULE.CandidateError(
+                    "Published GitHub release already exists; candidate is frozen."
+                )
+
+        source_lock = MODULE.resolve_source_lock(
+            package_root=self.package_root,
+            package=self.package,
+            package_commit=self.package_commit,
+            source_lock={},
+            transport=transport,
+            store_base_urls=self.bases,
+            release_guard=evolving_guard,
+        )
+        with self.assertRaisesRegex(MODULE.CandidateError, "candidate is frozen"):
+            MODULE.verify_source_lock_candidate(
+                package_root=self.package_root,
+                source_lock=source_lock,
+                transport=transport,
+                store_base_urls=self.bases,
+                release_guard=evolving_guard,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- resolve Tuva Core release candidates with verifier code copied from the exact trusted workflow commit into `$RUNNER_TEMP`, never PR-controlled code
- stream and hash every declared payload in S3, GCS, and Azure before minting the release source lock
- pin the marker digest plus S3 version IDs, GCS generations/metagenerations, and Azure ETags for every marker and payload
- recheck all locked identities and release state before and after every warehouse build and before final status
- route only Tuva Core to candidate stores while standalone packages continue using released assets
- reject exact version tags and published GitHub releases while allowing draft-only candidate work

## Validation

- `/opt/homebrew/bin/python3.13 -m unittest discover -s tests/unit -v` — 29 passed
- `actionlint .github/workflows/ci-all-warehouses.yml .github/workflows/ci.yml` — passed
- Python compilation — passed
- `git diff --check origin/main...HEAD` — passed
- rebased onto current `main`, including the latest all-warehouse dependency-lock fixes

A hosted candidate end-to-end run is intentionally pending until a complete candidate is synchronized into all three isolated stores.

## Release-note disposition

`ignore-for-release`

Closes #1425.