### PR TITLE
Make Core identities collision-safe and restore hospice attribution

### DIFF
--- a/macros/cross_database_utils/encounter_id_hash.sql
+++ b/macros/cross_database_utils/encounter_id_hash.sql
@@ -10,18 +10,14 @@
     Hashing the natural key instead makes the id a pure function of the row, so
     the same encounter keeps the same id no matter what else is in the data.
 
-    Fields are cast to string, null-marked and pipe-delimited before hashing so
-    that a null and an empty string cannot produce the same input, and neither
-    can ('a','bc') and ('ab','c').
+    Each field uses the shared stable-ID encoding before hashing. That encoding
+    distinguishes null, empty strings, literal sentinel values, escaped
+    characters, and component boundaries. Callers include the encounter type
+    as the first field so encounter domains remain distinct.
 #}
 
 {% macro encounter_id_input_string(fields) -%}
-    {%- set parts = [] -%}
-    {%- for field in fields -%}
-        {%- do parts.append("coalesce(cast(" ~ field ~ " as " ~ dbt.type_string() ~ "), '<NULL>')") -%}
-        {%- if not loop.last -%}{%- do parts.append("'|'") -%}{%- endif -%}
-    {%- endfor -%}
-    {{ the_tuva_project.concat_custom(parts) }}
+    {{ the_tuva_project.stable_id_input_string(fields) }}
 {%- endmacro %}
 
 
@@ -31,13 +27,13 @@
 
 
 {% macro default__encounter_id_hash(fields) -%}
