### PR TITLE
Clean up Tuva Core dbt variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
       - name: Test the portability linter
         run: python3 scripts/test_portability_lint.py
 
+      - name: Test the Core dbt var inventory
+        run: python3 tests/unit/test_dbt_var_inventory.py
+
       - name: Lint models for non-portable SQL
         run: python3 scripts/portability_lint.py
 
@@ -541,7 +544,7 @@ jobs:
       CI_DBT_SELECTOR: ${{ needs.resolve.outputs.selector }}
       TUVA_CI_SCHEMA_PREFIX: ${{ needs.resolve.outputs.schema_prefix }}
       CI_DBT_VARS: >-
-        {"use_synthetic_data": true, "synthetic_data_size": "small",
+        {"synthetic_data_size": "small",
         "parity_enabled": false, "data_quality_enabled": true,
         "enable_data_quality_failure_keys": true,
         "tuva_schema_prefix": "${{ needs.resolve.outputs.schema_prefix }}"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,12 @@ generate typed YAML or JSON before invoking dbt. In model configuration and
 SQL, use the existing `tuva_boolean_var` package macro rather than ad hoc
 coercion.
 
+Keep `integration_tests/dbt_project.yml` as the canonical commented inventory
+of every public, integration-only, warehouse-specific, and internal Core dbt
+variable. Keep standalone-package variables in their separate section. The
+CI-wired `tests/unit/test_dbt_var_inventory.py` contract must stay aligned with
+new, renamed, or removed Core variable lookups.
+
 CodeRx Open is the default medication terminology. When
 `use_coderx_enterprise: true`, every CodeRx consumer reads user-managed
 `packages`, `drugs`, and `classes` relations from the target database's
@@ -266,7 +272,6 @@ redefine an existing ID; append a new ID for a new calculation.
 - Keep `integration_tests/dbt_project.yml` on `profile: default` before
   pushing.
 - Use the integration defaults unless the task requires otherwise:
-  - `use_synthetic_data: true`
   - `synthetic_data_size: small`
   - `parity_enabled: false`
   - `data_quality_enabled: false`

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -46,11 +46,9 @@ and reads profiles from `~/.dbt` unless `DBT_PROFILES_DIR`,
 
 ## Synthetic Data
 
-Synthetic data is controlled through vars in `integration_tests/dbt_project.yml`.
-The defaults are:
-
-- `use_synthetic_data: true`
-- `synthetic_data_size: small`
+The integration project always maps the package's synthetic seeds into its
+Input Layer models. `synthetic_data_size` controls which published payload is
+loaded and defaults to `small`.
 
 Use the large synthetic data release for heavier validation:
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -5,19 +5,30 @@ config-version: 2
 profile: default
 
 vars:
+  # This is the canonical commented inventory for Tuva Core variables. Keep
+  # every public, integration-only, warehouse-specific, and internal test var
+  # documented here when its lookup is added or changed.
+  # Every Core boolean below must be a native, unquoted YAML boolean.
+
+  ## Tuva Core variables
+
   ## Domain enablement
   # These vars default to false in Tuva Core when omitted.
   # Integration tests set them true so local and CI builds exercise the full Tuva Core path.
   claims_enabled: true                 # Enables payer/claims input layer, normalization, claims preprocessing, and claims-derived core tables.
   clinical_enabled: true               # Enables provider/clinical input layer, normalization, and clinical-derived core tables.
   provider_attribution_enabled: true   # Enables provider attribution input and claims preprocessing attribution. Requires claims_enabled.
-  parity_enabled: false                # Keeps optional parity metric models out of normal development and CI builds.
+
+  ## Parity
+  # Enables maintainer release-comparison metrics when claims are also enabled.
+  parity_enabled: false                # Normal development and CI default.
 
   ## Data quality
   # Enables Structural Data Quality and Logical Data Quality models.
   # Production projects can leave this false/omitted unless they want to build these queryable result tables.
   data_quality_enabled: false           # Keeps optional data-quality result models out of this compatibility run.
-  enable_data_quality_failure_keys: false  # Adds the optional key-only logical failure drilldown table.
+  # Requires data_quality_enabled and at least one of claims_enabled or clinical_enabled.
+  enable_data_quality_failure_keys: false  # Adds the optional key-only Logical failure drilldown table.
 
   ## Medication terminology
   # False uses the package's CodeRx Open assets. True requires user-managed
@@ -25,16 +36,54 @@ vars:
   use_coderx_enterprise: false
 
   ## Synthetic data validation
-  # These vars are for this integration_tests project. They are not normal production Tuva Core settings.
-  use_synthetic_data: true             # Maps package synthetic seeds into this project's Input Layer models.
-  synthetic_data_size: small           # Synthetic payload to load: small or large.
+  # This integration project always maps package synthetic seeds into its Input Layer models.
+  # The var is not needed in production projects that map their own source data.
+  synthetic_data_size: small           # Selects the small or large payload; Core's loader fallback is large.
 
   ## Data asset releases and buckets
   # Tuva Core resolves assets from tuva-core/<installed-package-version>/.
   custom_bucket_name: tuva-public-resources  # Default public bucket for package data assets.
-  tuva_seed_buckets: {}                # Optional per-family bucket overrides, keyed by seed family.
+  # Resolution precedence is Core asset family, package slug, then custom_bucket_name.
+  tuva_seed_buckets: {}                # Optional bucket overrides keyed by Core asset family or package slug.
 
-  ## Standalone package behavior
+  ## Schema naming
+  # Optional prefix for output schemas, e.g. dev_aaron_core, dev_aaron_input_layer.
+  # tuva_schema_prefix: dev_aaron
+
+  ## Run metadata
+  # Root package default is the dbt run_started_at timestamp in UTC.
+  # Uncomment to force a fixed value in the tuva_last_run column.
+  # tuva_last_run: "2026-01-01 00:00:00"
+
+  ## Extension columns
+  # Allows prefixed custom columns to flow from a supported Input Layer model
+  # to the same-named Core table. Derived outputs such as member_month are excluded.
+  # passthrough:
+  #   prefix: 'x_'                     # Prefix used to identify extension columns.
+  #   strip: false                     # Whether to strip the prefix in final output aliases.
+
+  ## Provider attribution
+  # Optional current-panel as-of date override for provider ranking and current assignments.
+  # When omitted, each source uses its latest claim end date capped at the current date.
+  # provider_attribution_as_of_date: "2026-01-01"
+
+  ## Warehouse-specific seed loading
+  # Microsoft Fabric public storage endpoint used by seed loading macros.
+  # tuva_seed_fabric_storage_root: "https://tuvapublicresources.blob.core.windows.net"
+
+  ## Internal test hooks
+  # Local filesystem root for validating staged package data assets with DuckDB.
+  # The root must contain <bucket>/<package>/<version>/...; omit in normal projects.
+  # tuva_seed_duckdb_storage_root: "/tmp/tuva-data-assets"
+  # Internal dbt unit-test hook for extension-column tests; do not set in normal projects.
+  # _extension_columns_override: []
+  # Internal dbt unit-test hook for the shared columns used by smart_union.
+  # _smart_union_columns_override: []
+  # Internal dbt unit-test hook for the medical-claim procedure positions to expand.
+  # The normal default is every position from 1 through 25.
+  # _medical_claim_procedure_cols_override: [1]
+
+  ## Standalone package variables
   # Importing a standalone package enables it. These vars change package behavior;
   # none is a package-level on/off switch or an external-asset version pin.
   ccsr:
@@ -70,41 +119,6 @@ vars:
 
   quality_measures:
     quality_measures_period_end: "2018-12-31"  # Matches the shipped small synthetic dataset.
-
-  ## Schema naming
-  # Optional prefix for output schemas, e.g. dev_aaron_core, dev_aaron_input_layer.
-  # tuva_schema_prefix: dev_aaron
-
-  ## Run metadata
-  # Root package default is the dbt run_started_at timestamp in UTC.
-  # Uncomment to force a fixed value in the tuva_last_run column.
-  # tuva_last_run: "2026-01-01 00:00:00"
-
-  ## Extension columns
-  # Allows prefixed custom columns to flow from a supported Input Layer model
-  # to the same-named Core table. Derived outputs such as member_month are excluded.
-  # passthrough:
-  #   prefix: 'x_'                     # Prefix used to identify extension columns.
-  #   strip: false                     # Whether to strip the prefix in final output aliases.
-
-  ## Provider attribution
-  # Optional current-panel as-of date override for assigned_beneficiaries_current.
-  # provider_attribution_as_of_date: "2026-01-01"
-
-  ## Warehouse-specific seed loading
-  # Microsoft Fabric public storage endpoint used by seed loading macros.
-  # tuva_seed_fabric_storage_root: "https://tuvapublicresources.blob.core.windows.net"
-  # Warehouse-specific S3 bucket override used by seed loading macros.
-  # tuva_seeds_s3_bucket: tuva-public-resources
-  # Optional prefix under the selected S3 bucket.
-  # tuva_seeds_s3_key_prefix: ""
-
-  ## Internal test hooks
-  # Local filesystem root for validating staged package data assets with DuckDB.
-  # The root must contain <bucket>/<package>/<version>/...; omit in normal projects.
-  # tuva_seed_duckdb_storage_root: "/tmp/tuva-data-assets"
-  # Internal dbt unit-test hook for extension-column tests; do not set in normal projects.
-  # _extension_columns_override: []
 
 
 model-paths: ["models"]

--- a/macros/cross_database_utils/load_seed.sql
+++ b/macros/cross_database_utils/load_seed.sql
@@ -384,52 +384,6 @@ COPY_OPTIONS (
 {% endif %}
 {% endmacro %}
 
-
-
-{% macro postgres__load_seed(uri,pattern,compression,headers,null_marker) %}
-{% do the_tuva_project.reset_seed_relation() %}
-{%- set columns = adapter.get_columns_in_relation(this) -%}
-{%- set collist = [] -%}
-{%- for col in columns -%}
-  {%- do collist.append(col.name) -%}
-{%- endfor -%}
-{%- set cols = collist|join(",") -%}
-
-{%- set s3_bucket = var("tuva_seeds_s3_bucket", uri.split("/")[0]) -%}
-{%- set s3_key = uri.split("/")[1:]|join("/") + "/" + pattern -%}
-{%- if var("tuva_seeds_s3_key_prefix", "") != "" -%}
-{%- set s3_key = var("tuva_seeds_s3_key_prefix") + "/" + s3_key -%}
-{%- endif -%}
-{%- set s3_region = "us-east-1" -%}
-{%- set options = ["(", "format csv", ", encoding ''utf8''"] -%}
-{%- do options.append(", header true") if headers == true -%}
-{# PostgreSQL COPY CSV already treats an unquoted empty field as NULL. #}
-{%- do options.append(")") -%}
-{%- set options_s = options | join("") -%}
-
-{% set sql %}
-SELECT aws_s3.table_import_from_s3(
-   '{{ this }}',
-   '{{ cols }}',
-   '{{ options_s }}',
-   aws_commons.create_s3_uri('{{s3_bucket}}', '{{s3_key}}', '{{s3_region}}')
-)
-{% endset %}
-
-{% call statement('postgressql',fetch_result=true) %}
-{{ sql }}
-{% endcall %}
-
-{% if execute %}
-{# debugging { log(sql, True)} #}
-{% set results = load_result('postgressql') %}
-{{ log("Loaded data from external s3 resource\n  loaded to: " ~ this ~ "\n  from: s3://" ~ s3_bucket ~ "/" ~ s3_key ,True) }}
-{# debugging { log(results, True) } #}
-{% endif %}
-
-{% endmacro %}
-
-
 {% macro fabric__load_seed(uri, pattern, compression, headers, null_marker) %}
 {% do the_tuva_project.reset_seed_relation() %}
 {% set fabric_storage_root = var('tuva_seed_fabric_storage_root', 'https://tuvapublicresources.blob.core.windows.net') | trim('/') %}

--- a/tests/data_assets/test_package_seed_paths.sql
+++ b/tests/data_assets/test_package_seed_paths.sql
@@ -1,8 +1,76 @@
 {% set synthetic_size = the_tuva_project.get_synthetic_data_size() %}
 {% set package_version = the_tuva_project.get_tuva_package_version() %}
-{% set expected_terminology_bucket = var('expected_terminology_bucket', 'tuva-public-resources') %}
-{% set expected_core_bucket = var('expected_core_bucket', 'tuva-public-resources') %}
-{% set expected_package_bucket = var('expected_package_bucket', 'tuva-public-resources') %}
+{# Resolve expected buckets independently from the macros exercised below. #}
+{% set configured_buckets = var('tuva_seed_buckets', {}) %}
+{% if configured_buckets is not mapping %}
+  {% set configured_buckets = {} %}
+{% endif %}
+{% set default_bucket = var('custom_bucket_name', 'tuva-public-resources') %}
+
+{% set terminology_bucket = configured_buckets.get('terminology') %}
+{% if terminology_bucket is none %}
+  {% set terminology_bucket = configured_buckets.get('tuva-core') %}
+{% endif %}
+{% if terminology_bucket is none %}
+  {% set terminology_bucket = configured_buckets.get('tuva_core') %}
+{% endif %}
+{% if terminology_bucket is none %}
+  {% set terminology_bucket = default_bucket %}
+{% endif %}
+
+{% set provider_data_bucket = configured_buckets.get('provider_data') %}
+{% if provider_data_bucket is none %}
+  {% set provider_data_bucket = configured_buckets.get('tuva-core') %}
+{% endif %}
+{% if provider_data_bucket is none %}
+  {% set provider_data_bucket = configured_buckets.get('tuva_core') %}
+{% endif %}
+{% if provider_data_bucket is none %}
+  {% set provider_data_bucket = default_bucket %}
+{% endif %}
+
+{% set value_sets_bucket = configured_buckets.get('value_sets') %}
+{% if value_sets_bucket is none %}
+  {% set value_sets_bucket = configured_buckets.get('tuva-core') %}
+{% endif %}
+{% if value_sets_bucket is none %}
+  {% set value_sets_bucket = configured_buckets.get('tuva_core') %}
+{% endif %}
+{% if value_sets_bucket is none %}
+  {% set value_sets_bucket = default_bucket %}
+{% endif %}
+
+{% set package_bucket = configured_buckets.get('cms-hcc') %}
+{% if package_bucket is none %}
+  {% set package_bucket = configured_buckets.get('cms_hcc') %}
+{% endif %}
+{% if package_bucket is none %}
+  {% set package_bucket = default_bucket %}
+{% endif %}
+
+{% set terminology_bucket = terminology_bucket | string | trim %}
+{% if terminology_bucket.startswith('s3://') %}
+  {% set terminology_bucket = terminology_bucket[5:] %}
+{% endif %}
+{% set terminology_bucket = terminology_bucket | trim('/') %}
+
+{% set provider_data_bucket = provider_data_bucket | string | trim %}
+{% if provider_data_bucket.startswith('s3://') %}
+  {% set provider_data_bucket = provider_data_bucket[5:] %}
+{% endif %}
+{% set provider_data_bucket = provider_data_bucket | trim('/') %}
+
+{% set value_sets_bucket = value_sets_bucket | string | trim %}
+{% if value_sets_bucket.startswith('s3://') %}
+  {% set value_sets_bucket = value_sets_bucket[5:] %}
+{% endif %}
+{% set value_sets_bucket = value_sets_bucket | trim('/') %}
+
+{% set package_bucket = package_bucket | string | trim %}
+{% if package_bucket.startswith('s3://') %}
+  {% set package_bucket = package_bucket[5:] %}
+{% endif %}
+{% set package_bucket = package_bucket | trim('/') %}
 
 with resolved_paths as (
   select
@@ -16,9 +84,9 @@ with resolved_paths as (
 
 select *
 from resolved_paths
-where terminology_uri <> '{{ expected_terminology_bucket }}/tuva-core/{{ package_version }}/terminology'
-  or provider_data_uri <> '{{ expected_core_bucket }}/tuva-core/{{ package_version }}/provider-data'
-  or value_sets_uri <> '{{ expected_core_bucket }}/tuva-core/{{ package_version }}/value-sets'
+where terminology_uri <> '{{ terminology_bucket }}/tuva-core/{{ package_version }}/terminology'
+  or provider_data_uri <> '{{ provider_data_bucket }}/tuva-core/{{ package_version }}/provider-data'
+  or value_sets_uri <> '{{ value_sets_bucket }}/tuva-core/{{ package_version }}/value-sets'
   or synthetic_object_path <> 'synthetic-data/{{ synthetic_size }}/synthetic_data__appointment.csv.gz'
   or generic_package_uri <> 'custom-assets/cms-hcc/1.0.0/cms_hcc__sample.csv.gz'
-  or overridden_package_uri <> '{{ expected_package_bucket }}/cms-hcc/1.0.0/cms_hcc__sample.csv.gz'
+  or overridden_package_uri <> '{{ package_bucket }}/cms-hcc/1.0.0/cms_hcc__sample.csv.gz'

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -187,6 +187,9 @@ class DataAssetContractTest(unittest.TestCase):
         load_macro = (
             ROOT / "macros" / "cross_database_utils" / "load_seed.sql"
         ).read_text()
+        path_test = (
+            ROOT / "tests" / "data_assets" / "test_package_seed_paths.sql"
+        ).read_text()
 
         self.assertIn("macro get_tuva_package_version()", version_macro)
         self.assertNotIn("get_installed_" + "package_version", version_macro)
@@ -214,6 +217,9 @@ class DataAssetContractTest(unittest.TestCase):
         )
         self.assertIn("var('custom_bucket_name', 'tuva-public-resources')", path_macro)
         self.assertIn("var('tuva_seed_buckets', {})", path_macro)
+        self.assertNotIn("the_tuva_project.get_seed_bucket", path_test)
+        self.assertIn("var('custom_bucket_name', 'tuva-public-resources')", path_test)
+        self.assertIn("var('tuva_seed_buckets', {})", path_test)
 
         self.assertIn("iam_role default", load_macro.lower())
         self.assertIn(
@@ -244,11 +250,7 @@ class DataAssetContractTest(unittest.TestCase):
         self.assertIn("set null_char = ''", load_macro)
         self.assertIn("'escapeChar' = '\\0'", load_macro)
         self.assertIn("'nullValue' = ''", load_macro)
-        self.assertIn('options.append(", header true") if headers == true', load_macro)
-        self.assertIn(
-            "PostgreSQL COPY CSV already treats an unquoted empty field as NULL",
-            load_macro,
-        )
+        self.assertNotIn("macro postgres__load_seed", load_macro)
         self.assertNotIn("null ''\\\\N''", load_macro)
 
         readme = (ROOT / "README.md").read_text()

--- a/tests/unit/test_dbt_var_inventory.py
+++ b/tests/unit/test_dbt_var_inventory.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ROOT_PROJECT_FILE = ROOT / "dbt_project.yml"
+PROJECT_FILE = ROOT / "integration_tests" / "dbt_project.yml"
+SOURCE_SUFFIXES = {".sql", ".yml", ".yaml"}
+TEXT_SUFFIXES = SOURCE_SUFFIXES | {".md"}
+EXCLUDED_PARTS = {".git", "dbt_packages", "logs", "target"}
+
+
+def repository_files(suffixes):
+    for path in ROOT.rglob("*"):
+        if not path.is_file() or path.suffix not in suffixes:
+            continue
+        if EXCLUDED_PARTS.intersection(path.relative_to(ROOT).parts):
+            continue
+        yield path
+
+
+def executable_var_names():
+    names = set()
+    literal_var = re.compile(
+        r"(?<![A-Za-z0-9_])var\(\s*['\"]([^'\"]+)['\"]"
+    )
+    boolean_var = re.compile(
+        r"tuva_boolean_var\(\s*['\"]([^'\"]+)['\"]"
+    )
+
+    for path in repository_files(SOURCE_SUFFIXES):
+        text = path.read_text()
+        names.update(literal_var.findall(text))
+        names.update(boolean_var.findall(text))
+    return names
+
+
+def documented_core_var_names():
+    project_text = PROJECT_FILE.read_text()
+    start_marker = "  ## Tuva Core variables\n"
+    end_marker = "  ## Standalone package variables\n"
+    if start_marker not in project_text or end_marker not in project_text:
+        raise AssertionError("Tuva Core variable inventory markers are missing")
+
+    core_block = project_text.split(start_marker, 1)[1].split(end_marker, 1)[0]
+    return set(
+        re.findall(
+            r"^  (?:# )?([A-Za-z_][A-Za-z0-9_]*):",
+            core_block,
+            re.MULTILINE,
+        )
+    )
+
+
+def declared_root_var_names():
+    project_text = ROOT_PROJECT_FILE.read_text()
+    vars_block = project_text.split("\nvars:\n", 1)[1].split("\nmodel-paths:", 1)[0]
+    return set(
+        re.findall(
+            r"^  ([A-Za-z_][A-Za-z0-9_]*):",
+            vars_block,
+            re.MULTILINE,
+        )
+    )
+
+
+class DbtVarInventoryTest(unittest.TestCase):
+    def test_every_executable_core_var_is_documented(self):
+        self.assertEqual(documented_core_var_names(), executable_var_names())
+
+    def test_every_root_declaration_has_an_executable_lookup(self):
+        self.assertLessEqual(declared_root_var_names(), executable_var_names())
+
+    def test_removed_vars_stay_absent(self):
+        removed_vars = (
+            "use_" + "synthetic_data",
+            "expected_" + "terminology_bucket",
+            "expected_" + "core_bucket",
+            "expected_" + "package_bucket",
+            "tuva_seeds_s3_" + "bucket",
+            "tuva_seeds_s3_" + "key_prefix",
+        )
+        this_file = Path(__file__).resolve()
+
+        for path in repository_files(TEXT_SUFFIXES):
+            if path.resolve() == this_file:
+                continue
+            text = path.read_text()
+            for var_name in removed_vars:
+                self.assertNotIn(var_name, text, str(path.relative_to(ROOT)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Remove the no-op use_synthetic_data variable and three test-only expected bucket variables.
- Remove the unsupported PostgreSQL seed loader and its two S3 configuration variables.
- Make integration_tests/dbt_project.yml the canonical commented Tuva Core variable inventory.
- Add a CI-wired inventory contract and retain independent coverage of seed bucket precedence and normalization.

## Validation

- Full local Snowflake build: PASS=487, WARN=0, ERROR=0, SKIP=0
- Snowflake test_package_seed_paths: passed with defaults, family/package overrides, and underscore-key fallbacks
- DuckDB synthetic_data__appointment seed smoke: 4,418 rows loaded
- dbt parse --no-partial-parse
- Data asset contract: 9 passed
- Core dbt var inventory: 3 passed
- Portability tests: 59 passed
- Portability lint, actionlint, and git diff --check passed

## Release-note disposition

ignore-for-release