### PR TITLE
Harden extension column handling

### DIFF
--- a/macros/core/select_extension_columns.sql
+++ b/macros/core/select_extension_columns.sql
@@ -2,10 +2,10 @@
 {#
     Returns the validated extension-column configuration.
 
-    `passthrough` must be a mapping, `prefix` must be a non-empty string, and
-    `strip` must be a real boolean. Macro arguments override the corresponding
-    configured value, but do not make an otherwise invalid project
-    configuration valid.
+    `passthrough` must be a mapping containing only `prefix` and `strip`,
+    `prefix` must be a non-empty string, and `strip` must be a real boolean.
+    Macro arguments override the corresponding configured value, but do not
+    make an otherwise invalid project configuration valid.
 #}
     {%- set passthrough_config = var('passthrough', {}) -%}
 
@@ -15,6 +15,16 @@
             ~ "`prefix` and `strip` keys."
         ) -%}
     {%- endif -%}
+
+    {%- set allowed_passthrough_keys = ['prefix', 'strip'] -%}
+    {%- for config_key in passthrough_config.keys() -%}
+        {%- if config_key not in allowed_passthrough_keys -%}
+            {%- do exceptions.raise_compiler_error(
+                "Invalid `passthrough` configuration: unsupported key `" ~ config_key
+                ~ "`. Allowed keys are `prefix` and `strip`."
+            ) -%}
+        {%- endif -%}
+    {%- endfor -%}
 
     {%- set configured_prefix = passthrough_config.get('prefix', 'x_') -%}
     {%- if configured_prefix is not string or configured_prefix | trim | length == 0 -%}
@@ -121,53 +131,20 @@
 {% endmacro %}
 
 
-{% macro select_extension_columns(relation, alias=none, prefix=none, strip_prefix=none) %}
+{% macro _get_extension_source_columns(relation, effective_prefix) %}
 {#
-    Selects extension columns from a relation.
+    Discovers extension-column names and data types once for downstream renderers.
 
-    Extension columns are identified case-insensitively by a prefix (default:
-    `x_`). The macro reads column metadata from the relation and emits the
-    matching columns. The prefix can optionally be stripped in the output.
-
-    Arguments:
-        relation: The relation to inspect.
-        alias: Optional SQL table alias used to qualify column references.
-        prefix: Optional explicit prefix; defaults to `passthrough.prefix`.
-        strip_prefix: Optional boolean; defaults to `passthrough.strip`.
-
-    Configuration in dbt_project.yml:
-        vars:
-          passthrough:
-            prefix: 'x_'
-            strip: false
-
-    Unit-test override:
-        dbt unit-test refs compile to ephemeral CTEs that cannot be introspected
-        reliably. `_extension_columns_override` supplies the source column names
-        for those tests. Include fixed columns too when testing collision errors.
+    The unit-test override supplies names without data types because dbt unit-test
+    refs compile to ephemeral CTEs that cannot be introspected reliably.
 #}
-    {%- set passthrough = get_extension_passthrough_config(prefix, strip_prefix) -%}
-    {%- set effective_prefix = passthrough['prefix'] -%}
-    {%- set effective_strip_prefix = passthrough['strip'] -%}
-
-    {%- if alias is not none
-        and (alias is not string or alias | trim | length == 0) -%}
-        {%- do exceptions.raise_compiler_error(
-            "Invalid `alias` argument to `select_extension_columns`: expected a "
-            ~ "non-empty string or `none`."
-        ) -%}
-    {%- endif -%}
-
     {%- if not execute -%}
-        {{ return('') }}
+        {{ return({'columns': [], 'using_override': false}) }}
     {%- endif -%}
 
-    {%- set alias_prefix = alias ~ '.' if alias else '' -%}
     {%- set prefix_lower = effective_prefix | lower -%}
-    {%- set extension_columns = [] -%}
-    {%- set source_column_names = [] -%}
+    {%- set source_columns = [] -%}
     {%- set using_override = false -%}
-
     {%- set declared_fixed_columns = _extension_declared_fixed_columns(relation) -%}
 
     {#- A prefix must never classify a declared fixed model column as an extension. -#}
@@ -201,20 +178,24 @@
                     ~ "non-empty column-name string."
                 ) -%}
             {%- endif -%}