-    md5({{ the_tuva_project.encounter_id_input_string(fields) }})
+    lower(md5({{ the_tuva_project.encounter_id_input_string(fields) }}))
 {%- endmacro %}
 
 
 {# BigQuery's md5() returns bytes. #}
 {% macro bigquery__encounter_id_hash(fields) -%}
-    to_hex(md5({{ the_tuva_project.encounter_id_input_string(fields) }}))
+    lower(to_hex(md5({{ the_tuva_project.encounter_id_input_string(fields) }})))
 {%- endmacro %}
 
 

--- a/models/claims_preprocessing/encounters/encounter_models.yml
+++ b/models/claims_preprocessing/encounters/encounter_models.yml
@@ -5300,9 +5300,12 @@ models:
 
   - name: encounters__patient_data_source_id
     description: |-
-      One row per person per data source. patient_data_source_id is the person
-      and the source concatenated rather than a rank, so it does not change when
-      other people are added to the data.
+      One row per person per data source. patient_data_source_id is a
+      deterministic 32-character lowercase hash of an unambiguous encoding of
+      the patient-data-source domain marker, person_id, and data_source. It
+      distinguishes null, empty strings, literal sentinel values, escaped
+      characters, and component boundaries and does not change when unrelated
+      people are added to the data.
     config:
       schema: |
         {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_claims_preprocessing
@@ -5311,3 +5314,25 @@ models:
       tags:
         - claims_preprocessing
         - encounters
+    columns:
+      - name: patient_data_source_id
+        description: >-
+          Deterministic patient-and-source identifier created with Tuva's
+          collision-safe stable-ID encoding.
+        tests:
+          - not_null
+          - unique
+        config:
+          meta:
+            data_type: varchar
+            is_primary_key: true
+      - name: person_id
+        description: Person identifier from the normalized claims inputs.
+        config:
+          meta:
+            data_type: varchar
+      - name: data_source
+        description: Source system in which the person record appears.
+        config:
+          meta:
+            data_type: varchar

--- a/models/claims_preprocessing/encounters/encounter_unit_tests.yml
+++ b/models/claims_preprocessing/encounters/encounter_unit_tests.yml
@@ -57,10 +57,12 @@ unit_tests:
           select 'hospice_prof_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 'hospice-encounter' as encounter_id, 1 as claim_attribution_number
       - input: ref('inpatient_substance_use__prof_claims')
         format: sql
-        rows: *empty_crosswalk_rows
+        rows: |
+          select 'hospice_prof_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 'substance-encounter' as encounter_id, 1 as claim_attribution_number
       - input: ref('office_visits__int_office_visits_claim_line')
         format: sql
-        rows: *empty_crosswalk_rows
+        rows: |
+          select 'hospice_prof_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 'office-encounter' as old_encounter_id, 'office visit radiology' as encounter_type
       - input: ref('urgent_care__match_claims_to_anchor')
         format: sql
         rows: *empty_crosswalk_rows
@@ -130,7 +132,17 @@ unit_tests:
           encounter_id: f1d4798551acd93ebdd672b219cc1aa4
           encounter_type: outpatient injections
           encounter_group: outpatient
-          priority_number: 18
+          priority_number: 17
+          anchor_claim_id: null
+          claim_line_attribution_number: 1
+        - claim_id: hospice_prof_claim
+          claim_line_number: 1
+          data_source: source-a
+          old_encounter_id: substance-encounter
+          encounter_id: 0584fcec3f1da8f2b829ca8c53e8d661
+          encounter_type: inpatient substance use
+          encounter_group: inpatient
+          priority_number: 6
           anchor_claim_id: null
           claim_line_attribution_number: 1
         - claim_id: hospice_prof_claim
@@ -142,7 +154,17 @@ unit_tests:
           encounter_group: inpatient
           priority_number: 7
           anchor_claim_id: null
-          claim_line_attribution_number: 1
+          claim_line_attribution_number: 2
+        - claim_id: hospice_prof_claim
+          claim_line_number: 1
+          data_source: source-a
+          old_encounter_id: office-encounter
+          encounter_id: d68e202bf46bc24eb2115642b57ccc06
+          encounter_type: office visit radiology
+          encounter_group: office based
+          priority_number: 7
+          anchor_claim_id: null
+          claim_line_attribution_number: 3
 
   - name: test_patient_data_source_id_uses_unambiguous_stable_encoding
     description: >-

--- a/models/claims_preprocessing/encounters/encounter_unit_tests.yml
+++ b/models/claims_preprocessing/encounters/encounter_unit_tests.yml
@@ -1,13 +1,16 @@
 version: 2
 
 unit_tests:
-  - name: test_combined_encounter_crosswalk_excludes_undetermined_candidates
+  - name: test_combined_encounter_crosswalk_handles_undetermined_and_hospice_candidates
     description: >
       Broad same-day matchers can produce an encounter candidate for an
       undetermined claim. The final combined crosswalk must exclude that
       candidate while preserving the same classified candidate, so the
-      undetermined line flows through the orphan fallback. Regression coverage
-      for https://github.com/tuva-health/tuva-core/issues/1388.
+      undetermined line flows through the orphan fallback. It must also consume
+      hospice professional-claim matches and place them below existing
+      inpatient priorities but above outpatient candidates. Regression
+      coverage for https://github.com/tuva-health/tuva-core/issues/1388 and
+      https://github.com/tuva-health/tuva-core/issues/1394.
     model: encounters__combined_claim_line_crosswalk
     config:
       enabled: "{{ var('claims_enabled', false) | as_bool }}"
@@ -48,6 +51,10 @@ unit_tests:
       - input: ref('inpatient_snf__prof_claims')
         format: sql
         rows: *empty_crosswalk_rows
+      - input: ref('inpatient_hospice__prof_claims')
+        format: sql
+        rows: |
+          select 'hospice_prof_claim' as claim_id, 1 as claim_line_number, 'source-a' as data_source, 'hospice-encounter' as encounter_id, 1 as claim_attribution_number
       - input: ref('inpatient_substance_use__prof_claims')
         format: sql
         rows: *empty_crosswalk_rows
@@ -120,12 +127,64 @@ unit_tests:
           claim_line_number: 1
           data_source: source-a
           old_encounter_id: anchor-1
-          encounter_id: 599f9d17ecf5bc86e964968be6fea2cf
+          encounter_id: f1d4798551acd93ebdd672b219cc1aa4
           encounter_type: outpatient injections
           encounter_group: outpatient
-          priority_number: 17
+          priority_number: 18
           anchor_claim_id: null
           claim_line_attribution_number: 1
+        - claim_id: hospice_prof_claim
+          claim_line_number: 1
+          data_source: source-a
+          old_encounter_id: hospice-encounter
+          encounter_id: 6823a3d0e472c12d95ed4248c6456eed
+          encounter_type: inpatient hospice
+          encounter_group: inpatient
+          priority_number: 7
+          anchor_claim_id: null
+          claim_line_attribution_number: 1
+
+  - name: test_patient_data_source_id_uses_unambiguous_stable_encoding
+    description: >-
+      Proves patient_data_source_id distinguishes pipe-delimited component
+      boundaries, null, empty strings, and the former literal null sentinel.
+      These cases collided under the pre-1.0 raw concatenation contract.
+    model: encounters__patient_data_source_id
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+    given:
+      - input: ref('normalized__medical_claim')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select 'a|b' as person_id, 'c' as data_source
+          union all select 'a', 'b|c'
+          union all select cast(null as {{ string_type }}), 'source'
+      - input: ref('normalized__eligibility')
+        format: sql
+        rows: |
+          select '<NULL>' as person_id, 'source' as data_source
+          union all select '', 'source'
+    expect:
+      rows:
+        - person_id: a|b
+          data_source: c
+          patient_data_source_id: 6df3a7e57fc92cfa0be719b5adf946f8
+        - person_id: a
+          data_source: b|c
+          patient_data_source_id: e5310aa4d517cbca0fc4c5b827430b0c
+        - person_id: null
+          data_source: source
+          patient_data_source_id: d52d0aaae616fbaf04b69c2e0a758efa
+        - person_id: <NULL>
+          data_source: source
+          patient_data_source_id: 6c73a9dd22de8d9d6318a28394f496b3
+        - person_id: ''
+          data_source: source
+          patient_data_source_id: ab07412b6175919ea556de5888d90102
 
   - name: test_undetermined_claim_lines_receive_source_scoped_orphan_encounters
     description: >
@@ -172,19 +231,19 @@ unit_tests:
         - claim_id: shared-undetermined
           claim_line_number: 1
           data_source: source-a
-          encounter_id: 02288fa2b6c8335e69225d63811d6187
+          encounter_id: 8064c56a071fed311a8a820b4c249ca1
           encounter_type: orphaned claim
           encounter_group: other
         - claim_id: shared-undetermined
           claim_line_number: 2
           data_source: source-a
-          encounter_id: 02288fa2b6c8335e69225d63811d6187
+          encounter_id: 8064c56a071fed311a8a820b4c249ca1
           encounter_type: orphaned claim
           encounter_group: other
         - claim_id: shared-undetermined
           claim_line_number: 1
           data_source: source-b
-          encounter_id: 4e85975bd2bdd2e25e0558d72ac95af7
+          encounter_id: f49d40e1f7a1b5865812f52b43f2a5eb
           encounter_type: orphaned claim
           encounter_group: other
 
@@ -240,6 +299,6 @@ unit_tests:
         - claim_id: 'shared_claim'
           claim_line_number: 1
           data_source: 'source_b'
-          encounter_id: 'df275fbe54ad3d9527ec49ce64abfafa'
+          encounter_id: '3fea38bb36c37ec87adde74cfe8825ab'
           encounter_type: 'orphaned claim'
           encounter_group: 'other'

--- a/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
@@ -111,6 +111,23 @@ where claim_attribution_number = 1
 
 union all
 
+/* Keep hospice below the existing inpatient priorities but above every
+   office-based and outpatient candidate. This preserves the relative order of
+   all existing encounter types while allowing hospice professional lines to
+   contribute to their inpatient hospice encounter. */
+select claim_id
+, claim_line_number
+, data_source
+, encounter_id
+, 'inpatient hospice' as encounter_type
+, 'inpatient' as encounter_group
+, 7 as priority_number
+, null as anchor_claim_id
+from {{ ref('inpatient_hospice__prof_claims') }}
+where claim_attribution_number = 1
+
+union all
+
 select claim_id
 , claim_line_number
 , data_source
@@ -131,7 +148,7 @@ select claim_id
 , old_encounter_id
 , encounter_type
 , 'office based' as encounter_group
-, 7 as priority_number
+, 8 as priority_number
 , null as anchor_claim_id
 from {{ ref('office_visits__int_office_visits_claim_line') }}
 where encounter_type = 'office visit radiology'
@@ -144,7 +161,7 @@ select claim_id
 , old_encounter_id
 , encounter_type
 , 'office based' as encounter_group
-, 8 as priority_number
+, 9 as priority_number
 , null as anchor_claim_id
 from {{ ref('office_visits__int_office_visits_claim_line') }}
 where encounter_type <> 'office visit radiology'
@@ -158,7 +175,7 @@ select claim_id
 , old_encounter_id
 , 'urgent care' as encounter_type
 , 'outpatient' as encounter_group
-, 9 as priority_number
+, 10 as priority_number
 , null as anchor_claim_id
 from {{ ref('urgent_care__match_claims_to_anchor') }}
 
@@ -170,7 +187,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient psych' as encounter_type
 , 'outpatient' as encounter_group
-, 10 as priority_number
+, 11 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_psych__match_claims_to_anchor') }}
 
@@ -182,7 +199,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient rehabilitation' as encounter_type
 , 'outpatient' as encounter_group
-, 11 as priority_number
+, 12 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_rehab__match_claims_to_anchor') }}
 
@@ -194,7 +211,7 @@ select claim_id
 , old_encounter_id
 , 'ambulatory surgery center' as encounter_type
 , 'outpatient' as encounter_group
-, 12 as priority_number
+, 13 as priority_number
 , null as anchor_claim_id
 from {{ ref('asc__match_claims_to_anchor') }}
 
@@ -206,7 +223,7 @@ select claim_id
 , old_encounter_id
 , 'dialysis' as encounter_type
 , 'outpatient' as encounter_group
-, 13 as priority_number
+, 14 as priority_number
 , null as anchor_claim_id
 from {{ ref('dialysis__match_claims_to_anchor') }}
 
@@ -218,7 +235,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient hospice' as encounter_type
 , 'outpatient' as encounter_group
-, 14 as priority_number
+, 15 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_hospice__match_claims_to_anchor') }}
 
@@ -230,7 +247,7 @@ select claim_id
 , old_encounter_id
 , 'home health' as encounter_type
 , 'outpatient' as encounter_group
-, 15 as priority_number
+, 16 as priority_number
 , null as anchor_claim_id
 from {{ ref('home_health__match_claims_to_anchor') }}
 
@@ -242,7 +259,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient surgery' as encounter_type
 , 'outpatient' as encounter_group
-, 16 as priority_number
+, 17 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_surgery__match_claims_to_anchor') }}
 
@@ -254,7 +271,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient injections' as encounter_type
 , 'outpatient' as encounter_group
-, 17 as priority_number
+, 18 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_injections__match_claims_to_anchor') }}
 
@@ -266,7 +283,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient pt/ot/st' as encounter_type
 , 'outpatient' as encounter_group
-, 18 as priority_number
+, 19 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_ptotst__match_claims_to_anchor') }}
 
@@ -278,7 +295,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient substance use' as encounter_type
 , 'outpatient' as encounter_group
-, 19 as priority_number
+, 20 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_substance_use__match_claims_to_anchor') }}
 
@@ -290,7 +307,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient radiology' as encounter_type
 , 'outpatient' as encounter_group
-, 20 as priority_number
+, 21 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_radiology__match_claims_to_anchor') }}
 

--- a/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
+++ b/models/claims_preprocessing/encounters/intermediate/encounters__combined_claim_line_crosswalk.sql
@@ -112,9 +112,9 @@ where claim_attribution_number = 1
 union all
 
 /* Keep hospice below the existing inpatient priorities but above every
-   office-based and outpatient candidate. This preserves the relative order of
-   all existing encounter types while allowing hospice professional lines to
-   contribute to their inpatient hospice encounter. */
+   office-based and outpatient candidate. Priority 7 is intentionally shared
+   with office visit radiology so existing published priority values do not
+   change; the final row_number tie-break puts inpatient hospice first. */
 select claim_id
 , claim_line_number
 , data_source
@@ -148,7 +148,7 @@ select claim_id
 , old_encounter_id
 , encounter_type
 , 'office based' as encounter_group
-, 8 as priority_number
+, 7 as priority_number
 , null as anchor_claim_id
 from {{ ref('office_visits__int_office_visits_claim_line') }}
 where encounter_type = 'office visit radiology'
@@ -161,7 +161,7 @@ select claim_id
 , old_encounter_id
 , encounter_type
 , 'office based' as encounter_group
-, 9 as priority_number
+, 8 as priority_number
 , null as anchor_claim_id
 from {{ ref('office_visits__int_office_visits_claim_line') }}
 where encounter_type <> 'office visit radiology'
@@ -175,7 +175,7 @@ select claim_id
 , old_encounter_id
 , 'urgent care' as encounter_type
 , 'outpatient' as encounter_group
-, 10 as priority_number
+, 9 as priority_number
 , null as anchor_claim_id
 from {{ ref('urgent_care__match_claims_to_anchor') }}
 
@@ -187,7 +187,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient psych' as encounter_type
 , 'outpatient' as encounter_group
-, 11 as priority_number
+, 10 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_psych__match_claims_to_anchor') }}
 
@@ -199,7 +199,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient rehabilitation' as encounter_type
 , 'outpatient' as encounter_group
-, 12 as priority_number
+, 11 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_rehab__match_claims_to_anchor') }}
 
@@ -211,7 +211,7 @@ select claim_id
 , old_encounter_id
 , 'ambulatory surgery center' as encounter_type
 , 'outpatient' as encounter_group
-, 13 as priority_number
+, 12 as priority_number
 , null as anchor_claim_id
 from {{ ref('asc__match_claims_to_anchor') }}
 
@@ -223,7 +223,7 @@ select claim_id
 , old_encounter_id
 , 'dialysis' as encounter_type
 , 'outpatient' as encounter_group
-, 14 as priority_number
+, 13 as priority_number
 , null as anchor_claim_id
 from {{ ref('dialysis__match_claims_to_anchor') }}
 
@@ -235,7 +235,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient hospice' as encounter_type
 , 'outpatient' as encounter_group
-, 15 as priority_number
+, 14 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_hospice__match_claims_to_anchor') }}
 
@@ -247,7 +247,7 @@ select claim_id
 , old_encounter_id
 , 'home health' as encounter_type
 , 'outpatient' as encounter_group
-, 16 as priority_number
+, 15 as priority_number
 , null as anchor_claim_id
 from {{ ref('home_health__match_claims_to_anchor') }}
 
@@ -259,7 +259,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient surgery' as encounter_type
 , 'outpatient' as encounter_group
-, 17 as priority_number
+, 16 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_surgery__match_claims_to_anchor') }}
 
@@ -271,7 +271,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient injections' as encounter_type
 , 'outpatient' as encounter_group
-, 18 as priority_number
+, 17 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_injections__match_claims_to_anchor') }}
 
@@ -283,7 +283,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient pt/ot/st' as encounter_type
 , 'outpatient' as encounter_group
-, 19 as priority_number
+, 18 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_ptotst__match_claims_to_anchor') }}
 
@@ -295,7 +295,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient substance use' as encounter_type
 , 'outpatient' as encounter_group
-, 20 as priority_number
+, 19 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_substance_use__match_claims_to_anchor') }}
 
@@ -307,7 +307,7 @@ select claim_id
 , old_encounter_id
 , 'outpatient radiology' as encounter_type
 , 'outpatient' as encounter_group
-, 21 as priority_number
+, 20 as priority_number
 , null as anchor_claim_id
 from {{ ref('outpatient_radiology__match_claims_to_anchor') }}
 
@@ -388,7 +388,9 @@ select
 , candidate.priority_number
 , candidate.anchor_claim_id
 , row_number() over (partition by candidate.claim_id, candidate.claim_line_number, candidate.data_source
-order by candidate.priority_number, case when candidate.claim_id = candidate.anchor_claim_id then 1 else 99 end
+order by candidate.priority_number
+       , case when candidate.encounter_type = 'inpatient hospice' then 0 else 1 end
+       , case when candidate.claim_id = candidate.anchor_claim_id then 1 else 99 end
        , candidate.encounter_type, candidate.encounter_id) as claim_line_attribution_number
 from cte as candidate
 left outer join undetermined_claim_lines

--- a/models/claims_preprocessing/encounters/staging/encounters__patient_data_source_id.sql
+++ b/models/claims_preprocessing/encounters/staging/encounters__patient_data_source_id.sql
@@ -18,5 +18,9 @@ from {{ ref('normalized__eligibility') }}
 select
 person_id
 , data_source
-, {{ the_tuva_project.concat_custom(['person_id', "'|'", 'data_source']) }} as patient_data_source_id
+, {{ the_tuva_project.stable_id_hash([
+    "'patient data source'",
+    'person_id',
+    'data_source'
+  ]) }} as patient_data_source_id
 from multiple_sources

--- a/models/core/coderx_unit_tests.yml
+++ b/models/core/coderx_unit_tests.yml
@@ -448,3 +448,157 @@ unit_tests:
           claim_line_number: 1
           ndc_code: '99988877766'
           ndc_description: CodeRx Enterprise package drug
+
+  - name: test_core_medication_keeps_overlapping_claims_and_clinical_ids
+    description: >-
+      A clinical medication and a pharmacy-claim medication may reuse the same
+      source identifier within one data source. source_type is part of the
+      Core medication grain, so both domain records must remain present.
+    model: core__medication
+    config:
+      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+        clinical_enabled: true
+        use_coderx_enterprise: false
+        _extension_columns_override: []
+        _smart_union_columns_override:
+          - medication_id
+          - source_type
+          - person_id
+          - member_id
+          - patient_id
+          - encounter_id
+          - claim_id
+          - claim_line_number
+          - payer
+          - plan
+          - dispensing_date
+          - prescribing_date
+          - source_code_type
+          - source_code
+          - source_description
+          - ndc_code
+          - ndc_description
+          - rxnorm_code
+          - atc_code
+          - route
+          - strength
+          - quantity
+          - quantity_unit
+          - days_supply
+          - practitioner_id
+          - ingest_datetime
+          - tuva_last_run
+          - data_source
+    given:
+      - input: ref('core__stg_claims_medication')
+        format: sql
+        rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          {% set integer_type = 'int64' if target.type == 'bigquery' else 'bigint' %}
+          select
+                'shared-id' as medication_id
+              , 'claims' as source_type
+              , 'person-claims' as person_id
+              , 'member-claims' as member_id
+              , cast(null as {{ string_type }}) as patient_id
+              , cast(null as {{ string_type }}) as encounter_id
+              , 'rx-claim' as claim_id
+              , 1 as claim_line_number
+              , 'payer' as payer
+              , 'plan' as {{ plan_identifier }}
+              , cast('2024-01-01' as date) as dispensing_date
+              , cast(null as date) as prescribing_date
+              , cast(null as {{ string_type }}) as source_code_type
+              , cast(null as {{ string_type }}) as source_code
+              , cast(null as {{ string_type }}) as source_description
+              , cast(null as {{ string_type }}) as ndc_code
+              , cast(null as {{ string_type }}) as ndc_description
+              , cast(null as {{ string_type }}) as rxnorm_code
+              , cast(null as {{ string_type }}) as atc_code
+              , cast(null as {{ string_type }}) as route
+              , cast(null as {{ string_type }}) as strength
+              , cast(null as {{ integer_type }}) as quantity
+              , cast(null as {{ string_type }}) as quantity_unit
+              , cast(null as {{ integer_type }}) as days_supply
+              , cast(null as {{ string_type }}) as practitioner_id
+              , cast(null as {{ timestamp_type }}) as ingest_datetime
+              , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+              , 'shared-source' as data_source
+      - input: ref('normalized__medication')
+        format: sql
+        rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          {% set integer_type = 'int64' if target.type == 'bigquery' else 'bigint' %}
+          select
+                'shared-id' as medication_id
+              , 'clinical' as source_type
+              , 'person-clinical' as person_id
+              , cast(null as {{ string_type }}) as member_id
+              , 'patient-clinical' as patient_id
+              , cast(null as {{ string_type }}) as encounter_id
+              , cast(null as {{ string_type }}) as claim_id
+              , cast(null as {{ integer_type }}) as claim_line_number
+              , cast(null as {{ string_type }}) as payer
+              , cast(null as {{ string_type }}) as {{ plan_identifier }}
+              , cast(null as date) as dispensing_date
+              , cast('2024-01-01' as date) as prescribing_date
+              , cast(null as {{ string_type }}) as source_code_type
+              , cast(null as {{ string_type }}) as source_code
+              , cast(null as {{ string_type }}) as source_description
+              , cast(null as {{ string_type }}) as ndc_code
+              , cast(null as {{ string_type }}) as ndc_description
+              , cast(null as {{ string_type }}) as rxnorm_code
+              , cast(null as {{ string_type }}) as atc_code
+              , cast(null as {{ string_type }}) as route
+              , cast(null as {{ string_type }}) as strength
+              , cast(null as {{ integer_type }}) as quantity
+              , cast(null as {{ string_type }}) as quantity_unit
+              , cast(null as {{ integer_type }}) as days_supply
+              , cast(null as {{ string_type }}) as practitioner_id
+              , cast(null as {{ timestamp_type }}) as ingest_datetime
+              , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+              , 'shared-source' as data_source
+      - input: ref('core__stg_coderx_packages')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select cast(null as {{ string_type }}) as ndc11, cast(null as {{ string_type }}) as ndc, cast(null as {{ string_type }}) as drug_id, cast(null as {{ string_type }}) as drug_name
+          from (select 1 as _tuva_empty_fixture) as _tuva_empty_fixture where 1 = 0
+      - input: ref('core__stg_coderx_drugs')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select cast(null as {{ string_type }}) as drug_id, cast(null as {{ string_type }}) as drug_name
+          from (select 1 as _tuva_empty_fixture) as _tuva_empty_fixture where 1 = 0
+      - input: ref('core__stg_coderx_classes')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select
+                cast(null as {{ string_type }}) as drug_id
+              , cast(null as {{ string_type }}) as atc_1_code
+              , cast(null as {{ string_type }}) as atc_1_name
+              , cast(null as {{ string_type }}) as atc_2_code
+              , cast(null as {{ string_type }}) as atc_2_name
+              , cast(null as {{ string_type }}) as atc_3_code
+              , cast(null as {{ string_type }}) as atc_3_name
+              , cast(null as {{ string_type }}) as atc_4_code
+              , cast(null as {{ string_type }}) as atc_4_name
+          from (select 1 as _tuva_empty_fixture) as _tuva_empty_fixture where 1 = 0
+    expect:
+      rows:
+        - medication_id: shared-id
+          source_type: claims
+          person_id: person-claims
+          data_source: shared-source
+        - medication_id: shared-id
+          source_type: clinical
+          person_id: person-clinical
+          data_source: shared-source

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -242,7 +242,7 @@ models:
             data_type: varchar
   - name: int_procedure_from_claims
     description: |-
-      Creates core-ready claims-derived procedure rows from normalized__medical_claim_procedures. This model joins normalized procedure rows to the claims preprocessing encounter claim-line crosswalk to populate encounter_id, then creates the Tuva synthetic procedure_id used by core.procedure.
+      Creates core-ready claims-derived procedure rows from normalized__medical_claim_procedures. This model joins normalized procedure rows to the claims preprocessing encounter claim-line crosswalk to populate encounter_id, then creates the collision-safe, domain-separated Tuva synthetic procedure_id used by core.procedure.
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -257,7 +257,12 @@ models:
       materialized: table
     columns:
       - name: procedure_id
-        description: Tuva synthetic identifier for the claims-derived procedure row.
+        description: >-
+          Deterministic 32-character lowercase Tuva identifier created by
+          hashing an unambiguous encoding of the claims-procedure domain,
+          source, claim, encounter, procedure sequence, code, procedure date,
+          modifiers, and practitioner. Null, empty, sentinel-like, and
+          delimiter-bearing values remain distinct.
         tests:
           - not_null
         config:
@@ -2150,12 +2155,15 @@ models:
 
       When clinical data is enabled, this model pulls from input_layer__medication through normalized__medication. When claims data is enabled, this model pulls from core.pharmacy_claim through core__stg_claims_medication. Tuva derives NDC, RxNorm, and ATC codes and descriptions from the package's CodeRx Open data assets when standard medication codes are available. When `use_coderx_enterprise` is true, Tuva's shared CodeRx interfaces instead use user-managed `packages`, `drugs`, and `classes` relations in the target database's `coderx` schema throughout pharmacy normalization, medication enrichment, data quality, and dependent packages. If CodeRx supplies multiple class rows for a drug, Tuva selects the lexicographically first non-null level 3 ATC code to preserve the medication grain. Claims-derived rows use pharmacy_claim_id as medication_id, set source_type to claims, populate claim_id and claim_line_number from core.pharmacy_claim, and populate practitioner_id from the prescribing provider NPI.
 
-      Primary key: medication_id, data_source.
+      Clinical and claims records retain their source identifiers in medication_id. Because those two domains can independently reuse the same value in one data source, source_type is part of the public key.
+
+      Primary key: medication_id, source_type, data_source.
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - medication_id
+              - source_type
               - data_source
     config:
       schema: |
@@ -2168,7 +2176,9 @@ models:
       - name: medication_id
         description: Identifier for a medication record within a data source. Clinical rows
           are populated from input_layer__medication.medication_id. Claims rows
-          are populated from core.pharmacy_claim.pharmacy_claim_id.
+          are populated from core.pharmacy_claim.pharmacy_claim_id. The same
+          value may exist in both source domains, so use source_type and
+          data_source with this field as the complete record key.
         tests:
           - not_null
         config:
@@ -2177,10 +2187,19 @@ models:
             is_primary_key: true
       - name: source_type
         description: Indicates whether the medication row came from claims or clinical
-          data. Accepted values are claims and clinical.
+          data. Accepted values are claims and clinical. This field is part of
+          the public primary key with medication_id and data_source.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - claims
+                  - clinical
         config:
           meta:
             data_type: varchar
+            is_primary_key: true
       - name: person_id
         description: Globally unique identifier for the person associated with the
           medication record. Clinical rows are populated from
@@ -3355,7 +3374,7 @@ models:
 
       Claims-derived rows are created from the input layer medical_claim table. Tuva creates one procedure row for each non-null HCPCS code on a medical claim line and one procedure row for each non-null procedure_code_1 through procedure_code_25 value on the claim header. HCPCS rows retain HCPCS modifiers from the medical claim line and use the rendering NPI as practitioner_id. Clinical rows are created directly from input_layer__procedure when the clinical input layer is enabled.
 
-      The Normalized Layer unpivots claims procedure fields and normalizes supported procedure code systems. The int_procedure_from_claims model attaches encounter_id for claims-derived rows and creates the Tuva synthetic procedure_id. Core procedure unions normalized clinical procedure rows with claims-derived procedure rows from int_procedure_from_claims, then joins normalized ICD-10-PCS codes to the Tuva Procedure Grouper to populate procedure_family and procedure. Clinical extension columns are pulled through when clinical data is enabled.
+      The Normalized Layer unpivots claims procedure fields and normalizes supported procedure code systems. The normalized clinical path and int_procedure_from_claims create collision-safe, domain-separated 32-character procedure IDs. Core procedure unions normalized clinical procedure rows with claims-derived procedure rows from int_procedure_from_claims, then joins normalized ICD-10-PCS codes to the Tuva Procedure Grouper to populate procedure_family and procedure. Clinical extension columns are pulled through when clinical data is enabled.
 
       Primary key: procedure_id.
     tests:
@@ -3372,7 +3391,13 @@ models:
       materialized: table
     columns:
       - name: procedure_id
-        description: Tuva synthetic record-level identifier for the procedure. Clinical IDs are created in normalized__procedure from source_procedure_id and data_source. Claims-derived IDs are created in int_procedure_from_claims from source data, claim, encounter, procedure sequence, code system, source code, HCPCS modifiers when present, and rendering NPI when present.
+        description: >-
+          Collision-safe, domain-separated 32-character lowercase Tuva
+          identifier for the procedure. Clinical IDs hash data_source and
+          source_procedure_id in the clinical-procedure domain. Claims-derived
+          IDs hash source, claim, encounter, procedure sequence, code,
+          procedure date, HCPCS modifiers, and rendering practitioner in the
+          claims-procedure domain.
         tests:
           - not_null
         config:

--- a/models/core/intermediate/int_procedure_from_claims.sql
+++ b/models/core/intermediate/int_procedure_from_claims.sql
@@ -89,30 +89,22 @@ with encounter_crosswalk as (
 )
 
 select distinct
-    {{ dbt.safe_cast(
-        concat_custom([
-            "'claims'",
-            "'_'",
-            "cast(data_source as " ~ dbt.type_string() ~ ")",
-            "'_'",
-            "cast(claim_id as " ~ dbt.type_string() ~ ")",
-            "'_'",
-            "coalesce(cast(encounter_id as " ~ dbt.type_string() ~ "), 'no_encounter')",
-            "'_'",
-            "cast(procedure_sequence_id as " ~ dbt.type_string() ~ ")",
-            "'_'",
-            "cast(coalesce(code_system, 'unknown') as " ~ dbt.type_string() ~ ")",
-            "'_'",
-            "cast(source_code as " ~ dbt.type_string() ~ ")",
-            "case when procedure_date is not null then concat('_', cast(procedure_date as " ~ dbt.type_string() ~ ")) else '' end",
-            "case when modifier_1 is not null then concat('_', modifier_1) else '' end",
-            "case when modifier_2 is not null then concat('_', modifier_2) else '' end",
-            "case when modifier_3 is not null then concat('_', modifier_3) else '' end",
-            "case when modifier_4 is not null then concat('_', modifier_4) else '' end",
-            "case when modifier_5 is not null then concat('_', modifier_5) else '' end",
-            "case when practitioner_id is not null then concat('_', practitioner_id) else '' end"
-        ]), api.Column.translate_type("string"))
-    }} as procedure_id
+    {{ the_tuva_project.stable_id_hash([
+        "'claims procedure'",
+        'data_source',
+        'claim_id',
+        'encounter_id',
+        'procedure_sequence_id',
+        'code_system',
+        'source_code',
+        'procedure_date',
+        'modifier_1',
+        'modifier_2',
+        'modifier_3',
+        'modifier_4',
+        'modifier_5',
+        'practitioner_id'
+    ]) }} as procedure_id
     , cast(person_id as {{ dbt.type_string() }}) as person_id
     , cast(member_id as {{ dbt.type_string() }}) as member_id
     , cast(null as {{ dbt.type_string() }}) as patient_id

--- a/models/core/procedure_unit_tests.yml
+++ b/models/core/procedure_unit_tests.yml
@@ -1,0 +1,87 @@
+version: 2
+
+unit_tests:
+  - name: test_claims_procedure_uses_collision_safe_domain_id
+    description: >-
+      Proves claims procedure IDs preserve underscore-delimited component
+      boundaries and distinguish a null encounter from the former literal
+      no_encounter sentinel.
+    model: int_procedure_from_claims
+    config:
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        claims_enabled: true
+    given:
+      - input: ref('normalized__medical_claim_procedures')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+                'person-1' as person_id
+              , 'member-1' as member_id
+              , 'c' as claim_id
+              , 1 as claim_line_number
+              , 1 as procedure_sequence_id
+              , cast(null as date) as procedure_date
+              , cast(null as {{ string_type }}) as practitioner_id
+              , 'hcpcs' as code_system
+              , 'A001' as source_code
+              , cast(null as {{ string_type }}) as source_description
+              , 'A001' as normalized_code
+              , cast(null as {{ string_type }}) as normalized_description
+              , cast(null as {{ string_type }}) as modifier_1
+              , cast(null as {{ string_type }}) as modifier_2
+              , cast(null as {{ string_type }}) as modifier_3
+              , cast(null as {{ string_type }}) as modifier_4
+              , cast(null as {{ string_type }}) as modifier_5
+              , cast(null as {{ timestamp_type }}) as ingest_datetime
+              , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
+              , 'a_b' as data_source
+          union all
+          select
+                'person-2', 'member-2', 'b_c', 1, 1, cast(null as date), null
+              , 'hcpcs', 'A001', null, 'A001', null
+              , null, null, null, null, null, null
+              , cast('2024-01-01 00:00:00' as {{ timestamp_type }}), 'a'
+          union all
+          select
+                'person-3', 'member-3', 'claim', 1, 1, cast(null as date), null
+              , 'hcpcs', 'A001', null, 'A001', null
+              , null, null, null, null, null, null
+              , cast('2024-01-01 00:00:00' as {{ timestamp_type }}), 'source'
+          union all
+          select
+                'person-4', 'member-4', 'claim-literal', 1, 1, cast(null as date), null
+              , 'hcpcs', 'A001', null, 'A001', null
+              , null, null, null, null, null, null
+              , cast('2024-01-01 00:00:00' as {{ timestamp_type }}), 'source'
+      - input: ref('encounters__combined_claim_line_crosswalk')
+        format: sql
+        rows: |
+          select 'c' as claim_id, 1 as claim_line_number, 'a_b' as data_source, 'enc' as encounter_id, 1 as claim_line_attribution_number
+          union all select 'b_c', 1, 'a', 'enc', 1
+          union all select 'claim-literal', 1, 'source', 'no_encounter', 1
+    expect:
+      rows:
+        - procedure_id: 80da4009cb1bc9fbfb1507b41852c44d
+          person_id: person-1
+          claim_id: c
+          encounter_id: enc
+          data_source: a_b
+        - procedure_id: e4e43b464352826af5c8c7cee7f2954d
+          person_id: person-2
+          claim_id: b_c
+          encounter_id: enc
+          data_source: a
+        - procedure_id: 91f61f9b1cd05bd8e4398007a1cef4b2
+          person_id: person-3
+          claim_id: claim
+          encounter_id: null
+          data_source: source
+        - procedure_id: 0107b0683cfb81ec86f4a40b7ae1bf67
+          person_id: person-4
+          claim_id: claim-literal
+          encounter_id: no_encounter
+          data_source: source

--- a/models/normalized_layer/final/normalized__procedure.sql
+++ b/models/normalized_layer/final/normalized__procedure.sql
@@ -4,15 +4,11 @@
 }}
 
 {%- set tuva_core_columns -%}
-      {{ dbt.safe_cast(
-          concat_custom([
-              "'clinical'",
-              "'_'",
-              "cast(procedure_source.data_source as " ~ dbt.type_string() ~ ")",
-              "'_'",
-              "cast(procedure_source.source_procedure_id as " ~ dbt.type_string() ~ ")"
-          ]), api.Column.translate_type("string"))
-      }} as procedure_id
+      {{ the_tuva_project.stable_id_hash([
+          "'clinical procedure'",
+          'procedure_source.data_source',
+          'procedure_source.source_procedure_id'
+      ]) }} as procedure_id
     , cast(procedure_source.person_id as {{ dbt.type_string() }}) as person_id
     , cast(null as {{ dbt.type_string() }}) as member_id
     , cast(procedure_source.patient_id as {{ dbt.type_string() }}) as patient_id

--- a/models/normalized_layer/normalized_layer_models.yml
+++ b/models/normalized_layer/normalized_layer_models.yml
@@ -247,10 +247,33 @@ models:
       <<: *normalized_output_config
       alias: normalized__practitioner
   - name: normalized__procedure
-    description: Casts clinical procedure records from input_layer__procedure before core.procedure consumes them.
+    description: >-
+      Casts clinical procedure records from input_layer__procedure and creates
+      the collision-safe, domain-separated 32-character procedure_id before
+      core.procedure consumes them.
     config:
       <<: *normalized_output_config
       alias: normalized__procedure