-            {%- do source_column_names.append(column_name) -%}
+            {%- do source_columns.append({
+                'name': column_name,
+                'data_type': none
+            }) -%}
         {%- endfor -%}
     {%- else -%}
         {%- for column in adapter.get_columns_in_relation(relation) -%}
-            {%- do source_column_names.append(column.name) -%}
+            {%- do source_columns.append({
+                'name': column.name,
+                'data_type': column.data_type
+            }) -%}
         {%- endfor -%}
     {%- endif -%}
 
-    {%- if source_column_names | length == 0 -%}
-        {{ return('') }}
-    {%- endif -%}
-
+    {%- set extension_columns = [] -%}
     {%- set source_names_by_lower = {} -%}
-    {%- for column_name in source_column_names -%}
+    {%- for source_column in source_columns -%}
+        {%- set column_name = source_column['name'] -%}
         {%- set column_name_lower = column_name | lower -%}
         {%- if column_name_lower.startswith(prefix_lower) -%}
             {%- if column_name_lower in source_names_by_lower -%}
@@ -226,8 +207,70 @@
                 ) -%}
             {%- endif -%}
             {%- do source_names_by_lower.update({column_name_lower: column_name}) -%}
+            {%- do extension_columns.append(source_column) -%}
         {%- endif -%}
     {%- endfor -%}