+    columns:
+      - name: procedure_id
+        description: >-
+          Deterministic Tuva identifier created by hashing an unambiguous
+          encoding of the clinical-procedure domain marker, data_source, and
+          source_procedure_id.
+        tests:
+          - not_null
+          - unique
+        config:
+          meta:
+            data_type: varchar
+            is_primary_key: true
+      - name: data_source
+        description: Source system that supplied the clinical procedure.
+        tests:
+          - not_null
+        config:
+          meta:
+            data_type: varchar
 
 ### Normalized Claim Input Layer
 ##    Final

--- a/models/normalized_layer/procedure_unit_tests.yml
+++ b/models/normalized_layer/procedure_unit_tests.yml
@@ -1,0 +1,76 @@
+version: 2
+
+unit_tests:
+  - name: test_normalized_procedure_uses_collision_safe_domain_id
+    description: >-
+      Proves clinical procedure IDs preserve source-key boundaries that the
+      former underscore-delimited identifier collapsed.
+    model: normalized__procedure
+    config:
+      enabled: "{{ var('clinical_enabled', false) | as_bool }}"
+    overrides:
+      vars:
+        clinical_enabled: true
+        _extension_columns_override: []
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('input_layer__procedure')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          select
+                'c' as source_procedure_id
+              , 'person-1' as person_id
+              , 'patient-1' as patient_id
+              , cast(null as {{ string_type }}) as encounter_id
+              , cast('2024-01-01' as date) as procedure_date
+              , 'local' as code_system
+              , 'code-1' as source_code
+              , 'description' as source_description
+              , cast(null as {{ string_type }}) as modifier_1
+              , cast(null as {{ string_type }}) as modifier_2
+              , cast(null as {{ string_type }}) as modifier_3
+              , cast(null as {{ string_type }}) as modifier_4
+              , cast(null as {{ string_type }}) as modifier_5
+              , cast(null as {{ string_type }}) as practitioner_id
+              , cast(null as {{ timestamp_type }}) as ingest_datetime
+              , 'a_b' as data_source
+          union all
+          select
+                'b_c', 'person-2', 'patient-2', null
+              , cast('2024-01-01' as date), 'local', 'code-2', 'description'
+              , null, null, null, null, null, null
+              , cast(null as {{ timestamp_type }}), 'a'
+      - input: ref('terminology__icd_10_pcs')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select cast(null as {{ string_type }}) as icd_10_pcs, cast(null as {{ string_type }}) as description
+          from (select 1 as _tuva_empty_fixture) as _tuva_empty_fixture where 1 = 0
+      - input: ref('terminology__icd_9_pcs')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select cast(null as {{ string_type }}) as icd_9_pcs, cast(null as {{ string_type }}) as short_description
+          from (select 1 as _tuva_empty_fixture) as _tuva_empty_fixture where 1 = 0
+      - input: ref('terminology__hcpcs_level_2')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select cast(null as {{ string_type }}) as hcpcs, cast(null as {{ string_type }}) as short_description
+          from (select 1 as _tuva_empty_fixture) as _tuva_empty_fixture where 1 = 0
+      - input: ref('terminology__snomed_ct')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
+          select cast(null as {{ string_type }}) as snomed_ct, cast(null as {{ string_type }}) as description
+          from (select 1 as _tuva_empty_fixture) as _tuva_empty_fixture where 1 = 0
+    expect:
+      rows:
+        - procedure_id: bd68d0fe75e880eefc854d0ec42fedf0
+          person_id: person-1
+          data_source: a_b
+        - procedure_id: 699c699c53bc5e8b2cd73ad65e1fe2ac
+          person_id: person-2
+          data_source: a

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,7 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: "1.2.1"
+    version:
+      - ">=1.3.2"
+      - "<2.0.0"
 
 

--- a/tests/check_encounter_id_hash_contract.sql
+++ b/tests/check_encounter_id_hash_contract.sql
@@ -1,0 +1,71 @@
+{{ config(
+     severity = 'error',
+     tags = ['contract', 'stable_id_contract']
+   )
+}}
+
+{#
+  Encounter IDs share the collision-safe stable-ID serialization. These cases
+  pin delimiter boundaries and the former literal <NULL> sentinel so a later
+  macro change cannot silently reintroduce either collision class.
+#}
+
+with contract_cases as (
+    select
+          'pipe_left_boundary' as case_name
+        , {{ the_tuva_project.encounter_id_hash([
+              "'outpatient visit'", "'a|b'", "'c'"
+          ]) }} as actual_id
+        , '400a99d1fda4fae42d75ea2ea10484a0' as expected_id
+
+    union all
+
+    select
+          'pipe_right_boundary' as case_name
+        , {{ the_tuva_project.encounter_id_hash([
+              "'outpatient visit'", "'a'", "'b|c'"
+          ]) }} as actual_id
+        , '08c26e2f270adb2fd490118eee57c0ec' as expected_id
+
+    union all
+
+    select
+          'null_component' as case_name
+        , {{ the_tuva_project.encounter_id_hash([
+              "'outpatient visit'",
+              "cast(null as " ~ dbt.type_string() ~ ")",
+              "'c'"
+          ]) }} as actual_id
+        , 'a2ca8a74fabface17f33e83d7ea9f914' as expected_id
+
+    union all
+
+    select
+          'literal_legacy_null_marker' as case_name
+        , {{ the_tuva_project.encounter_id_hash([
+              "'outpatient visit'", "'<NULL>'", "'c'"
+          ]) }} as actual_id
+        , '2f9676fb1f59f056a7e027e9ad9ee389' as expected_id
+)
+
+, duplicate_ids as (
+    select actual_id
+    from contract_cases
+    group by actual_id
+    having count(*) > 1
+)
+
+select
+      case_name
+    , actual_id
+    , expected_id
+from contract_cases
+where actual_id <> expected_id
+
+union all
+
+select
+      'duplicate_contract_id' as case_name
+    , actual_id
+    , cast(null as {{ dbt.type_string() }}) as expected_id
+from duplicate_ids


### PR DESCRIPTION
## Summary

- replace delimiter- and sentinel-sensitive encounter, patient-source, and procedure identifiers with the shared collision-safe 32-character hash encoding
- separate clinical and claims medication identities while preserving the public source identifier
- attribute inpatient hospice professional claims before outpatient candidates
- widen the dbt_utils dependency to the validated 1.3.2 through 1.x range
- add deterministic collision, cross-domain, grain, and hospice regressions

These identifier corrections intentionally change affected published IDs. Downstream consumers should full-refresh the affected relations when adopting 1.0.

## Validation

- scripts/dbt-local deps (dbt_utils 1.4.1)
- dbt 1.11.2 parse
- dbt Core 2.0.0-beta.2 parse
- all 50 Core unit tests passed
- focused Snowflake full-refresh build: 40/40 nodes passed
- portability harness: 59/59 passed
- portability lint and git diff --check passed

Per request, parity, the final all-warehouse matrix, asset release work, documentation-site release validation, tagging, and other release gates were not run.

## Release-note disposition

breaking-change