+
+    {{ return({
+        'columns': extension_columns,
+        'using_override': using_override
+    }) }}
+{% endmacro %}
+
+
+{% macro select_extension_columns(relation, alias=none, prefix=none, strip_prefix=none, _extension_source=none) %}
+{#
+    Selects extension columns from a relation.
+
+    Extension columns are identified case-insensitively by a prefix (default:
+    `x_`). The macro reads column metadata from the relation and emits the
+    matching columns. The prefix can optionally be stripped in the output.
+
+    Arguments:
+        relation: The physical relation whose column metadata is inspected.
+        alias: Optional SQL table alias used to qualify column references. It
+            may name a schema-preserving ephemeral CTE sourced from `relation`.
+        prefix: Optional explicit prefix; defaults to `passthrough.prefix`.
+        strip_prefix: Optional boolean; defaults to `passthrough.strip`.
+
+    Configuration in dbt_project.yml:
+        vars:
+          passthrough:
+            prefix: 'x_'
+            strip: false
+
+    Unit-test override:
+        dbt unit-test refs compile to ephemeral CTEs that cannot be introspected
+        reliably. `_extension_columns_override` supplies the source column names
+        for those tests. Include fixed columns too when testing collision errors.
+#}
+    {%- set passthrough = get_extension_passthrough_config(prefix, strip_prefix) -%}
+    {%- set effective_prefix = passthrough['prefix'] -%}
+    {%- set effective_strip_prefix = passthrough['strip'] -%}
+
+    {%- if alias is not none
+        and (alias is not string or alias | trim | length == 0) -%}
+        {%- do exceptions.raise_compiler_error(
+            "Invalid `alias` argument to `select_extension_columns`: expected a "
+            ~ "non-empty string or `none`."
+        ) -%}
+    {%- endif -%}
+
+    {%- if not execute -%}
+        {{ return('') }}
+    {%- endif -%}
+
+    {%- set alias_prefix = alias ~ '.' if alias else '' -%}
+    {%- set extension_columns = [] -%}
+    {%- set extension_source = _extension_source
+        if _extension_source is not none
+        else _get_extension_source_columns(relation, effective_prefix) -%}
+    {%- set source_extension_columns = extension_source['columns'] -%}
+    {%- set using_override = extension_source['using_override'] -%}
+
+    {%- if source_extension_columns | length == 0 -%}
+        {{ return('') }}
+    {%- endif -%}
 
     {#- Only columns declared by the current output model reserve final names.
         A non-extension column on the inspected source relation may be omitted
@@ -248,56 +291,54 @@
     {%- endif -%}
 
     {%- set extension_output_names = {} -%}
-    {%- for column_name in source_column_names -%}
-        {%- set column_name_lower = column_name | lower -%}
-        {%- if column_name_lower.startswith(prefix_lower) -%}
-            {%- if effective_strip_prefix -%}
-                {%- set output_name = column_name[effective_prefix | length:] -%}
-            {%- else -%}
-                {%- set output_name = column_name -%}
-            {%- endif -%}
+    {%- for source_column in source_extension_columns -%}
+        {%- set column_name = source_column['name'] -%}
+        {%- if effective_strip_prefix -%}
+            {%- set output_name = column_name[effective_prefix | length:] -%}
+        {%- else -%}
+            {%- set output_name = column_name -%}
+        {%- endif -%}
 
-            {%- if output_name | length == 0 -%}
-                {%- do exceptions.raise_compiler_error(
-                    "Extension column `" ~ column_name ~ "` on relation `" ~ relation
-                    ~ "` becomes an empty output name when prefix `" ~ effective_prefix
-                    ~ "` is stripped. Rename the extension column or disable stripping."
-                ) -%}
-            {%- endif -%}
+        {%- if output_name | length == 0 -%}
+            {%- do exceptions.raise_compiler_error(
+                "Extension column `" ~ column_name ~ "` on relation `" ~ relation
+                ~ "` becomes an empty output name when prefix `" ~ effective_prefix
+                ~ "` is stripped. Rename the extension column or disable stripping."
+            ) -%}
+        {%- endif -%}
 
-            {%- set output_name_lower = output_name | lower -%}
-            {%- if output_name_lower in fixed_output_names -%}
-                {%- set collision = fixed_output_names[output_name_lower] -%}
-                {%- do exceptions.raise_compiler_error(
-                    "Extension column `" ~ column_name ~ "` on relation `" ~ relation
-                    ~ "` resolves to output column `" ~ output_name ~ "`, which "
-                    ~ "collides case-insensitively with fixed column `"
-                    ~ collision['name'] ~ "` in " ~ collision['location'] ~ ". Rename "
-                    ~ "the extension column, choose another prefix, or disable stripping."
-                ) -%}
-            {%- endif -%}
+        {%- set output_name_lower = output_name | lower -%}
+        {%- if output_name_lower in fixed_output_names -%}
+            {%- set collision = fixed_output_names[output_name_lower] -%}
+            {%- do exceptions.raise_compiler_error(
+                "Extension column `" ~ column_name ~ "` on relation `" ~ relation
+                ~ "` resolves to output column `" ~ output_name ~ "`, which "
+                ~ "collides case-insensitively with fixed column `"
+                ~ collision['name'] ~ "` in " ~ collision['location'] ~ ". Rename "
+                ~ "the extension column, choose another prefix, or disable stripping."
+            ) -%}
+        {%- endif -%}
 
-            {%- if output_name_lower in extension_output_names -%}
-                {%- do exceptions.raise_compiler_error(
-                    "Extension columns `" ~ extension_output_names[output_name_lower]
-                    ~ "` and `" ~ column_name ~ "` on relation `" ~ relation
-                    ~ "` both resolve case-insensitively to output column `" ~ output_name
-                    ~ "`. Extension output names must be unique case-insensitively."
-                ) -%}
-            {%- endif -%}
-            {%- do extension_output_names.update({output_name_lower: column_name}) -%}
+        {%- if output_name_lower in extension_output_names -%}
+            {%- do exceptions.raise_compiler_error(
+                "Extension columns `" ~ extension_output_names[output_name_lower]
+                ~ "` and `" ~ column_name ~ "` on relation `" ~ relation
+                ~ "` both resolve case-insensitively to output column `" ~ output_name
+                ~ "`. Extension output names must be unique case-insensitively."
+            ) -%}
+        {%- endif -%}
+        {%- do extension_output_names.update({output_name_lower: column_name}) -%}
 
-            {#- Overrides are an internal unit-test hook and do not carry the
-                adapter-normalized identifier casing returned by introspection. -#}
-            {%- set source_identifier = column_name if using_override else adapter.quote(column_name) -%}
-            {%- set source_expression = alias_prefix ~ source_identifier -%}
-            {%- if effective_strip_prefix -%}
-                {%- do extension_columns.append(
-                    source_expression ~ ' as ' ~ adapter.quote(output_name)
-                ) -%}
-            {%- else -%}
-                {%- do extension_columns.append(source_expression) -%}
-            {%- endif -%}
+        {#- Overrides are an internal unit-test hook and do not carry the
+            adapter-normalized identifier casing returned by introspection. -#}
+        {%- set source_identifier = column_name if using_override else adapter.quote(column_name) -%}
+        {%- set source_expression = alias_prefix ~ source_identifier -%}
+        {%- if effective_strip_prefix -%}
+            {%- do extension_columns.append(
+                source_expression ~ ' as ' ~ adapter.quote(output_name)
+            ) -%}
+        {%- else -%}
+            {%- do extension_columns.append(source_expression) -%}
         {%- endif -%}
     {%- endfor -%}
 

--- a/macros/core/select_null_extension_columns.sql
+++ b/macros/core/select_null_extension_columns.sql
@@ -1,0 +1,42 @@
+{% macro select_null_extension_columns(
+    relation,
+    prefix=none,
+    type_source_alias=none,
+    _extension_source=none
+) %}
+{#
+    Emits typed null expressions for every extension column on a relation.
+
+    This is used when a derived source participates in a union with a direct
+    source that owns extension columns. The derived rows keep the same schema
+    without receiving values that cannot be traced to that source.
+#}
+    {%- set passthrough = get_extension_passthrough_config(prefix, false) -%}
+    {%- set effective_prefix = passthrough['prefix'] -%}
+
+    {%- if not execute -%}
+        {{ return('') }}
+    {%- endif -%}
+
+    {%- set extension_source = _extension_source
+        if _extension_source is not none
+        else _get_extension_source_columns(relation, effective_prefix) -%}
+
+    {%- for column in extension_source['columns'] -%}
+        {%- if column['data_type'] is none -%}
+            {%- if type_source_alias is not string or type_source_alias | trim | length == 0 -%}
+                {%- do exceptions.raise_compiler_error(
+                    "`select_null_extension_columns` requires `type_source_alias` "
+                    ~ "when `_extension_columns_override` supplies extension columns."
+                ) -%}
+            {%- endif -%}
+    , (
+        select extension_type_source.{{ column['name'] }}
+        from {{ type_source_alias }} as extension_type_source
+        where 1 = 0
+      ) as {{ column['name'] }}
+        {%- else -%}
+    , cast(null as {{ column['data_type'] }}) as {{ adapter.quote(column['name']) }}
+        {%- endif -%}
+    {%- endfor -%}
+{% endmacro %}

--- a/macros/core/smart_union.sql
+++ b/macros/core/smart_union.sql
@@ -1,7 +1,7 @@
 {% macro smart_union(relations, source_index='_source') %}
 {#
     Unions relations with automatic alignment of columns.
-    Missing columns are filled with NULL. Extension columns (prefixed) are sorted last.
+    Missing columns are filled with NULL. Columns matching the configured extension prefix are sorted last.
 
     smart_union vs dbt_utils.union_relations:
     ┌─────────────────────┬─────────────────────────────────────┬─────────────────────────┐
@@ -9,7 +9,7 @@
     ├─────────────────────┼─────────────────────────────────────┼─────────────────────────┤
     │ Source tracking     │ Full path string                    │ Numeric index (1, 2...) │
     │ Filter syntax       │ WHERE _source LIKE '%table_name%'   │ WHERE _source = 1       │
-    │ Column ordering     │ Arbitrary                           │ Core first, ext_ last   │
+    │ Column ordering     │ Arbitrary                           │ Core first, prefix last │
     └─────────────────────┴─────────────────────────────────────┴─────────────────────────┘
 
     Arguments:

--- a/models/core/final/core__patient.sql
+++ b/models/core/final/core__patient.sql
@@ -58,53 +58,50 @@ cast(
 {% if the_tuva_project.tuva_boolean_var('clinical_enabled', false) == true
    and the_tuva_project.tuva_boolean_var('claims_enabled', false) == true -%}
 
-{%- if execute -%}
-    {%- set passthrough_config = get_extension_passthrough_config() -%}
-    {%- set passthrough_prefix = passthrough_config['prefix'] | lower -%}
-    {%- set clinical_extension_columns = [] -%}
-
-    {%- for col in adapter.get_columns_in_relation(ref('core__int_patient_remove_duplicates')) -%}
-        {%- if col.name.lower().startswith(passthrough_prefix) -%}
-            {%- do clinical_extension_columns.append({"name": col.name, "data_type": col.data_type}) -%}
-        {%- endif -%}
-    {%- endfor -%}
-{%- else -%}
-    {%- set clinical_extension_columns = [] -%}
-{%- endif -%}
+{%- set patient_passthrough = get_extension_passthrough_config() -%}
+{%- set patient_extension_source = _get_extension_source_columns(
+    ref('core__int_patient_remove_duplicates'),
+    patient_passthrough['prefix']
+) -%}
 
 {%- set claims_patient_extension_columns -%}
-    {%- for clinical_col in clinical_extension_columns %}
-        , cast(null as {{ clinical_col["data_type"] }}) as {{ adapter.quote(clinical_col["name"]) }}
-    {%- endfor -%}
+    {{ select_null_extension_columns(
+        ref('core__int_patient_remove_duplicates'),
+        type_source_alias='clinical_patient',
+        _extension_source=patient_extension_source
+    ) }}
 {%- endset -%}
 
 {%- set clinical_patient_extension_columns -%}
-    {%- for clinical_col in clinical_extension_columns %}
-        , clinical_patient.{{ adapter.quote(clinical_col["name"]) }}
-    {%- endfor -%}
+    {{ select_extension_columns(
+        ref('core__int_patient_remove_duplicates'),
+        alias='clinical_patient',
+        strip_prefix=false,
+        _extension_source=patient_extension_source
+    ) }}
 {%- endset -%}
 
 {%- set unioned_extension_columns -%}
-    {%- for clinical_col in clinical_extension_columns %}
-        , unioned.{{ adapter.quote(clinical_col["name"]) }}
-    {%- endfor -%}
+    {{ select_extension_columns(
+        ref('core__int_patient_remove_duplicates'),
+        alias='unioned',
+        strip_prefix=false,
+        _extension_source=patient_extension_source
+    ) }}
 {%- endset -%}
 
 {%- set final_extension_columns -%}
-    {{ select_extension_columns(ref('core__int_patient_remove_duplicates'), alias='patient_base') }}
+    {{ select_extension_columns(
+        ref('core__int_patient_remove_duplicates'),
+        alias='patient_base',
+        _extension_source=patient_extension_source
+    ) }}
 {%- endset -%}
 
 with claims_patient as (
     select
         *
     from {{ ref('normalized__eligibility_remove_duplicates') }}
-)
-
-, person_list_to_exclude_because_in_claims as (
-    select distinct
-          person_id
-        , data_source
-    from claims_patient
 )
 
 , clinical_patient as (
@@ -175,6 +172,15 @@ with claims_patient as (
     from clinical_patient
 )
 
+, prioritized_patients as (
+    select
+          unioned.*
+        , max(case when unioned._source = 1 then 1 else 0 end) over (
+              partition by unioned.person_id, unioned.data_source
+          ) as _has_claims_record
+    from unioned
+)
+
 , patient_base as (
     select
           unioned.person_id
@@ -203,44 +209,11 @@ with claims_patient as (
         , unioned.ingest_datetime
         , unioned.tuva_last_run
         , cast(substring(cast(unioned.tuva_last_run as {{ dbt.type_string() }}), 1, 10) as date) as tuva_last_run_date
-    from unioned
-    where _source = 1
-
-    union all
-
-    select
-          unioned.person_id
-        , unioned.name_suffix
-        , unioned.first_name
-        , unioned.middle_name
-        , unioned.last_name
-        , unioned.sex
-        , unioned.race
-        , unioned.birth_date
-        , unioned.death_date
-        , unioned.death_flag
-        , unioned.social_security_number
-        , unioned.address
-        , unioned.city
-        , unioned.state
-        , unioned.zip_code
-        , unioned.county
-        , unioned.latitude
-        , unioned.longitude
-        , unioned.phone
-        , unioned.email
-        , unioned.ethnicity
-        {{ unioned_extension_columns }}
-        , unioned.data_source
-        , unioned.ingest_datetime
-        , unioned.tuva_last_run
-        , cast(substring(cast(unioned.tuva_last_run as {{ dbt.type_string() }}), 1, 10) as date) as tuva_last_run_date
-    from unioned
-    left outer join person_list_to_exclude_because_in_claims as claims_people
-        on unioned.person_id = claims_people.person_id
-        and unioned.data_source = claims_people.data_source
-    where _source = 2
-      and claims_people.person_id is null
+    from prioritized_patients as unioned
+    where unioned._source = 1
+       or unioned.person_id is null
+       or unioned.data_source is null
+       or unioned._has_claims_record = 0
 )
 
 select

--- a/models/normalized_layer/final/normalized__medical_claim.sql
+++ b/models/normalized_layer/final/normalized__medical_claim.sql
@@ -84,6 +84,7 @@ select
     , cast(med.ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
     , cast(med.file_name as {{ dbt.type_string() }}) as file_name
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
+    {# The staging model is ephemeral and forwards this Input relation's extensions. #}
     {{ select_extension_columns(ref('input_layer__medical_claim'), alias='med', strip_prefix=false) }}
 from {{ ref('normalized_input__stg_medical_claim') }} as med
 left outer join {{ ref('normalized_input__int_admit_source_final') }} as ad_source

--- a/models/normalized_layer/final/normalized__pharmacy_claim.sql
+++ b/models/normalized_layer/final/normalized__pharmacy_claim.sql
@@ -53,6 +53,7 @@ select
     , cast(pharm.ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
     , cast(pharm.file_name as {{ dbt.type_string() }}) as file_name
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
+    {# The staging model is ephemeral and forwards this Input relation's extensions. #}
     {{ select_extension_columns(ref('input_layer__pharmacy_claim'), alias='pharm', strip_prefix=false) }}
 from {{ ref('normalized_input__stg_pharmacy_claim') }} as pharm
 left outer join {{ ref('provider_data__provider') }} as pres


### PR DESCRIPTION
## Summary

- reject unsupported `passthrough` keys instead of silently accepting typos
- share extension-column discovery between value selection and typed-null rendering
- simplify Core patient extension alignment and claims precedence without changing its `(person_id, data_source)` behavior or null-key semantics
- document the intentional physical Input Layer metadata source used with ephemeral medical/pharmacy staging aliases
- make `smart_union` documentation refer to the configured extension prefix

The medical/pharmacy metadata source remains the physical Input Layer wrapper: the intermediate staging models are ephemeral and therefore cannot be introspected as warehouse relations. A broad full-refresh build confirmed that attempting to introspect those CTEs drops their extensions; the final implementation keeps the correct physical source and makes the relationship explicit.

## Validation

- `scripts/dbt-local deps`
- `scripts/dbt-local parse --no-partial-parse`
- expected-failure parse with `passthrough.strp`: failed with the intended allowed-key compiler error
- `python3 -m unittest discover -s tests/unit -p 'test_*.py'` — 14 passed
- `python3 scripts/test_portability_lint.py` — 59 passed
- `python3 scripts/portability_lint.py` — passed
- focused Snowflake build of `normalized__medical_claim`, `normalized__pharmacy_claim`, and `core__patient` — passed
- DuckDB `scripts/dbt-local test --select test_type:unit` — 42/42 passed including the project hook
- Snowflake broad full-refresh build of Core and the integration project, excluding unchanged seeds — 488/488 passed

## Scope

Internal-helper alias collision hardening and a broader extension configuration matrix remain deliberately out of scope for this follow-up.

## Release note

Disposition: `bug`.

Closes #1432
