### PR TITLE
Add SQL Server and Athena support to Tuva Core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,6 +373,13 @@ Write general-purpose SQL, prefer existing Tuva macros and package patterns,
 and isolate genuinely warehouse-specific behavior behind dispatched macros. A
 passing build on one warehouse is not evidence of portability to the others.
 
+Logical Data Quality depends on case-sensitive string comparison. SQL Server
+targets therefore require a case-sensitive database collation such as
+`SQL_Latin1_General_CP1_CS_AS`; the engine default
+`SQL_Latin1_General_CP1_CI_AS` makes those checks pass silently on values they
+should flag. Do not work around this by lowercasing the compared values, which
+would erase the case contract the checks exist to enforce.
+
 ## GitHub And Pull Requests
 
 - Create Tuva Core issues in `tuva-health/tuva-core`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Tuva Core requires dbt 1.10.5 through 2.x and supports Snowflake, Databricks,
 BigQuery, Microsoft Fabric, Redshift, and DuckDB. The 1.0 package ecosystem is
 validated against both dbt Core 2.0 and dbt Fusion on DuckDB.
 
+SQL Server deployments must use a case-sensitive database collation such as
+`SQL_Latin1_General_CP1_CS_AS`. Logical Data Quality compares values against
+exact lowercase literals, for example `sex in ('male', 'female', 'unknown')`.
+Under the SQL Server default `SQL_Latin1_General_CP1_CI_AS`, `'MALE'` compares
+equal to `'male'`, so those checks silently report an invalid value as valid
+instead of failing. Set the collation when the database is created; changing it
+afterwards requires rebuilding the affected objects.
+
 ## What Tuva Core Includes
 
 | Area | Responsibility |

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -69,6 +69,9 @@ vars:
   ## Warehouse-specific seed loading
   # Microsoft Fabric public storage endpoint used by seed loading macros.
   # tuva_seed_fabric_storage_root: "https://tuvapublicresources.blob.core.windows.net"
+  # SQL Server seed source. Accepts an https blob endpoint (the default public
+  # mirror) or a local filesystem root readable by the database engine.
+  # tuva_seed_sqlserver_storage_root: "https://tuvapublicresources.blob.core.windows.net"
 
   ## Data quality internals
   # Number of part models the Logical Data Quality failure-key and result

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -70,6 +70,13 @@ vars:
   # Microsoft Fabric public storage endpoint used by seed loading macros.
   # tuva_seed_fabric_storage_root: "https://tuvapublicresources.blob.core.windows.net"
 
+  ## Data quality internals
+  # Number of part models the Logical Data Quality failure-key and result
+  # relations are split across. Each part is one slice of the test manifest,
+  # kept small enough that the generated statement stays inside Athena's
+  # 262,144-byte query-string limit. Raise it if the manifest grows.
+  # dq_logical_chunk_count: 4
+
   ## Internal test hooks
   # Local filesystem root for validating staged package data assets with DuckDB.
   # The root must contain <bucket>/<package>/<version>/...; omit in normal projects.

--- a/integration_tests/macros/fabric_test_expression_is_true.sql
+++ b/integration_tests/macros/fabric_test_expression_is_true.sql
@@ -25,3 +25,12 @@ where (
 )
 
 {% endmacro %}
+
+
+{#
+  SQL Server is T-SQL and needs the same named-column CTE, but dbt-sqlserver
+  registers no adapter-type parent, so fabric__ is not reached by dispatch.
+#}
+{% macro sqlserver__test_expression_is_true(model, expression, column_name=none, condition='1=1') %}
+    {{ return(fabric__test_expression_is_true(model, expression, column_name, condition)) }}
+{% endmacro %}

--- a/macros/cross_database_utils/apply_regex.sql
+++ b/macros/cross_database_utils/apply_regex.sql
@@ -58,3 +58,9 @@
     regexp_matches({{ column_name }}, '{{ regex }}')
 
 {%- endmacro -%}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__apply_regex(column_name, regex) -%}
+    {{ the_tuva_project.fabric__apply_regex(column_name, regex) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/bool_and_agg.sql
+++ b/macros/cross_database_utils/bool_and_agg.sql
@@ -26,3 +26,9 @@
 {% macro fabric__bool_and_agg(expression) %}
   cast( min( cast( {{ expression }} as int) ) as bit)
 {% endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__bool_and_agg(expression) -%}
+    {{ the_tuva_project.fabric__bool_and_agg(expression) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/bool_or_agg.sql
+++ b/macros/cross_database_utils/bool_or_agg.sql
@@ -26,3 +26,9 @@
 {% macro fabric__bool_or_agg(expression) %}
   cast( max( cast( {{ expression }} as int) ) as bit)
 {% endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__bool_or_agg(expression) -%}
+    {{ the_tuva_project.fabric__bool_or_agg(expression) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/create_json_object.sql
+++ b/macros/cross_database_utils/create_json_object.sql
@@ -187,3 +187,9 @@ select
 from {{ table_ref }}
 group by {{ group_by_col }}
 {% endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__create_json_object(table_ref, group_by_col, object_col_name, object_col_list) -%}
+    {{ the_tuva_project.fabric__create_json_object(table_ref, group_by_col, object_col_name, object_col_list) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/date_part.sql
+++ b/macros/cross_database_utils/date_part.sql
@@ -25,3 +25,9 @@
         NULL
     {% endif %}
 {% endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__date_part(datepart, date) -%}
+    {{ the_tuva_project.fabric__date_part(datepart, date) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/is_numeric_string.sql
+++ b/macros/cross_database_utils/is_numeric_string.sql
@@ -43,3 +43,9 @@
     )
 
 {%- endmacro -%}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__is_numeric_string(column_name) -%}
+    {{ the_tuva_project.fabric__is_numeric_string(column_name) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/left.sql
+++ b/macros/cross_database_utils/left.sql
@@ -15,3 +15,9 @@
 {% macro default__left(expression, length) %}
   left( {{ expression }}, {{ length }} )
 {% endmacro %}
+
+
+{# Athena/Trino has no left(); substr is the portable spelling. #}
+{% macro athena__left(expression, length) %}
+  substr( {{ expression }}, 1, {{ length }} )
+{% endmacro %}

--- a/macros/cross_database_utils/length.sql
+++ b/macros/cross_database_utils/length.sql
@@ -9,3 +9,9 @@
 {% macro fabric__length(col) %}
   len( {{ col }} )
 {% endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__length(col) -%}
+    {{ the_tuva_project.fabric__length(col) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/limit_zero.sql
+++ b/macros/cross_database_utils/limit_zero.sql
@@ -14,3 +14,9 @@
 {% macro fabric__limit_zero() -%}
     {# No limit statement for Fabric #}
 {%- endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__limit_zero() -%}
+    {{ the_tuva_project.fabric__limit_zero() }}
+{%- endmacro %}

--- a/macros/cross_database_utils/load_seed.sql
+++ b/macros/cross_database_utils/load_seed.sql
@@ -176,7 +176,7 @@ copy  {{ this }}
             CREATE TABLE {{ table_name }} AS
                 SELECT
                 {% for col in columns %}
-                    cast(nullif(c{{ loop.index0 }},'{{ null_char }}') as {{ dml_data_type(col.dtype) }}) as `{{ col.name }}` {%-if not loop.last -%},{%- endif %}
+                    cast(nullif(c{{ loop.index0 }},'{{ null_char }}') as {{ dml_data_type(col.dtype) }}) as "{{ col.name }}" {%-if not loop.last -%},{%- endif %}
                 {% endfor %}
                 FROM {{ tmp_table }}
                 WHERE "$path" like '{{ full_path }}%';

--- a/macros/cross_database_utils/load_seed.sql
+++ b/macros/cross_database_utils/load_seed.sql
@@ -417,6 +417,172 @@ WITH (
 {% endmacro %}
 
 
+{#
+    SQL Server has no COPY INTO and no wildcard bulk loader, and BULK INSERT
+    cannot decompress. It does have a native GZIP builtin, so the published
+    .csv.gz is read as a single blob, decompressed in-engine, split into lines
+    and parsed field-wise.
+
+    The parse is RFC 4180 over the assets exactly as published, with their
+    existing minimal quoting: only fields that need quotes carry them. Splitting
+    a line on every comma over-splits any quoted field containing one, so tokens
+    are re-joined wherever the running count of double quotes before them is
+    odd, which is precisely when the preceding comma fell inside a quoted field.
+
+    Parsing what is already published matters more than a simpler parser would.
+    Requiring fully-quoted CSV instead would turn every bare empty field into a
+    quoted empty string, and several loaders treat only the bare form as NULL,
+    so republishing to suit this adapter risks changing NULL semantics for the
+    warehouses that already work.
+
+    tuva_seed_sqlserver_storage_root accepts either an https blob endpoint
+    (the default public mirror) or a local filesystem root for testing.
+#}
+
+{% macro sqlserver__load_seed(uri, pattern, compression, headers, null_marker) %}
+{% if execute %}
+{% do the_tuva_project.reset_seed_relation() %}
+
+{%- set columns = adapter.get_columns_in_relation(this) -%}
+{%- if columns | length == 0 -%}
+  {% do exceptions.raise_compiler_error("SQL Server seed load found no columns on " ~ this ~ ".") %}
+{%- endif -%}
+
+{%- set storage_root = var('tuva_seed_sqlserver_storage_root', 'https://tuvapublicresources.blob.core.windows.net') | string | trim -%}
+{%- set storage_root = storage_root.rstrip('/') -%}
+{%- set is_remote = storage_root.startswith('http://') or storage_root.startswith('https://') -%}
+{%- set normalized_uri = uri | string | trim | trim('/') -%}
+
+{%- if is_remote -%}
+  {#- The first uri segment is the storage container; the rest is the blob path. -#}
+  {%- set uri_parts = normalized_uri.split('/') -%}
+  {%- set container = uri_parts[0] -%}
+  {%- set blob_path = uri_parts[1:] | join('/') -%}
+  {%- set data_source_name = 'tuva_seed_' ~ container | replace('-', '_') | replace('.', '_') -%}
+  {%- set object_path = blob_path ~ '/' ~ pattern -%}
+  {%- set source_args = "'" ~ object_path ~ "', data_source = '" ~ data_source_name ~ "', single_blob" -%}
+  {% set ensure_source %}
+    if not exists (select 1 from sys.external_data_sources where name = '{{ data_source_name }}')
+      exec('create external data source [{{ data_source_name }}] with (type = BLOB_STORAGE, location = ''{{ storage_root }}/{{ container }}'')');
+  {% endset %}
+  {% call statement('sqlserver_seed_source', fetch_result=false) %}{{ ensure_source }}{% endcall %}
+{%- else -%}
+  {%- set object_path = storage_root ~ '/' ~ normalized_uri ~ '/' ~ pattern -%}
+  {%- set source_args = "'" ~ object_path ~ "', single_blob" -%}
+{%- endif -%}
+
+{#- DECOMPRESS is SQL Server's GZIP builtin; skip it for uncompressed sources. -#}
+{%- if compression == true -%}
+  {%- set payload = "cast(decompress(src.BulkColumn) as varchar(max))" -%}
+{%- else -%}
+  {%- set payload = "cast(src.BulkColumn as varchar(max))" -%}
+{%- endif -%}
+
+{%- set insert_cols = [] -%}
+{%- set select_exprs = [] -%}
+{%- set pivot_exprs = [] -%}
+{%- for col in columns -%}
+  {%- do insert_cols.append(the_tuva_project.quote_column(col.name)) -%}
+  {%- do pivot_exprs.append("max(case when field_no = " ~ loop.index ~ " then val end) as c" ~ loop.index0) -%}
+  {#- cast(x as varchar) with no length silently truncates to 30 characters in
+      T-SQL, and get_columns_in_relation reports varchar(max) as a bare
+      "varchar". Always render an explicit length. -#}
+  {%- set dt = col.dtype | lower | trim -%}
+  {%- if 'char' in dt and '(' not in dt -%}
+    {%- set size = col.char_size -%}
+    {%- set target_type = dt ~ '(' ~ ('max' if (size is none or size <= 0) else size) ~ ')' -%}
+  {%- else -%}
+    {%- set target_type = col.dtype -%}
+  {%- endif -%}
+  {%- set raw = "nullif(parsed.c" ~ loop.index0 ~ ", '__TUVA_RESERVED_NULL_MARKER_1_0__')" -%}
+  {%- do select_exprs.append("cast(" ~ raw ~ " as " ~ target_type ~ ")") -%}
+{%- endfor -%}
+
+{% set sql %}
+insert into {{ this }} ({{ insert_cols | join(', ') }})
+select
+      {{ select_exprs | join('\n    , ') }}
+from (
+    select
+          line_no
+        , {{ pivot_exprs | join('\n        , ') }}
+    from (
+        /* Strip the surrounding quotes from a quoted field and undouble its
+           internal quotes. len() ignores trailing spaces, so measure with a
+           sentinel appended. An empty field is NULL, matching the bare-empty
+           null convention the assets are published with. */
+        select
+              line_no
+            , field_no
+            , nullif(
+                  case
+                      when (len(rf + '|') - 1) >= 2 and left(rf, 1) = '"' and right(rf, 1) = '"'
+                          then replace(substring(rf, 2, (len(rf + '|') - 1) - 2), '""', '"')
+                      else rf
+                  end
+              , '') as val
+        from (
+            select
+                  line_no
+                , field_no
+                , string_agg(cast(tok as varchar(max)), ',') within group (order by tok_no) as rf
+            from (
+                /* A comma only ends a field when an even number of quotes has
+                   been seen so far on the line; otherwise it is inside a
+                   quoted field and its tokens belong to the same field. */
+                select
+                      line_no
+                    , tok_no
+                    , tok
+                    , 1 + isnull(
+                          sum(case when cum % 2 = 0 then 1 else 0 end) over (
+                              partition by line_no order by tok_no
+                              rows between unbounded preceding and 1 preceding
+                          ), 0) as field_no
+                from (
+                    select
+                          line_no
+                        , tok_no
+                        , tok
+                        , sum(quote_count) over (
+                              partition by line_no order by tok_no
+                              rows between unbounded preceding and current row
+                          ) as cum
+                    from (
+                        select
+                              ln.ordinal as line_no
+                            , t.ordinal as tok_no
+                            , t.value as tok
+                            , (len(t.value + '|') - 1) - (len(replace(t.value, '"', '') + '|') - 1) as quote_count
+                        from openrowset(bulk {{ source_args }}) as src
+                        cross apply (select replace({{ payload }}, char(13), '') as text) as body
+                        cross apply string_split(body.text, char(10), 1) as ln
+                        cross apply string_split(ln.value, ',', 1) as t
+                        where ln.ordinal > {{ 1 if headers == true else 0 }}
+                          and len(ln.value + '|') > 1
+                    ) as tokens
+                ) as running
+            ) as fields
+            group by line_no, field_no
+        ) as grouped
+    ) as cleaned
+    group by line_no
+) as parsed
+{% endset %}
+
+{% call statement('sqlserver_seed', fetch_result=false) %}{{ sql }}{% endcall %}
+
+{% set count_sql %}select count(*) as row_count from {{ this }}{% endset %}
+{% call statement('sqlserver_seed_count', fetch_result=true) %}{{ count_sql }}{% endcall %}
+{% set count_result = load_result('sqlserver_seed_count') %}
+{% set row_count = count_result.table.columns[0].values()[0] if count_result.table else 0 %}
+{{ log("Loaded data from " ~ ("external blob storage" if is_remote else "local storage")
+       ~ "\n  loaded to: " ~ this ~ "\n  from: " ~ object_path ~ "\n  rows: " ~ row_count, True) }}
+
+{% endif %}
+{% endmacro %}
+
+
 {% macro default__load_seed(uri,pattern,compression,headers,null_marker) %}
 {% if execute %}
 {% do log('No adapter found, seed not loaded',info = True) %}

--- a/macros/cross_database_utils/load_seed.sql
+++ b/macros/cross_database_utils/load_seed.sql
@@ -136,7 +136,10 @@ copy  {{ this }}
         {%- set null_char = '' -%}
 
         {% for col in columns %}
-            {% do column_definitions.append(col.name ~ " string" ) %}
+            {# Positional names on the staging table. A Glue table carrying a
+               reserved word such as `procedure` cannot be read by CTAS at all,
+               so the real names are reapplied in the select below. #}
+            {% do column_definitions.append("c" ~ loop.index0 ~ " string" ) %}
         {% endfor %}
 
         {%- set col_ddl = column_definitions|join(',') -%}
@@ -173,7 +176,7 @@ copy  {{ this }}
             CREATE TABLE {{ table_name }} AS
                 SELECT
                 {% for col in columns %}
-                    cast(nullif({{ col.name }},'{{ null_char }}') as {{ dml_data_type(col.dtype) }}) as {{ col.name }} {%-if not loop.last -%},{%- endif %}
+                    cast(nullif(c{{ loop.index0 }},'{{ null_char }}') as {{ dml_data_type(col.dtype) }}) as `{{ col.name }}` {%-if not loop.last -%},{%- endif %}
                 {% endfor %}
                 FROM {{ tmp_table }}
                 WHERE "$path" like '{{ full_path }}%';

--- a/macros/cross_database_utils/quote_column.sql
+++ b/macros/cross_database_utils/quote_column.sql
@@ -1,5 +1,5 @@
 {% macro quote_column(column_name) %}
-    {%- if target.type == 'fabric' -%}
+    {%- if target.type in ('fabric', 'sqlserver') -%}
         [{{ column_name }}]
     {%- else -%}
         {{ column_name }}

--- a/macros/cross_database_utils/union_distinct.sql
+++ b/macros/cross_database_utils/union_distinct.sql
@@ -15,3 +15,9 @@
 {% macro fabric__union_distinct() -%}
     union
 {%- endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__union_distinct() -%}
+    {{ the_tuva_project.fabric__union_distinct() }}
+{%- endmacro %}

--- a/macros/cross_database_utils/year_month.sql
+++ b/macros/cross_database_utils/year_month.sql
@@ -46,3 +46,9 @@
 {% macro fabric__year_month(date_column) -%}
     FORMAT(cast({{ date_column }} as date), 'yyyyMM')
 {%- endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__year_month(date_column) -%}
+    {{ the_tuva_project.fabric__year_month(date_column) }}
+{%- endmacro %}

--- a/macros/cross_database_utils/yyyymm.sql
+++ b/macros/cross_database_utils/yyyymm.sql
@@ -21,3 +21,15 @@
 {% macro default__yyyymm(date) -%}
     to_char({{ date }}, 'YYYYMM')
 {%- endmacro %}
+
+{# SQL Server is T-SQL. dbt-sqlserver registers no adapter-type parent,
+   so fabric__ macros are not reached by dispatch and must be aliased. #}
+{% macro sqlserver__yyyymm(date) -%}
+    {{ the_tuva_project.fabric__yyyymm(date) }}
+{%- endmacro %}
+
+
+{# Athena/Trino has no to_char(); date_format uses MySQL-style patterns. #}
+{% macro athena__yyyymm(date) -%}
+    DATE_FORMAT(cast({{ date }} as date), '%Y%m')
+{%- endmacro %}

--- a/macros/data_quality/dq_logical_helpers.sql
+++ b/macros/data_quality/dq_logical_helpers.sql
@@ -86,3 +86,63 @@
         ~ " and " ~ bill_type_prefix_expression ~ " in ('11', '12')"
     ) }}
 {% endmacro %}
+
+
+{#
+    Athena caps a query string at 262,144 bytes. The logical failure-key and
+    result models emit one UNION ALL branch per enabled logical test, which
+    passes that cap well before the manifest is exhausted, and unlike the test
+    catalog they cannot be brought under it by trimming aliases and whitespace.
+
+    Splitting the manifest across several materialized part models turns one
+    oversized statement into several small ones. The public relation stays a
+    thin UNION over the parts. Parts are implementation details, not consumer
+    contracts.
+#}
+
+{% macro dq_logical_chunk_count() %}
+    {{ return(var('dq_logical_chunk_count', 4) | int) }}
+{% endmacro %}
+
+
+{% macro dq_enabled_logical_test_manifest_chunk(chunk_index) %}
+    {% set chunk_count = the_tuva_project.dq_logical_chunk_count() %}
+    {% set chunk = [] %}
+    {% for definition in dq_enabled_logical_test_manifest() %}
+        {% if loop.index0 % chunk_count == chunk_index %}
+            {% do chunk.append(definition) %}
+        {% endif %}
+    {% endfor %}
+    {{ return(chunk) }}
+{% endmacro %}
+
+
+{#
+    logical_test_results groups the manifest by source flag model and builds
+    per-model aggregate CTEs, so its chunks must split on whole models. Slicing
+    on definition index would spread one flag model's definitions across parts
+    and each part would aggregate only its own slice.
+#}
+
+{% macro dq_enabled_logical_test_manifest_chunk_by_model(chunk_index) %}
+    {% set chunk_count = the_tuva_project.dq_logical_chunk_count() %}
+    {% set source_models = [] %}
+    {% for definition in dq_enabled_logical_test_manifest() %}
+        {% if definition['source_model_name'] not in source_models %}
+            {% do source_models.append(definition['source_model_name']) %}
+        {% endif %}
+    {% endfor %}
+    {% set selected = [] %}
+    {% for source_model_name in source_models %}
+        {% if loop.index0 % chunk_count == chunk_index %}
+            {% do selected.append(source_model_name) %}
+        {% endif %}
+    {% endfor %}
+    {% set chunk = [] %}
+    {% for definition in dq_enabled_logical_test_manifest() %}
+        {% if definition['source_model_name'] in selected %}
+            {% do chunk.append(definition) %}
+        {% endif %}
+    {% endfor %}
+    {{ return(chunk) }}
+{% endmacro %}

--- a/models/claims_preprocessing/provider_attribution/provider_attribution_unit_tests.yml
+++ b/models/claims_preprocessing/provider_attribution/provider_attribution_unit_tests.yml
@@ -19,7 +19,7 @@ unit_tests:
       - input: ref('normalized__medical_claim')
         format: sql
         rows: |
-          {% set numeric_type = 'numeric' %}
+          {% set numeric_type = 'decimal(18, 2)' if target.type == 'athena' else 'numeric' %}
           select
               'undetermined_claim' as claim_id
             , 1 as claim_line_number

--- a/models/core/coderx_unit_tests.yml
+++ b/models/core/coderx_unit_tests.yml
@@ -224,8 +224,8 @@ unit_tests:
             , 'claims' as source_type
             , 'person' as person_id
             , 'member' as member_id
-            , null as patient_id
-            , null as encounter_id
+            , cast(null as {{ string_type }}) as patient_id
+            , cast(null as {{ string_type }}) as encounter_id
             , 'claim' as claim_id
             , 1 as claim_line_number
             , 'payer' as payer
@@ -239,12 +239,12 @@ unit_tests:
             , 'Stale CodeRx Open normalized description' as ndc_description
             , cast(null as {{ string_type }}) as rxnorm_code
             , cast(null as {{ string_type }}) as atc_code
-            , null as route
-            , null as strength
+            , cast(null as {{ string_type }}) as route
+            , cast(null as {{ string_type }}) as strength
             , 30 as quantity
-            , null as quantity_unit
+            , cast(null as {{ string_type }}) as quantity_unit
             , 30 as days_supply
-            , null as practitioner_id
+            , cast(null as {{ string_type }}) as practitioner_id
             , cast('2024-01-02 03:04:05' as {{ timestamp_type }}) as ingest_datetime
             , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
             , 'source' as data_source
@@ -312,8 +312,8 @@ unit_tests:
             , 'claims' as source_type
             , 'person' as person_id
             , 'member' as member_id
-            , null as patient_id
-            , null as encounter_id
+            , cast(null as {{ string_type }}) as patient_id
+            , cast(null as {{ string_type }}) as encounter_id
             , 'claim' as claim_id
             , 1 as claim_line_number
             , 'payer' as payer
@@ -327,12 +327,12 @@ unit_tests:
             , 'CodeRx Enterprise package drug' as ndc_description
             , cast(null as {{ string_type }}) as rxnorm_code
             , cast(null as {{ string_type }}) as atc_code
-            , null as route
-            , null as strength
+            , cast(null as {{ string_type }}) as route
+            , cast(null as {{ string_type }}) as strength
             , 30 as quantity
-            , null as quantity_unit
+            , cast(null as {{ string_type }}) as quantity_unit
             , 30 as days_supply
-            , null as practitioner_id
+            , cast(null as {{ string_type }}) as practitioner_id
             , cast('2024-02-03 04:05:06' as {{ timestamp_type }}) as ingest_datetime
             , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
             , 'source' as data_source

--- a/models/core/condition_unit_tests.yml
+++ b/models/core/condition_unit_tests.yml
@@ -65,7 +65,7 @@ unit_tests:
         format: sql
         rows: |
           {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
-          select 'icd-10-cm' as code_system, 'E039' as code, 'Endocrine & Metabolic Disease' as condition_family, 'Hypothyroidism' as condition, 'active' as status
+          select 'icd-10-cm' as code_system, 'E039' as code, 'Endocrine & Metabolic Disease' as condition_family, 'Hypothyroidism' as condition_name, 'active' as status
           union all select 'snomed-ct', '123456789', 'Respiratory Disease', 'Asthma', 'active'
           union all select 'icd-10-cm', 'R999', 'Symptoms, Signs & Abnormal Findings', 'Abnormal Clinical or Laboratory Findings', 'active'
           union all select 'ICD-10-CM', 'r99.9', 'Other', 'Other Specified and Unspecified Conditions', 'active'
@@ -79,31 +79,31 @@ unit_tests:
       rows:
         - condition_id: condition-icd-10-cm
           condition_family: Endocrine & Metabolic Disease
-          condition: Hypothyroidism
+          condition_name: Hypothyroidism
         - condition_id: condition-snomed-ct
           condition_family: Respiratory Disease
-          condition: Asthma
+          condition_name: Asthma
         - condition_id: condition-unsupported
           condition_family: null
-          condition: null
+          condition_name: null
         - condition_id: condition-ambiguous-map
           condition_family: null
-          condition: null
+          condition_name: null
         - condition_id: condition-identical-map-duplicates
           condition_family: Respiratory Disease
-          condition: Asthma
+          condition_name: Asthma
         - condition_id: condition-historical-active-map
           condition_family: Injury & Poisoning
-          condition: Sprain and Strain
+          condition_name: Sprain and Strain
         - condition_id: condition-inactive-map
           condition_family: null
-          condition: null
+          condition_name: null
         - condition_id: condition-incomplete-map
           condition_family: null
-          condition: null
+          condition_name: null
         - condition_id: condition-nonbillable-heading
           condition_family: Infectious Disease
-          condition: Fungal Infections
+          condition_name: Fungal Infections
 
   - name: test_claims_condition_stable_ids_and_semantics
     description: >-

--- a/models/core/condition_unit_tests.yml
+++ b/models/core/condition_unit_tests.yml
@@ -23,17 +23,8 @@ unit_tests:
         rows: |
           {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
-          with fixture_rows as (
-              select 'condition-icd-10-cm' as condition_id, 'person-1' as person_id, 'ICD-10-CM' as code_system, 'e03.9' as normalized_code
-              union all select 'condition-snomed-ct', 'person-2', 'snomed-ct', '123456789'
-              union all select 'condition-unsupported', 'person-3', 'icd-9-cm', '2449'
-              union all select 'condition-ambiguous-map', 'person-4', 'icd-10-cm', 'R99.9'
-              union all select 'condition-identical-map-duplicates', 'person-5', 'icd-10-cm', 'J45.909'
-              union all select 'condition-historical-active-map', 'person-6', 'icd-10-cm', 's23.420a'
-              union all select 'condition-inactive-map', 'person-7', 'icd-10-cm', 'B00.0'
-              union all select 'condition-incomplete-map', 'person-8', 'icd-10-cm', 'M99.9'
-              union all select 'condition-nonbillable-heading', 'person-9', 'icd-10-cm', 'b37'
-          )
+          -- Derived table rather than a leading CTE: T-SQL rejects a nested
+          -- WITH when this ephemeral input is inlined as a CTE by the unit test.
           select
               condition_id
             , cast(null as {{ string_type }}) as source_condition_id
@@ -59,7 +50,17 @@ unit_tests:
             , cast(null as {{ timestamp_type }}) as ingest_datetime
             , cast(null as {{ timestamp_type }}) as tuva_last_run
             , 'source' as data_source
-          from fixture_rows
+          from (
+              select 'condition-icd-10-cm' as condition_id, 'person-1' as person_id, 'ICD-10-CM' as code_system, 'e03.9' as normalized_code
+              union all select 'condition-snomed-ct', 'person-2', 'snomed-ct', '123456789'
+              union all select 'condition-unsupported', 'person-3', 'icd-9-cm', '2449'
+              union all select 'condition-ambiguous-map', 'person-4', 'icd-10-cm', 'R99.9'
+              union all select 'condition-identical-map-duplicates', 'person-5', 'icd-10-cm', 'J45.909'
+              union all select 'condition-historical-active-map', 'person-6', 'icd-10-cm', 's23.420a'
+              union all select 'condition-inactive-map', 'person-7', 'icd-10-cm', 'B00.0'
+              union all select 'condition-incomplete-map', 'person-8', 'icd-10-cm', 'M99.9'
+              union all select 'condition-nonbillable-heading', 'person-9', 'icd-10-cm', 'b37'
+          ) as fixture_rows
       - input: ref('tuva_condition_grouper_code_map')
         format: sql
         rows: |

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -496,7 +496,7 @@ models:
         config:
           meta:
             data_type: varchar
-      - name: condition
+      - name: condition_name
         description: Mutually exclusive condition assigned by the Tuva Condition
           Grouper. This field is populated when code_system is
           icd-10-cm or snomed-ct and normalized_code has one unambiguous active

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -3498,7 +3498,7 @@ models:
         config:
           meta:
             data_type: varchar
-      - name: procedure
+      - name: procedure_name
         description: Mutually exclusive analytic procedure assigned by the Tuva Procedure
           Grouper. Tuva populates this by joining normalized ICD-10-PCS procedure codes
           to tuva_procedure_grouper_code_map. This field remains null for HCPCS,

--- a/models/core/final/core__condition.sql
+++ b/models/core/final/core__condition.sql
@@ -45,7 +45,7 @@ with all_conditions as (
             else {{ the_tuva_project.trim('code') }}
         end as code
       , condition_family
-      , condition
+      , condition_name
     from {{ ref('tuva_condition_grouper_code_map') }}
     where lower({{ the_tuva_project.trim('status') }}) = 'active'
       and lower({{ the_tuva_project.trim('code_system') }}) in ('icd-10-cm', 'snomed-ct')
@@ -58,7 +58,7 @@ with all_conditions as (
         code_system
       , code
       , max(condition_family) as condition_family
-      , max(condition) as condition
+      , max(condition_name) as condition_name
     from active_condition_grouper_candidates
     group by
         code_system
@@ -66,9 +66,9 @@ with all_conditions as (
     -- Collapse identical duplicates, but fail closed when one normalized code
     -- has multiple active targets or an incomplete target.
     having count(condition_family) = count(*)
-       and count(condition) = count(*)
+       and count(condition_name) = count(*)
        and min(condition_family) = max(condition_family)
-       and min(condition) = max(condition)
+       and min(condition_name) = max(condition_name)
 
 )
 
@@ -92,7 +92,7 @@ select
   , all_conditions.normalized_code
   , all_conditions.normalized_description
   , condition_grouper.condition_family
-  , condition_grouper.condition
+  , condition_grouper.condition_name
   , all_conditions.condition_rank
   , all_conditions.present_on_admit_code
   , all_conditions.present_on_admit_description

--- a/models/core/final/core__procedure.sql
+++ b/models/core/final/core__procedure.sql
@@ -49,7 +49,7 @@ select
   , all_procedures.normalized_code
   , all_procedures.normalized_description
   , procedure_grouper.procedure_family
-  , procedure_grouper.{{ quote_column("procedure") }} as {{ quote_column("procedure") }}
+  , procedure_grouper.procedure_name as procedure_name
   , all_procedures.modifier_1
   , all_procedures.modifier_2
   , all_procedures.modifier_3

--- a/models/core/medical_claim_unit_tests.yml
+++ b/models/core/medical_claim_unit_tests.yml
@@ -22,7 +22,7 @@ unit_tests:
         rows: |
           {% set string_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' %}
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
-          {% set numeric_type = 'numeric' %}
+          {% set numeric_type = 'decimal(18, 2)' if target.type == 'athena' else 'numeric' %}
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
           {% set base_sql %}
               select

--- a/models/core/staging/core__stg_coderx_classes.sql
+++ b/models/core/staging/core__stg_coderx_classes.sql
@@ -8,26 +8,18 @@
 {%- set coderx_name_type = 'string' if target.type in ['bigquery', 'databricks'] else 'varchar(3000)' -%}
 {%- set coderx_string_type = 'varchar(256)' if target.type == 'redshift' else dbt.type_string() -%}
 
-with source_rows as (
-    select
-          nullif(cast(drug_id as {{ coderx_string_type }}), 'NULL') as drug_id
-        , nullif(cast(drug_name as {{ coderx_name_type }}), 'NULL') as drug_name
-        , nullif(cast(atc_1_code as {{ coderx_string_type }}), 'NULL') as atc_1_code
-        , nullif(cast(atc_1_name as {{ coderx_name_type }}), 'NULL') as atc_1_name
-        , nullif(cast(atc_2_code as {{ coderx_string_type }}), 'NULL') as atc_2_code
-        , nullif(cast(atc_2_name as {{ coderx_name_type }}), 'NULL') as atc_2_name
-        , nullif(cast(atc_3_code as {{ coderx_string_type }}), 'NULL') as atc_3_code
-        , nullif(cast(atc_3_name as {{ coderx_name_type }}), 'NULL') as atc_3_name
-        , nullif(cast(atc_4_code as {{ coderx_string_type }}), 'NULL') as atc_4_code
-        , nullif(cast(atc_4_name as {{ coderx_name_type }}), 'NULL') as atc_4_name
-    {% if the_tuva_project.tuva_boolean_var('use_coderx_enterprise', false) %}
-    from {{ source('coderx', 'classes') }}
-    {% else %}
-    from {{ ref('terminology__coderx_classes') }}
-    {% endif %}
-),
-
-ranked as (
+select
+      drug_id
+    , drug_name
+    , atc_1_code
+    , atc_1_name
+    , atc_2_code
+    , atc_2_name
+    , atc_3_code
+    , atc_3_name
+    , atc_4_code
+    , atc_4_name
+from (
     select
           *
         , row_number() over (
@@ -44,19 +36,23 @@ ranked as (
                   , coalesce(atc_1_name, '')
                   , coalesce(drug_name, '')
           ) as class_rank
-    from source_rows
-)
-
-select
-      drug_id
-    , drug_name
-    , atc_1_code
-    , atc_1_name
-    , atc_2_code
-    , atc_2_name
-    , atc_3_code
-    , atc_3_name
-    , atc_4_code
-    , atc_4_name
-from ranked
+    from (
+        select
+              nullif(cast(drug_id as {{ coderx_string_type }}), 'NULL') as drug_id
+            , nullif(cast(drug_name as {{ coderx_name_type }}), 'NULL') as drug_name
+            , nullif(cast(atc_1_code as {{ coderx_string_type }}), 'NULL') as atc_1_code
+            , nullif(cast(atc_1_name as {{ coderx_name_type }}), 'NULL') as atc_1_name
+            , nullif(cast(atc_2_code as {{ coderx_string_type }}), 'NULL') as atc_2_code
+            , nullif(cast(atc_2_name as {{ coderx_name_type }}), 'NULL') as atc_2_name
+            , nullif(cast(atc_3_code as {{ coderx_string_type }}), 'NULL') as atc_3_code
+            , nullif(cast(atc_3_name as {{ coderx_name_type }}), 'NULL') as atc_3_name
+            , nullif(cast(atc_4_code as {{ coderx_string_type }}), 'NULL') as atc_4_code
+            , nullif(cast(atc_4_name as {{ coderx_name_type }}), 'NULL') as atc_4_name
+        {% if the_tuva_project.tuva_boolean_var('use_coderx_enterprise', false) %}
+        from {{ source('coderx', 'classes') }}
+        {% else %}
+        from {{ ref('terminology__coderx_classes') }}
+        {% endif %}
+    ) as source_rows
+) as ranked
 where class_rank = 1

--- a/models/data_quality/logical/claims_logical_unit_tests.yml
+++ b/models/data_quality/logical/claims_logical_unit_tests.yml
@@ -262,7 +262,7 @@ unit_tests:
   - name: test_eligibility_binary_flags_are_integer_and_tristate
     description: >
       Verifies that public eligibility flags accept only integer 0 and 1,
-      preserve null as not applicable, and reject Boolean-style true and false.
+      preserve cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as not applicable, and reject Boolean-style true and false.
     model: data_quality__eligibility_span_flags
     config:
       enabled: "{{ (var('data_quality_enabled', false) and var('claims_enabled', false)) | as_bool }}"
@@ -274,7 +274,7 @@ unit_tests:
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select fixture_rows.*, cast(null as date) as file_date, cast(null as {{ timestamp_type }}) as ingest_datetime
           from (
-          select 'one_missing_date' as person_id, 'member' as member_id, cast('2024-01-01' as date) as enrollment_start_date, cast('2024-01-31' as date) as enrollment_end_date, 'payer' as payer, 'plan' as {{ plan_identifier }}, 'unknown' as sex, 'Unknown' as race, cast('1980-01-01' as date) as birth_date, cast(null as date) as death_date, '1' as death_flag, 'commercial' as payer_type, 'source' as data_source, '1' as hospice_flag, '0' as institutional_snp_flag, null as long_term_institutional_flag
+          select 'one_missing_date' as person_id, 'member' as member_id, cast('2024-01-01' as date) as enrollment_start_date, cast('2024-01-31' as date) as enrollment_end_date, 'payer' as payer, 'plan' as {{ plan_identifier }}, 'unknown' as sex, 'Unknown' as race, cast('1980-01-01' as date) as birth_date, cast(null as date) as death_date, '1' as death_flag, 'commercial' as payer_type, 'source' as data_source, '1' as hospice_flag, '0' as institutional_snp_flag, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as long_term_institutional_flag
           union all
           select 'invalid_numeric_values', 'member', cast('2024-01-01' as date), cast('2024-01-31' as date), 'payer', 'plan', 'unknown', 'Unknown', cast('1980-01-01' as date), cast('2024-01-15' as date), '2', 'commercial', 'source', '-1', '2', '3'
           union all
@@ -492,7 +492,7 @@ unit_tests:
       - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
-          select 'valid_ndc' as ndc11, null as ndc
+          select 'valid_ndc' as ndc11, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as ndc
     expect:
       rows:
         - claim_id: missing_values
@@ -626,7 +626,7 @@ unit_tests:
       - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
-          select 'valid_ndc' as ndc11, null as ndc
+          select 'valid_ndc' as ndc11, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as ndc
     expect:
       rows:
         - claim_id: paid_month_match
@@ -732,7 +732,7 @@ unit_tests:
       - input: ref('core__stg_coderx_packages')
         format: sql
         rows: |
-          select 'valid_ndc' as ndc11, null as ndc
+          select 'valid_ndc' as ndc11, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as ndc
     expect:
       rows:
         - claim_id: before_spine
@@ -789,20 +789,20 @@ unit_tests:
               , case when row_ids.claim_id = 'invalid_values' then cast('1899-12-31' as date) else cast('2024-01-01' as date) end as claim_line_end_date
               , case when row_ids.claim_id = 'invalid_values' then cast('1899-12-31' as date) when row_ids.claim_id = 'valid_values' then cast('2024-01-01' as date) else cast(null as date) end as admission_date
               , case when row_ids.claim_id = 'invalid_values' then cast('1899-12-31' as date) when row_ids.claim_id = 'valid_values' then cast('2024-01-01' as date) else cast(null as date) end as discharge_date
-              , null as admit_source_code
-              , null as admit_type_code
-              , null as discharge_disposition_code
-              , null as place_of_service_code
-              , null as bill_type_code
-              , null as revenue_center_code
-              , null as hcpcs_code
-              , null as rendering_npi
-              , null as billing_npi
-              , null as facility_npi
-              , null as drg_code_type
-              , null as drg_code
-              , null as diagnosis_code_type
-              , null as procedure_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_source_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_type_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as discharge_disposition_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as place_of_service_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as bill_type_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as revenue_center_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as hcpcs_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as rendering_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as billing_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as facility_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as diagnosis_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as procedure_code_type
               , case
                   when row_ids.claim_id = 'missing_paid_date' then cast(null as date)
                   when row_ids.claim_id = 'invalid_values' then cast('1899-12-31' as date)
@@ -811,10 +811,10 @@ unit_tests:
               , 1 as paid_amount
               , 2 as allowed_amount
               {% for index in range(1, 26) %}
-              , null as diagnosis_code_{{ index }}
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as diagnosis_code_{{ index }}
               {% endfor %}
               {% for index in range(1, 26) %}
-              , null as procedure_code_{{ index }}
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as procedure_code_{{ index }}
               {% endfor %}
               {% for index in range(1, 26) %}
               , case when row_ids.claim_id = 'invalid_values' then cast('1899-12-31' as date) when row_ids.claim_id = 'valid_values' then cast('2024-01-01' as date) else cast(null as date) end as procedure_date_{{ index }}
@@ -972,28 +972,28 @@ unit_tests:
               , cast('2024-01-01' as date) as claim_line_end_date
               , cast(null as date) as admission_date
               , cast(null as date) as discharge_date
-              , null as admit_source_code
-              , null as admit_type_code
-              , null as discharge_disposition_code
-              , null as place_of_service_code
-              , null as bill_type_code
-              , null as revenue_center_code
-              , null as hcpcs_code
-              , null as rendering_npi
-              , null as billing_npi
-              , null as facility_npi
-              , null as drg_code_type
-              , null as drg_code
-              , null as diagnosis_code_type
-              , null as procedure_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_source_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_type_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as discharge_disposition_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as place_of_service_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as bill_type_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as revenue_center_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as hcpcs_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as rendering_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as billing_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as facility_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as diagnosis_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as procedure_code_type
               , cast('2024-01-15' as date) as paid_date
               , 1 as paid_amount
               , 2 as allowed_amount
               {% for index in range(1, 26) %}
-              , null as diagnosis_code_{{ index }}
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as diagnosis_code_{{ index }}
               {% endfor %}
               {% for index in range(1, 26) %}
-              , null as procedure_code_{{ index }}
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as procedure_code_{{ index }}
               {% endfor %}
               {% for index in range(1, 26) %}
               , cast(null as date) as procedure_date_{{ index }}
@@ -1563,28 +1563,28 @@ unit_tests:
               , cases.claim_date as claim_line_end_date
               , cast(null as date) as admission_date
               , cast(null as date) as discharge_date
-              , null as admit_source_code
-              , null as admit_type_code
-              , null as discharge_disposition_code
-              , null as place_of_service_code
-              , null as bill_type_code
-              , null as revenue_center_code
-              , null as hcpcs_code
-              , null as rendering_npi
-              , null as billing_npi
-              , null as facility_npi
-              , null as drg_code_type
-              , null as drg_code
-              , null as diagnosis_code_type
-              , null as procedure_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_source_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_type_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as discharge_disposition_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as place_of_service_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as bill_type_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as revenue_center_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as hcpcs_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as rendering_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as billing_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as facility_npi
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as diagnosis_code_type
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as procedure_code_type
               , cases.claim_date as paid_date
               , 1 as paid_amount
               , 1 as allowed_amount
               {% for index in range(1, 26) %}
-              , null as diagnosis_code_{{ index }}
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as diagnosis_code_{{ index }}
               {% endfor %}
               {% for index in range(1, 26) %}
-              , null as procedure_code_{{ index }}
+              , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as procedure_code_{{ index }}
               {% endfor %}
               {% for index in range(1, 26) %}
               , cast(null as date) as procedure_date_{{ index }}

--- a/models/data_quality/logical/clinical_reference_unit_tests.yml
+++ b/models/data_quality/logical/clinical_reference_unit_tests.yml
@@ -129,13 +129,13 @@ unit_tests:
               'person_1' as person_id
             , 'integer_one' as patient_id
             , 'male' as sex
-            , null as race
-            , null as ethnicity
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as race
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as ethnicity
             , cast('1980-01-01' as date) as birth_date
             , cast('2020-01-01' as date) as death_date
             , 1 as death_flag
-            , null as state
-            , null as zip_code
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as state
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as zip_code
             , 'source' as data_source
           union all
           select 'person_2', 'integer_one_missing_date', 'male', null, null
@@ -199,9 +199,9 @@ unit_tests:
           select fixture_rows.*, cast(null as {{ timestamp_type }}) as ingest_datetime
           from (
           select 'case_variant_person' as person_id, 'lowercase_patient' as patient_id
-            , 'male' as sex, null as race, null as ethnicity
+            , 'male' as sex, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as race, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as ethnicity
             , cast('1980-01-01' as date) as birth_date, cast(null as date) as death_date
-            , 0 as death_flag, null as state, null as zip_code, 'source' as data_source
+            , 0 as death_flag, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as state, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as zip_code, 'source' as data_source
           union all
           select 'case_variant_person', 'uppercase_patient', 'Male', null, null
             , cast('1980-01-01' as date), cast(null as date), 0, null, null, 'source'
@@ -327,7 +327,7 @@ unit_tests:
         format: sql
         rows: |
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
-          select 'null_location' as location_id, null as npi, cast(null as {{ timestamp_type }}) as ingest_datetime, 'source' as data_source
+          select 'null_location' as location_id, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as npi, cast(null as {{ timestamp_type }}) as ingest_datetime, 'source' as data_source
           union all
           select 'valid_location', '1111111111', cast('2000-01-01' as {{ timestamp_type }}), 'source'
           union all
@@ -360,7 +360,7 @@ unit_tests:
         format: sql
         rows: |
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
-          select 'null_practitioner' as practitioner_id, null as npi, cast(null as {{ timestamp_type }}) as ingest_datetime, 'source' as data_source
+          select 'null_practitioner' as practitioner_id, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as npi, cast(null as {{ timestamp_type }}) as ingest_datetime, 'source' as data_source
           union all
           select 'individual_practitioner', '1111111111', cast('2000-01-01' as {{ timestamp_type }}), 'source'
           union all

--- a/models/data_quality/logical/clinical_semantic_unit_tests.yml
+++ b/models/data_quality/logical/clinical_semantic_unit_tests.yml
@@ -185,8 +185,8 @@ unit_tests:
           from (
           select 'valid' as source_condition_id, 'p1' as person_id, 'a1' as patient_id, 'e1' as encounter_id
             , cast('2020-01-01' as date) as recorded_date, cast('2010-01-01' as date) as onset_date
-            , cast('2020-01-01' as date) as resolved_date, null as code_system, null as source_code
-            , cast(null as integer) as condition_rank, null as present_on_admit_code, 'source' as data_source
+            , cast('2020-01-01' as date) as resolved_date, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as code_system, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_code
+            , cast(null as integer) as condition_rank, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as present_on_admit_code, 'source' as data_source
           union all
           select 'date_fail', 'p1', 'a1', 'e1'
             , cast('1899-01-01' as date), cast('2999-01-01' as date), cast('1899-01-01' as date)
@@ -300,8 +300,8 @@ unit_tests:
           select 'rank_valid' as source_condition_id, 'p1' as person_id, 'a1' as patient_id
             , cast(null as {{ string_type }}) as encounter_id
             , cast(null as date) as recorded_date, cast(null as date) as onset_date, cast(null as date) as resolved_date
-            , 'icd-10-cm' as code_system, null as source_code, 1 as condition_rank
-            , null as present_on_admit_code, 'source' as data_source
+            , 'icd-10-cm' as code_system, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_code, 1 as condition_rank
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as present_on_admit_code, 'source' as data_source
           union all
           select 'rank_negative', 'p1', 'a1', null
             , cast(null as date), cast(null as date), cast(null as date), null, null, -1, null, 'source'
@@ -377,10 +377,10 @@ unit_tests:
           select fixture_rows.*, cast(null as {{ timestamp_type }}) as ingest_datetime
           from (
           select 'pair_fail' as encounter_id, 'p1' as person_id, 'b2' as patient_id
-            , null as encounter_type, cast(null as date) as encounter_start_date, cast(null as date) as encounter_end_date
-            , null as admit_source_code, null as admit_type_code, null as discharge_disposition_code
-            , null as facility_npi, null as primary_diagnosis_code_type, null as primary_diagnosis_code
-            , null as drg_code_type, null as drg_code, 'source' as data_source
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as encounter_type, cast(null as date) as encounter_start_date, cast(null as date) as encounter_end_date
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_source_code, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as admit_type_code, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as discharge_disposition_code
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as facility_npi, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as primary_diagnosis_code_type, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as primary_diagnosis_code
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code_type, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as drg_code, 'source' as data_source
           union all
           select 'both_absent', 'p1', 'a1', null, cast(null as date), cast(null as date)
             , null, null, null, null, null, null, null, null, 'source'
@@ -795,7 +795,7 @@ unit_tests:
           from (
           select 'valid' as lab_result_id, 'p1' as person_id, 'a1' as patient_id, 'e1' as encounter_id
             , 'acc' as accession_number, 'loinc' as source_order_type, 'L1' as source_order_code
-            , null as source_component_type, null as source_component_code
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_component_type, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_component_code
             , cast('2020-01-02' as date) as result_datetime
             , cast('2020-01-01' as date) as collection_datetime, 'source' as data_source
           union all
@@ -993,9 +993,9 @@ unit_tests:
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select fixture_rows.*, cast(null as {{ timestamp_type }}) as ingest_datetime
           from (
-          select 'pair_fail' as medication_id, 'p1' as person_id, 'b2' as patient_id, null as encounter_id
-            , null as practitioner_id, cast(null as date) as dispensing_date, cast(null as date) as prescribing_date
-            , null as source_code_type, null as source_code, null as ndc_code, null as rxnorm_code, null as atc_code
+          select 'pair_fail' as medication_id, 'p1' as person_id, 'b2' as patient_id, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as encounter_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as practitioner_id, cast(null as date) as dispensing_date, cast(null as date) as prescribing_date
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_code_type, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_code, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as ndc_code, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as rxnorm_code, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as atc_code
             , cast(null as {{ 'numeric' if target.type == 'bigquery' else 'decimal(18, 2)' }}) as quantity
             , cast(null as {{ 'numeric' if target.type == 'bigquery' else 'decimal(18, 2)' }}) as days_supply, 'source' as data_source
           union all
@@ -1180,9 +1180,9 @@ unit_tests:
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select fixture_rows.*, cast(null as {{ timestamp_type }}) as ingest_datetime
           from (
-          select 'pair_fail' as observation_id, 'p1' as person_id, 'b2' as patient_id, null as encounter_id
-            , cast('2020-01-01' as date) as observation_date, null as observation_type
-            , null as source_code_type, null as source_code, 'source' as data_source
+          select 'pair_fail' as observation_id, 'p1' as person_id, 'b2' as patient_id, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as encounter_id
+            , cast('2020-01-01' as date) as observation_date, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as observation_type
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_code_type, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_code, 'source' as data_source
           union all
           select 'encounter_fail', 'p1', 'a1', 'e2', cast('2020-01-01' as date), null, null, null, 'source'
           union all
@@ -1307,9 +1307,9 @@ unit_tests:
           {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select fixture_rows.*, cast(null as {{ timestamp_type }}) as ingest_datetime
           from (
-          select 'pair_fail' as source_procedure_id, 'p1' as person_id, 'b2' as patient_id, null as encounter_id
-            , null as practitioner_id, cast('2020-01-01' as date) as procedure_date
-            , null as code_system, null as source_code, 'source' as data_source
+          select 'pair_fail' as source_procedure_id, 'p1' as person_id, 'b2' as patient_id, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as encounter_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as practitioner_id, cast('2020-01-01' as date) as procedure_date
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as code_system, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_code, 'source' as data_source
           union all
           select 'encounter_fail', 'p1', 'a1', 'e2', null, cast('2020-01-01' as date), null, null, 'source'
           union all
@@ -1425,20 +1425,20 @@ unit_tests:
               'case_match' as observation_id
             , 'p1' as person_id
             , 'a1' as patient_id
-            , null as encounter_id
-            , null as panel_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as encounter_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as panel_id
             , cast('2020-01-01' as date) as observation_date
             , 'vital-signs' as observation_type
             , 'LOINC' as source_code_type
             , 'L1' as source_code
             , 'Raw description' as source_description
             , '1' as result
-            , null as source_units
-            , null as normalized_units
-            , null as source_reference_range_low
-            , null as source_reference_range_high
-            , null as normalized_reference_range_low
-            , null as normalized_reference_range_high
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_units
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as normalized_units
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_reference_range_low
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as source_reference_range_high
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as normalized_reference_range_low
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as normalized_reference_range_high
             , cast('2024-03-04 05:06:07' as {{ timestamp_type }}) as ingest_datetime
             , 'source' as data_source
       - input: ref('terminology__icd_10_cm')
@@ -1515,13 +1515,13 @@ unit_tests:
               'ndc_case' as medication_id
             , 'clinical' as source_type
             , 'p1' as person_id
-            , null as member_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as member_id
             , 'a1' as patient_id
-            , null as encounter_id
-            , null as claim_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as encounter_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as claim_id
             , cast(null as integer) as claim_line_number
-            , null as payer
-            , null as {{ plan_identifier }}
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as payer
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as {{ plan_identifier }}
             , cast(null as date) as dispensing_date
             , cast(null as date) as prescribing_date
             , 'NDC' as source_code_type
@@ -1529,14 +1529,14 @@ unit_tests:
             , 'Raw NDC description' as source_description
             , cast(null as {{ string_type }}) as ndc_code
             , cast(null as {{ string_type }}) as ndc_description
-            , null as rxnorm_code
-            , null as atc_code
-            , null as route
-            , null as strength
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as rxnorm_code
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as atc_code
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as route
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as strength
             , cast(null as integer) as quantity
-            , null as quantity_unit
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as quantity_unit
             , cast(null as integer) as days_supply
-            , null as practitioner_id
+            , cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as practitioner_id
             , 'source' as data_source
             , cast('2024-03-04 05:06:07' as {{ timestamp_type }}) as ingest_datetime
             , cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run

--- a/models/data_quality/logical/data_quality__logical_failure_keys.sql
+++ b/models/data_quality/logical/data_quality__logical_failure_keys.sql
@@ -13,60 +13,38 @@
    )
 }}
 
-{% set key_queries = [] %}
-{% set string_type = dbt.type_string() %}
-
 {#
-  percent_escaped_v1 encodes key components in key_columns order. Null is N.
-  A non-null value is V plus its string value after replacing % with %25 and
-  then | with %7C; therefore an empty string is V. Components are joined by |.
-  Decode %7C before %25 so escaped percent sequences remain unambiguous.
+    The manifest is emitted by data_quality__logical_failure_keys_part_N, which
+    are implementation details rather than consumer contracts. Splitting it
+    keeps each generated statement inside Athena's 262,144-byte query-string
+    limit; this relation stays the stable public interface and is a thin union
+    over the parts. dq_logical_chunk_count sets how many parts there are.
 #}
-{% for definition in dq_enabled_logical_test_manifest() %}
-    {% set key_value_parts = [] %}
-    {% for key_column in definition['key_columns'] %}
-        {% set qualified_key_column = "flags." ~ quote_column(key_column) %}
-        {% set string_key_value = "cast(" ~ qualified_key_column ~ " as " ~ string_type ~ ")" %}
-        {% set escaped_key_value = "replace(replace(" ~ string_key_value ~ ", '%', '%25'), '|', '%7C')" %}
-        {% set encoded_component =
-            "case when " ~ qualified_key_column ~ " is null then 'N' else "
-            ~ concat_custom(["'V'", escaped_key_value])
-            ~ " end"
-        %}
-        {% do key_value_parts.append(encoded_component) %}
-        {% if not loop.last %}
-            {% do key_value_parts.append("'|'") %}
-        {% endif %}
-    {% endfor %}
 
-    {% set query %}
-        select
-              cast(flags.data_source as {{ string_type }}) as data_source
-            , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
-            , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
-            , {{ dq_string_literal_sql(definition['grain']) }} as grain
-            , {{ dq_string_literal_sql(definition['key_columns'] | join(',')) }} as key_columns
-            , 'percent_escaped_v1' as key_values_format
-            , {{ concat_custom(key_value_parts) }} as key_values
-        from {{ ref(definition['source_model_name']) }} as flags
-        where flags.{{ quote_column(definition['flag_column_name']) }} = 1
-    {% endset %}
-    {% do key_queries.append(query) %}
+{% set part_models = [] %}
+{% for chunk_index in range(the_tuva_project.dq_logical_chunk_count()) %}
+    {% do part_models.append(ref('data_quality__logical_failure_keys_part_' ~ (chunk_index + 1))) %}
 {% endfor %}
 
-{% if key_queries | length > 0 %}
-    select *
-    from (
-        {{ key_queries | join('\nunion all\n') }}
-    ) as logical_failure_keys
-{% else %}
+select
+      cast(data_source as {{ dbt.type_string() }}) as data_source
+    , cast(input_table_name as {{ dbt.type_string() }}) as input_table_name
+    , cast(test_name as {{ dbt.type_string() }}) as test_name
+    , cast(grain as {{ dbt.type_string() }}) as grain
+    , cast(key_columns as {{ dbt.type_string() }}) as key_columns
+    , cast(key_values_format as {{ dbt.type_string() }}) as key_values_format
+    , cast(key_values as {{ dbt.type_string() }}) as key_values
+from (
+    {% for part_model in part_models %}
     select
-          cast(null as {{ dbt.type_string() }}) as data_source
-        , cast(null as {{ dbt.type_string() }}) as input_table_name
-        , cast(null as {{ dbt.type_string() }}) as test_name
-        , cast(null as {{ dbt.type_string() }}) as grain
-        , cast(null as {{ dbt.type_string() }}) as key_columns
-        , cast(null as {{ dbt.type_string() }}) as key_values_format
-        , cast(null as {{ dbt.type_string() }}) as key_values
-    {{ dq_empty_result_guard_sql() }}
-{% endif %}
+          data_source
+        , input_table_name
+        , test_name
+        , grain
+        , key_columns
+        , key_values_format
+        , key_values
+    from {{ part_model }}
+    {% if not loop.last %}union all{% endif %}
+    {% endfor %}
+) as logical_failure_keys

--- a/models/data_quality/logical/data_quality__logical_failure_keys_part_1.sql
+++ b/models/data_quality/logical/data_quality__logical_failure_keys_part_1.sql
@@ -1,0 +1,79 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_failure_keys_part_1',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit. data_quality__logical_failure_keys
+    unions every part.
+#}
+
+{% set key_queries = [] %}
+{% set string_type = dbt.type_string() %}
+
+{#
+  percent_escaped_v1 encodes key components in key_columns order. Null is N.
+  A non-null value is V plus its string value after replacing % with %25 and
+  then | with %7C; therefore an empty string is V. Components are joined by |.
+  Decode %7C before %25 so escaped percent sequences remain unambiguous.
+#}
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk(0) %}
+    {% set key_value_parts = [] %}
+    {% for key_column in definition['key_columns'] %}
+        {% set qualified_key_column = "flags." ~ quote_column(key_column) %}
+        {% set string_key_value = "cast(" ~ qualified_key_column ~ " as " ~ string_type ~ ")" %}
+        {% set escaped_key_value = "replace(replace(" ~ string_key_value ~ ", '%', '%25'), '|', '%7C')" %}
+        {% set encoded_component =
+            "case when " ~ qualified_key_column ~ " is null then 'N' else "
+            ~ concat_custom(["'V'", escaped_key_value])
+            ~ " end"
+        %}
+        {% do key_value_parts.append(encoded_component) %}
+        {% if not loop.last %}
+            {% do key_value_parts.append("'|'") %}
+        {% endif %}
+    {% endfor %}
+
+    {% set query %}
+        select
+              cast(flags.data_source as {{ string_type }}) as data_source
+            , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+            , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+            , {{ dq_string_literal_sql(definition['grain']) }} as grain
+            , {{ dq_string_literal_sql(definition['key_columns'] | join(',')) }} as key_columns
+            , 'percent_escaped_v1' as key_values_format
+            , {{ concat_custom(key_value_parts) }} as key_values
+        from {{ ref(definition['source_model_name']) }} as flags
+        where flags.{{ quote_column(definition['flag_column_name']) }} = 1
+    {% endset %}
+    {% do key_queries.append(query) %}
+{% endfor %}
+
+{% if key_queries | length > 0 %}
+    select *
+    from (
+        {{ key_queries | join('\nunion all\n') }}
+    ) as logical_failure_keys_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as key_columns
+        , cast(null as {{ dbt.type_string() }}) as key_values_format
+        , cast(null as {{ dbt.type_string() }}) as key_values
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/data_quality__logical_failure_keys_part_2.sql
+++ b/models/data_quality/logical/data_quality__logical_failure_keys_part_2.sql
@@ -1,0 +1,79 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_failure_keys_part_2',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit. data_quality__logical_failure_keys
+    unions every part.
+#}
+
+{% set key_queries = [] %}
+{% set string_type = dbt.type_string() %}
+
+{#
+  percent_escaped_v1 encodes key components in key_columns order. Null is N.
+  A non-null value is V plus its string value after replacing % with %25 and
+  then | with %7C; therefore an empty string is V. Components are joined by |.
+  Decode %7C before %25 so escaped percent sequences remain unambiguous.
+#}
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk(1) %}
+    {% set key_value_parts = [] %}
+    {% for key_column in definition['key_columns'] %}
+        {% set qualified_key_column = "flags." ~ quote_column(key_column) %}
+        {% set string_key_value = "cast(" ~ qualified_key_column ~ " as " ~ string_type ~ ")" %}
+        {% set escaped_key_value = "replace(replace(" ~ string_key_value ~ ", '%', '%25'), '|', '%7C')" %}
+        {% set encoded_component =
+            "case when " ~ qualified_key_column ~ " is null then 'N' else "
+            ~ concat_custom(["'V'", escaped_key_value])
+            ~ " end"
+        %}
+        {% do key_value_parts.append(encoded_component) %}
+        {% if not loop.last %}
+            {% do key_value_parts.append("'|'") %}
+        {% endif %}
+    {% endfor %}
+
+    {% set query %}
+        select
+              cast(flags.data_source as {{ string_type }}) as data_source
+            , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+            , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+            , {{ dq_string_literal_sql(definition['grain']) }} as grain
+            , {{ dq_string_literal_sql(definition['key_columns'] | join(',')) }} as key_columns
+            , 'percent_escaped_v1' as key_values_format
+            , {{ concat_custom(key_value_parts) }} as key_values
+        from {{ ref(definition['source_model_name']) }} as flags
+        where flags.{{ quote_column(definition['flag_column_name']) }} = 1
+    {% endset %}
+    {% do key_queries.append(query) %}
+{% endfor %}
+
+{% if key_queries | length > 0 %}
+    select *
+    from (
+        {{ key_queries | join('\nunion all\n') }}
+    ) as logical_failure_keys_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as key_columns
+        , cast(null as {{ dbt.type_string() }}) as key_values_format
+        , cast(null as {{ dbt.type_string() }}) as key_values
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/data_quality__logical_failure_keys_part_3.sql
+++ b/models/data_quality/logical/data_quality__logical_failure_keys_part_3.sql
@@ -1,0 +1,79 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_failure_keys_part_3',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit. data_quality__logical_failure_keys
+    unions every part.
+#}
+
+{% set key_queries = [] %}
+{% set string_type = dbt.type_string() %}
+
+{#
+  percent_escaped_v1 encodes key components in key_columns order. Null is N.
+  A non-null value is V plus its string value after replacing % with %25 and
+  then | with %7C; therefore an empty string is V. Components are joined by |.
+  Decode %7C before %25 so escaped percent sequences remain unambiguous.
+#}
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk(2) %}
+    {% set key_value_parts = [] %}
+    {% for key_column in definition['key_columns'] %}
+        {% set qualified_key_column = "flags." ~ quote_column(key_column) %}
+        {% set string_key_value = "cast(" ~ qualified_key_column ~ " as " ~ string_type ~ ")" %}
+        {% set escaped_key_value = "replace(replace(" ~ string_key_value ~ ", '%', '%25'), '|', '%7C')" %}
+        {% set encoded_component =
+            "case when " ~ qualified_key_column ~ " is null then 'N' else "
+            ~ concat_custom(["'V'", escaped_key_value])
+            ~ " end"
+        %}
+        {% do key_value_parts.append(encoded_component) %}
+        {% if not loop.last %}
+            {% do key_value_parts.append("'|'") %}
+        {% endif %}
+    {% endfor %}
+
+    {% set query %}
+        select
+              cast(flags.data_source as {{ string_type }}) as data_source
+            , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+            , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+            , {{ dq_string_literal_sql(definition['grain']) }} as grain
+            , {{ dq_string_literal_sql(definition['key_columns'] | join(',')) }} as key_columns
+            , 'percent_escaped_v1' as key_values_format
+            , {{ concat_custom(key_value_parts) }} as key_values
+        from {{ ref(definition['source_model_name']) }} as flags
+        where flags.{{ quote_column(definition['flag_column_name']) }} = 1
+    {% endset %}
+    {% do key_queries.append(query) %}
+{% endfor %}
+
+{% if key_queries | length > 0 %}
+    select *
+    from (
+        {{ key_queries | join('\nunion all\n') }}
+    ) as logical_failure_keys_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as key_columns
+        , cast(null as {{ dbt.type_string() }}) as key_values_format
+        , cast(null as {{ dbt.type_string() }}) as key_values
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/data_quality__logical_failure_keys_part_4.sql
+++ b/models/data_quality/logical/data_quality__logical_failure_keys_part_4.sql
@@ -1,0 +1,79 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and (the_tuva_project.tuva_boolean_var('enable_data_quality_failure_keys', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_failure_keys_part_4',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit. data_quality__logical_failure_keys
+    unions every part.
+#}
+
+{% set key_queries = [] %}
+{% set string_type = dbt.type_string() %}
+
+{#
+  percent_escaped_v1 encodes key components in key_columns order. Null is N.
+  A non-null value is V plus its string value after replacing % with %25 and
+  then | with %7C; therefore an empty string is V. Components are joined by |.
+  Decode %7C before %25 so escaped percent sequences remain unambiguous.
+#}
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk(3) %}
+    {% set key_value_parts = [] %}
+    {% for key_column in definition['key_columns'] %}
+        {% set qualified_key_column = "flags." ~ quote_column(key_column) %}
+        {% set string_key_value = "cast(" ~ qualified_key_column ~ " as " ~ string_type ~ ")" %}
+        {% set escaped_key_value = "replace(replace(" ~ string_key_value ~ ", '%', '%25'), '|', '%7C')" %}
+        {% set encoded_component =
+            "case when " ~ qualified_key_column ~ " is null then 'N' else "
+            ~ concat_custom(["'V'", escaped_key_value])
+            ~ " end"
+        %}
+        {% do key_value_parts.append(encoded_component) %}
+        {% if not loop.last %}
+            {% do key_value_parts.append("'|'") %}
+        {% endif %}
+    {% endfor %}
+
+    {% set query %}
+        select
+              cast(flags.data_source as {{ string_type }}) as data_source
+            , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+            , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+            , {{ dq_string_literal_sql(definition['grain']) }} as grain
+            , {{ dq_string_literal_sql(definition['key_columns'] | join(',')) }} as key_columns
+            , 'percent_escaped_v1' as key_values_format
+            , {{ concat_custom(key_value_parts) }} as key_values
+        from {{ ref(definition['source_model_name']) }} as flags
+        where flags.{{ quote_column(definition['flag_column_name']) }} = 1
+    {% endset %}
+    {% do key_queries.append(query) %}
+{% endfor %}
+
+{% if key_queries | length > 0 %}
+    select *
+    from (
+        {{ key_queries | join('\nunion all\n') }}
+    ) as logical_failure_keys_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as key_columns
+        , cast(null as {{ dbt.type_string() }}) as key_values_format
+        , cast(null as {{ dbt.type_string() }}) as key_values
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/data_quality__logical_test_catalog.sql
+++ b/models/data_quality/logical/data_quality__logical_test_catalog.sql
@@ -12,23 +12,30 @@
    )
 }}
 
+{#
+    Only the first UNION ALL branch carries column aliases; the rest inherit
+    them positionally. With one branch per logical test this keeps the
+    generated statement well inside Athena's 262,144-byte query-string limit,
+    which the fully-aliased form exceeded.
+#}
+
 {% set catalog_queries = [] %}
 
 {% for definition in dq_enabled_logical_test_manifest() %}
     {% set query %}
         select
-              {{ dq_string_literal_sql(definition['test_name']) }} as test_name
-            , {{ dq_string_literal_sql(definition['display_name']) }} as display_name
-            , {{ dq_string_literal_sql(definition['description']) }} as description
-            , {{ dq_string_literal_sql(definition['input_model_name']) }} as input_model_name
-            , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
-            , {{ dq_string_literal_sql(definition['source_model_name']) }} as flag_model_name
-            , {{ dq_string_literal_sql(definition['flag_table_name']) }} as flag_table_name
-            , {{ dq_string_literal_sql(definition['flag_column_name']) }} as flag_column_name
-            , {{ dq_string_literal_sql(definition['grain']) }} as grain
-            , {{ dq_string_literal_sql(definition['key_columns'] | join(',')) }} as key_columns
-            , {{ dq_string_literal_sql(definition['test_type']) }} as test_type
-            , cast({{ definition['severity'] }} as {{ dbt.type_int() }}) as severity
+              {{ dq_string_literal_sql(definition['test_name']) }}{{ ' as test_name' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['display_name']) }}{{ ' as display_name' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['description']) }}{{ ' as description' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['input_model_name']) }}{{ ' as input_model_name' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['input_table_name']) }}{{ ' as input_table_name' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['source_model_name']) }}{{ ' as flag_model_name' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['flag_table_name']) }}{{ ' as flag_table_name' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['flag_column_name']) }}{{ ' as flag_column_name' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['grain']) }}{{ ' as grain' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['key_columns'] | join(',')) }}{{ ' as key_columns' if loop.first else '' }}
+            , {{ dq_string_literal_sql(definition['test_type']) }}{{ ' as test_type' if loop.first else '' }}
+            , cast({{ definition['severity'] }} as {{ dbt.type_int() }}){{ ' as severity' if loop.first else '' }}
     {% endset %}
     {% do catalog_queries.append(query) %}
 {% endfor %}

--- a/models/data_quality/logical/data_quality__logical_test_results.sql
+++ b/models/data_quality/logical/data_quality__logical_test_results.sql
@@ -12,158 +12,54 @@
    )
 }}
 
-{% set definitions_by_model = {} %}
+{#
+    The manifest is emitted by data_quality__logical_test_results_part_N, which
+    are implementation details rather than consumer contracts. Splitting it on
+    whole flag models keeps each generated statement inside Athena's
+    262,144-byte query-string limit; this relation stays the stable public
+    interface and is a thin union over the parts.
+#}
 
-{% for definition in dq_enabled_logical_test_manifest() %}
-    {% set source_model_name = definition['source_model_name'] %}
-    {% if definitions_by_model.get(source_model_name) is none %}
-        {% do definitions_by_model.update({source_model_name: []}) %}
-    {% endif %}
-    {% do definitions_by_model[source_model_name].append(definition) %}
+{% set part_models = [] %}
+{% for chunk_index in range(the_tuva_project.dq_logical_chunk_count()) %}
+    {% do part_models.append(ref('data_quality__logical_test_results_part_' ~ (chunk_index + 1))) %}
 {% endfor %}
 
-{% set aggregate_ctes = [] %}
-{% set test_definition_ctes = [] %}
-{% set result_queries = [] %}
-
-{% for source_model_name, model_definitions in definitions_by_model.items() %}
-    {% set model_index = loop.index %}
-    {% set aggregate_columns = [] %}
-    {% set test_definition_queries = [] %}
-    {% set tested_count_cases = [] %}
-    {% set failed_count_cases = [] %}
-    {% set not_applicable_count_cases = [] %}
-
-    {% for definition in model_definitions %}
-        {% set test_ordinal = loop.index %}
-        {% set flag_column = quote_column(definition['flag_column_name']) %}
-
-        {% do aggregate_columns.append(
-            "cast(sum(cast(case when " ~ flag_column ~ " in (0, 1) then 1 else 0 end as "
-            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as tested_count_" ~ test_ordinal
-        ) %}
-        {% do aggregate_columns.append(
-            "cast(sum(cast(coalesce(" ~ flag_column ~ ", 0) as " ~ dbt.type_bigint() ~ ")) as "
-            ~ dbt.type_bigint() ~ ") as failed_count_" ~ test_ordinal
-        ) %}
-        {% do aggregate_columns.append(
-            "cast(sum(cast(case when " ~ flag_column ~ " is null then 1 else 0 end as "
-            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as not_applicable_count_" ~ test_ordinal
-        ) %}
-
-        {% set test_definition_query %}
-            select
-                  cast({{ test_ordinal }} as {{ dbt.type_int() }}) as test_ordinal
-                , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
-                , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
-                , {{ dq_string_literal_sql(definition['display_name']) }} as display_name
-                , {{ dq_string_literal_sql(definition['description']) }} as description
-                , {{ dq_string_literal_sql(definition['grain']) }} as grain
-                , {{ dq_string_literal_sql(definition['flag_table_name']) }} as flag_table_name
-                , {{ dq_string_literal_sql(definition['flag_column_name']) }} as flag_column_name
-                , {{ dq_string_literal_sql(definition['test_type']) }} as test_type
-                , cast({{ definition['severity'] }} as {{ dbt.type_int() }}) as severity
-        {% endset %}
-        {% do test_definition_queries.append(test_definition_query | trim) %}
-        {% do tested_count_cases.append(
-            "when " ~ test_ordinal ~ " then flag_aggregates.tested_count_" ~ test_ordinal
-        ) %}
-        {% do failed_count_cases.append(
-            "when " ~ test_ordinal ~ " then flag_aggregates.failed_count_" ~ test_ordinal
-        ) %}
-        {% do not_applicable_count_cases.append(
-            "when " ~ test_ordinal ~ " then flag_aggregates.not_applicable_count_" ~ test_ordinal
-        ) %}
-    {% endfor %}
-
-    {% set aggregate_cte %}
-        logical_model_{{ model_index }}_aggregates as (
-            select
-                  cast(data_source as {{ dbt.type_string() }}) as data_source
-                , cast(
-                    sum(cast(1 as {{ dbt.type_bigint() }}))
-                    as {{ dbt.type_bigint() }}
-                  ) as total_row_count
-                , {{ aggregate_columns | join('\n                , ') }}
-            from {{ ref(source_model_name) }}
-            group by cast(data_source as {{ dbt.type_string() }})
-        )
-    {% endset %}
-    {% do aggregate_ctes.append(aggregate_cte | trim) %}
-
-    {% set test_definition_cte %}
-        logical_model_{{ model_index }}_tests as (
-            {{ test_definition_queries | join('\n            union all\n') }}
-        )
-    {% endset %}
-    {% do test_definition_ctes.append(test_definition_cte | trim) %}
-
-    {% set result_query %}
-        select
-              flag_aggregates.data_source
-            , test_definitions.input_table_name
-            , test_definitions.test_name
-            , test_definitions.display_name
-            , test_definitions.description
-            , test_definitions.grain
-            , test_definitions.flag_table_name
-            , test_definitions.flag_column_name
-            , test_definitions.test_type
-            , test_definitions.severity
-            , flag_aggregates.total_row_count
-            , cast(
-                case test_definitions.test_ordinal
-                    {{ tested_count_cases | join('\n                    ') }}
-                end
-              as {{ dbt.type_bigint() }}) as tested_count
-            , cast(
-                case test_definitions.test_ordinal
-                    {{ failed_count_cases | join('\n                    ') }}
-                end
-              as {{ dbt.type_bigint() }}) as failed_count
-            , cast(
-                case test_definitions.test_ordinal
-                    {{ tested_count_cases | join('\n                    ') }}
-                end
-                - case test_definitions.test_ordinal
-                    {{ failed_count_cases | join('\n                    ') }}
-                end
-              as {{ dbt.type_bigint() }}) as passed_count
-            , cast(
-                case test_definitions.test_ordinal
-                    {{ not_applicable_count_cases | join('\n                    ') }}
-                end
-              as {{ dbt.type_bigint() }}) as not_applicable_count
-        from logical_model_{{ model_index }}_aggregates as flag_aggregates
-        cross join logical_model_{{ model_index }}_tests as test_definitions
-    {% endset %}
-    {% do result_queries.append(result_query | trim) %}
-{% endfor %}
-
-{% if result_queries | length > 0 %}
-    with
-    {{ (aggregate_ctes + test_definition_ctes) | join('\n    , ') }}
-
-    select *
-    from (
-        {{ result_queries | join('\n        union all\n') }}
-    ) as logical_test_results
-{% else %}
+select
+      cast(data_source as {{ dbt.type_string() }}) as data_source
+    , cast(input_table_name as {{ dbt.type_string() }}) as input_table_name
+    , cast(test_name as {{ dbt.type_string() }}) as test_name
+    , cast(display_name as {{ dbt.type_string() }}) as display_name
+    , cast(description as {{ dbt.type_string() }}) as description
+    , cast(grain as {{ dbt.type_string() }}) as grain
+    , cast(flag_table_name as {{ dbt.type_string() }}) as flag_table_name
+    , cast(flag_column_name as {{ dbt.type_string() }}) as flag_column_name
+    , cast(test_type as {{ dbt.type_string() }}) as test_type
+    , cast(severity as {{ dbt.type_int() }}) as severity
+    , cast(total_row_count as {{ dbt.type_bigint() }}) as total_row_count
+    , cast(tested_count as {{ dbt.type_bigint() }}) as tested_count
+    , cast(failed_count as {{ dbt.type_bigint() }}) as failed_count
+    , cast(passed_count as {{ dbt.type_bigint() }}) as passed_count
+    , cast(not_applicable_count as {{ dbt.type_bigint() }}) as not_applicable_count
+from (
+    {% for part_model in part_models %}
     select
-          cast(null as {{ dbt.type_string() }}) as data_source
-        , cast(null as {{ dbt.type_string() }}) as input_table_name
-        , cast(null as {{ dbt.type_string() }}) as test_name
-        , cast(null as {{ dbt.type_string() }}) as display_name
-        , cast(null as {{ dbt.type_string() }}) as description
-        , cast(null as {{ dbt.type_string() }}) as grain
-        , cast(null as {{ dbt.type_string() }}) as flag_table_name
-        , cast(null as {{ dbt.type_string() }}) as flag_column_name
-        , cast(null as {{ dbt.type_string() }}) as test_type
-        , cast(null as {{ dbt.type_int() }}) as severity
-        , cast(null as {{ dbt.type_bigint() }}) as total_row_count
-        , cast(null as {{ dbt.type_bigint() }}) as tested_count
-        , cast(null as {{ dbt.type_bigint() }}) as failed_count
-        , cast(null as {{ dbt.type_bigint() }}) as passed_count
-        , cast(null as {{ dbt.type_bigint() }}) as not_applicable_count
-    {{ dq_empty_result_guard_sql() }}
-{% endif %}
+          data_source
+        , input_table_name
+        , test_name
+        , display_name
+        , description
+        , grain
+        , flag_table_name
+        , flag_column_name
+        , test_type
+        , severity
+        , total_row_count
+        , tested_count
+        , failed_count
+        , passed_count
+        , not_applicable_count
+    from {{ part_model }}
+    {% if not loop.last %}union all{% endif %}
+    {% endfor %}
+) as logical_test_results

--- a/models/data_quality/logical/data_quality__logical_test_results_part_1.sql
+++ b/models/data_quality/logical/data_quality__logical_test_results_part_1.sql
@@ -1,0 +1,177 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_test_results_part_1',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, split on whole flag models so per-model aggregates stay
+    correct, and kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit.
+    data_quality__logical_test_results unions every part.
+#}
+
+{% set definitions_by_model = {} %}
+
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk_by_model(0) %}
+    {% set source_model_name = definition['source_model_name'] %}
+    {% if definitions_by_model.get(source_model_name) is none %}
+        {% do definitions_by_model.update({source_model_name: []}) %}
+    {% endif %}
+    {% do definitions_by_model[source_model_name].append(definition) %}
+{% endfor %}
+
+{% set aggregate_ctes = [] %}
+{% set test_definition_ctes = [] %}
+{% set result_queries = [] %}
+
+{% for source_model_name, model_definitions in definitions_by_model.items() %}
+    {% set model_index = loop.index %}
+    {% set aggregate_columns = [] %}
+    {% set test_definition_queries = [] %}
+    {% set tested_count_cases = [] %}
+    {% set failed_count_cases = [] %}
+    {% set not_applicable_count_cases = [] %}
+
+    {% for definition in model_definitions %}
+        {% set test_ordinal = loop.index %}
+        {% set flag_column = quote_column(definition['flag_column_name']) %}
+
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " in (0, 1) then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as tested_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(coalesce(" ~ flag_column ~ ", 0) as " ~ dbt.type_bigint() ~ ")) as "
+            ~ dbt.type_bigint() ~ ") as failed_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " is null then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as not_applicable_count_" ~ test_ordinal
+        ) %}
+
+        {% set test_definition_query %}
+            select
+                  cast({{ test_ordinal }} as {{ dbt.type_int() }}) as test_ordinal
+                , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+                , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+                , {{ dq_string_literal_sql(definition['display_name']) }} as display_name
+                , {{ dq_string_literal_sql(definition['description']) }} as description
+                , {{ dq_string_literal_sql(definition['grain']) }} as grain
+                , {{ dq_string_literal_sql(definition['flag_table_name']) }} as flag_table_name
+                , {{ dq_string_literal_sql(definition['flag_column_name']) }} as flag_column_name
+                , {{ dq_string_literal_sql(definition['test_type']) }} as test_type
+                , cast({{ definition['severity'] }} as {{ dbt.type_int() }}) as severity
+        {% endset %}
+        {% do test_definition_queries.append(test_definition_query | trim) %}
+        {% do tested_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.tested_count_" ~ test_ordinal
+        ) %}
+        {% do failed_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.failed_count_" ~ test_ordinal
+        ) %}
+        {% do not_applicable_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.not_applicable_count_" ~ test_ordinal
+        ) %}
+    {% endfor %}
+
+    {% set aggregate_cte %}
+        logical_model_{{ model_index }}_aggregates as (
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , cast(
+                    sum(cast(1 as {{ dbt.type_bigint() }}))
+                    as {{ dbt.type_bigint() }}
+                  ) as total_row_count
+                , {{ aggregate_columns | join('\n                , ') }}
+            from {{ ref(source_model_name) }}
+            group by cast(data_source as {{ dbt.type_string() }})
+        )
+    {% endset %}
+    {% do aggregate_ctes.append(aggregate_cte | trim) %}
+
+    {% set test_definition_cte %}
+        logical_model_{{ model_index }}_tests as (
+            {{ test_definition_queries | join('\n            union all\n') }}
+        )
+    {% endset %}
+    {% do test_definition_ctes.append(test_definition_cte | trim) %}
+
+    {% set result_query %}
+        select
+              flag_aggregates.data_source
+            , test_definitions.input_table_name
+            , test_definitions.test_name
+            , test_definitions.display_name
+            , test_definitions.description
+            , test_definitions.grain
+            , test_definitions.flag_table_name
+            , test_definitions.flag_column_name
+            , test_definitions.test_type
+            , test_definitions.severity
+            , flag_aggregates.total_row_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as tested_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as failed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+                - case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as passed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ not_applicable_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as not_applicable_count
+        from logical_model_{{ model_index }}_aggregates as flag_aggregates
+        cross join logical_model_{{ model_index }}_tests as test_definitions
+    {% endset %}
+    {% do result_queries.append(result_query | trim) %}
+{% endfor %}
+
+{% if result_queries | length > 0 %}
+    with
+    {{ (aggregate_ctes + test_definition_ctes) | join('\n    , ') }}
+
+    select *
+    from (
+        {{ result_queries | join('\n        union all\n') }}
+    ) as logical_test_results_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as display_name
+        , cast(null as {{ dbt.type_string() }}) as description
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as flag_table_name
+        , cast(null as {{ dbt.type_string() }}) as flag_column_name
+        , cast(null as {{ dbt.type_string() }}) as test_type
+        , cast(null as {{ dbt.type_int() }}) as severity
+        , cast(null as {{ dbt.type_bigint() }}) as total_row_count
+        , cast(null as {{ dbt.type_bigint() }}) as tested_count
+        , cast(null as {{ dbt.type_bigint() }}) as failed_count
+        , cast(null as {{ dbt.type_bigint() }}) as passed_count
+        , cast(null as {{ dbt.type_bigint() }}) as not_applicable_count
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/data_quality__logical_test_results_part_2.sql
+++ b/models/data_quality/logical/data_quality__logical_test_results_part_2.sql
@@ -1,0 +1,177 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_test_results_part_2',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, split on whole flag models so per-model aggregates stay
+    correct, and kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit.
+    data_quality__logical_test_results unions every part.
+#}
+
+{% set definitions_by_model = {} %}
+
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk_by_model(1) %}
+    {% set source_model_name = definition['source_model_name'] %}
+    {% if definitions_by_model.get(source_model_name) is none %}
+        {% do definitions_by_model.update({source_model_name: []}) %}
+    {% endif %}
+    {% do definitions_by_model[source_model_name].append(definition) %}
+{% endfor %}
+
+{% set aggregate_ctes = [] %}
+{% set test_definition_ctes = [] %}
+{% set result_queries = [] %}
+
+{% for source_model_name, model_definitions in definitions_by_model.items() %}
+    {% set model_index = loop.index %}
+    {% set aggregate_columns = [] %}
+    {% set test_definition_queries = [] %}
+    {% set tested_count_cases = [] %}
+    {% set failed_count_cases = [] %}
+    {% set not_applicable_count_cases = [] %}
+
+    {% for definition in model_definitions %}
+        {% set test_ordinal = loop.index %}
+        {% set flag_column = quote_column(definition['flag_column_name']) %}
+
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " in (0, 1) then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as tested_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(coalesce(" ~ flag_column ~ ", 0) as " ~ dbt.type_bigint() ~ ")) as "
+            ~ dbt.type_bigint() ~ ") as failed_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " is null then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as not_applicable_count_" ~ test_ordinal
+        ) %}
+
+        {% set test_definition_query %}
+            select
+                  cast({{ test_ordinal }} as {{ dbt.type_int() }}) as test_ordinal
+                , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+                , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+                , {{ dq_string_literal_sql(definition['display_name']) }} as display_name
+                , {{ dq_string_literal_sql(definition['description']) }} as description
+                , {{ dq_string_literal_sql(definition['grain']) }} as grain
+                , {{ dq_string_literal_sql(definition['flag_table_name']) }} as flag_table_name
+                , {{ dq_string_literal_sql(definition['flag_column_name']) }} as flag_column_name
+                , {{ dq_string_literal_sql(definition['test_type']) }} as test_type
+                , cast({{ definition['severity'] }} as {{ dbt.type_int() }}) as severity
+        {% endset %}
+        {% do test_definition_queries.append(test_definition_query | trim) %}
+        {% do tested_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.tested_count_" ~ test_ordinal
+        ) %}
+        {% do failed_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.failed_count_" ~ test_ordinal
+        ) %}
+        {% do not_applicable_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.not_applicable_count_" ~ test_ordinal
+        ) %}
+    {% endfor %}
+
+    {% set aggregate_cte %}
+        logical_model_{{ model_index }}_aggregates as (
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , cast(
+                    sum(cast(1 as {{ dbt.type_bigint() }}))
+                    as {{ dbt.type_bigint() }}
+                  ) as total_row_count
+                , {{ aggregate_columns | join('\n                , ') }}
+            from {{ ref(source_model_name) }}
+            group by cast(data_source as {{ dbt.type_string() }})
+        )
+    {% endset %}
+    {% do aggregate_ctes.append(aggregate_cte | trim) %}
+
+    {% set test_definition_cte %}
+        logical_model_{{ model_index }}_tests as (
+            {{ test_definition_queries | join('\n            union all\n') }}
+        )
+    {% endset %}
+    {% do test_definition_ctes.append(test_definition_cte | trim) %}
+
+    {% set result_query %}
+        select
+              flag_aggregates.data_source
+            , test_definitions.input_table_name
+            , test_definitions.test_name
+            , test_definitions.display_name
+            , test_definitions.description
+            , test_definitions.grain
+            , test_definitions.flag_table_name
+            , test_definitions.flag_column_name
+            , test_definitions.test_type
+            , test_definitions.severity
+            , flag_aggregates.total_row_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as tested_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as failed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+                - case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as passed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ not_applicable_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as not_applicable_count
+        from logical_model_{{ model_index }}_aggregates as flag_aggregates
+        cross join logical_model_{{ model_index }}_tests as test_definitions
+    {% endset %}
+    {% do result_queries.append(result_query | trim) %}
+{% endfor %}
+
+{% if result_queries | length > 0 %}
+    with
+    {{ (aggregate_ctes + test_definition_ctes) | join('\n    , ') }}
+
+    select *
+    from (
+        {{ result_queries | join('\n        union all\n') }}
+    ) as logical_test_results_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as display_name
+        , cast(null as {{ dbt.type_string() }}) as description
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as flag_table_name
+        , cast(null as {{ dbt.type_string() }}) as flag_column_name
+        , cast(null as {{ dbt.type_string() }}) as test_type
+        , cast(null as {{ dbt.type_int() }}) as severity
+        , cast(null as {{ dbt.type_bigint() }}) as total_row_count
+        , cast(null as {{ dbt.type_bigint() }}) as tested_count
+        , cast(null as {{ dbt.type_bigint() }}) as failed_count
+        , cast(null as {{ dbt.type_bigint() }}) as passed_count
+        , cast(null as {{ dbt.type_bigint() }}) as not_applicable_count
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/data_quality__logical_test_results_part_3.sql
+++ b/models/data_quality/logical/data_quality__logical_test_results_part_3.sql
@@ -1,0 +1,177 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_test_results_part_3',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, split on whole flag models so per-model aggregates stay
+    correct, and kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit.
+    data_quality__logical_test_results unions every part.
+#}
+
+{% set definitions_by_model = {} %}
+
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk_by_model(2) %}
+    {% set source_model_name = definition['source_model_name'] %}
+    {% if definitions_by_model.get(source_model_name) is none %}
+        {% do definitions_by_model.update({source_model_name: []}) %}
+    {% endif %}
+    {% do definitions_by_model[source_model_name].append(definition) %}
+{% endfor %}
+
+{% set aggregate_ctes = [] %}
+{% set test_definition_ctes = [] %}
+{% set result_queries = [] %}
+
+{% for source_model_name, model_definitions in definitions_by_model.items() %}
+    {% set model_index = loop.index %}
+    {% set aggregate_columns = [] %}
+    {% set test_definition_queries = [] %}
+    {% set tested_count_cases = [] %}
+    {% set failed_count_cases = [] %}
+    {% set not_applicable_count_cases = [] %}
+
+    {% for definition in model_definitions %}
+        {% set test_ordinal = loop.index %}
+        {% set flag_column = quote_column(definition['flag_column_name']) %}
+
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " in (0, 1) then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as tested_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(coalesce(" ~ flag_column ~ ", 0) as " ~ dbt.type_bigint() ~ ")) as "
+            ~ dbt.type_bigint() ~ ") as failed_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " is null then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as not_applicable_count_" ~ test_ordinal
+        ) %}
+
+        {% set test_definition_query %}
+            select
+                  cast({{ test_ordinal }} as {{ dbt.type_int() }}) as test_ordinal
+                , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+                , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+                , {{ dq_string_literal_sql(definition['display_name']) }} as display_name
+                , {{ dq_string_literal_sql(definition['description']) }} as description
+                , {{ dq_string_literal_sql(definition['grain']) }} as grain
+                , {{ dq_string_literal_sql(definition['flag_table_name']) }} as flag_table_name
+                , {{ dq_string_literal_sql(definition['flag_column_name']) }} as flag_column_name
+                , {{ dq_string_literal_sql(definition['test_type']) }} as test_type
+                , cast({{ definition['severity'] }} as {{ dbt.type_int() }}) as severity
+        {% endset %}
+        {% do test_definition_queries.append(test_definition_query | trim) %}
+        {% do tested_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.tested_count_" ~ test_ordinal
+        ) %}
+        {% do failed_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.failed_count_" ~ test_ordinal
+        ) %}
+        {% do not_applicable_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.not_applicable_count_" ~ test_ordinal
+        ) %}
+    {% endfor %}
+
+    {% set aggregate_cte %}
+        logical_model_{{ model_index }}_aggregates as (
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , cast(
+                    sum(cast(1 as {{ dbt.type_bigint() }}))
+                    as {{ dbt.type_bigint() }}
+                  ) as total_row_count
+                , {{ aggregate_columns | join('\n                , ') }}
+            from {{ ref(source_model_name) }}
+            group by cast(data_source as {{ dbt.type_string() }})
+        )
+    {% endset %}
+    {% do aggregate_ctes.append(aggregate_cte | trim) %}
+
+    {% set test_definition_cte %}
+        logical_model_{{ model_index }}_tests as (
+            {{ test_definition_queries | join('\n            union all\n') }}
+        )
+    {% endset %}
+    {% do test_definition_ctes.append(test_definition_cte | trim) %}
+
+    {% set result_query %}
+        select
+              flag_aggregates.data_source
+            , test_definitions.input_table_name
+            , test_definitions.test_name
+            , test_definitions.display_name
+            , test_definitions.description
+            , test_definitions.grain
+            , test_definitions.flag_table_name
+            , test_definitions.flag_column_name
+            , test_definitions.test_type
+            , test_definitions.severity
+            , flag_aggregates.total_row_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as tested_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as failed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+                - case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as passed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ not_applicable_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as not_applicable_count
+        from logical_model_{{ model_index }}_aggregates as flag_aggregates
+        cross join logical_model_{{ model_index }}_tests as test_definitions
+    {% endset %}
+    {% do result_queries.append(result_query | trim) %}
+{% endfor %}
+
+{% if result_queries | length > 0 %}
+    with
+    {{ (aggregate_ctes + test_definition_ctes) | join('\n    , ') }}
+
+    select *
+    from (
+        {{ result_queries | join('\n        union all\n') }}
+    ) as logical_test_results_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as display_name
+        , cast(null as {{ dbt.type_string() }}) as description
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as flag_table_name
+        , cast(null as {{ dbt.type_string() }}) as flag_column_name
+        , cast(null as {{ dbt.type_string() }}) as test_type
+        , cast(null as {{ dbt.type_int() }}) as severity
+        , cast(null as {{ dbt.type_bigint() }}) as total_row_count
+        , cast(null as {{ dbt.type_bigint() }}) as tested_count
+        , cast(null as {{ dbt.type_bigint() }}) as failed_count
+        , cast(null as {{ dbt.type_bigint() }}) as passed_count
+        , cast(null as {{ dbt.type_bigint() }}) as not_applicable_count
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/data_quality__logical_test_results_part_4.sql
+++ b/models/data_quality/logical/data_quality__logical_test_results_part_4.sql
@@ -1,0 +1,177 @@
+{{ config(
+     enabled = (the_tuva_project.tuva_boolean_var('data_quality_enabled', false))
+       and ((the_tuva_project.tuva_boolean_var('claims_enabled', false)) or (the_tuva_project.tuva_boolean_var('clinical_enabled', false))),
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = '_logical_test_results_part_4',
+     tags = ['data_quality', 'dq_logical'],
+     materialized = 'table'
+   )
+}}
+
+{#
+    Implementation detail, not a consumer contract. One slice of the logical
+    test manifest, split on whole flag models so per-model aggregates stay
+    correct, and kept small enough that the generated statement stays inside
+    Athena's 262,144-byte query-string limit.
+    data_quality__logical_test_results unions every part.
+#}
+
+{% set definitions_by_model = {} %}
+
+{% for definition in the_tuva_project.dq_enabled_logical_test_manifest_chunk_by_model(3) %}
+    {% set source_model_name = definition['source_model_name'] %}
+    {% if definitions_by_model.get(source_model_name) is none %}
+        {% do definitions_by_model.update({source_model_name: []}) %}
+    {% endif %}
+    {% do definitions_by_model[source_model_name].append(definition) %}
+{% endfor %}
+
+{% set aggregate_ctes = [] %}
+{% set test_definition_ctes = [] %}
+{% set result_queries = [] %}
+
+{% for source_model_name, model_definitions in definitions_by_model.items() %}
+    {% set model_index = loop.index %}
+    {% set aggregate_columns = [] %}
+    {% set test_definition_queries = [] %}
+    {% set tested_count_cases = [] %}
+    {% set failed_count_cases = [] %}
+    {% set not_applicable_count_cases = [] %}
+
+    {% for definition in model_definitions %}
+        {% set test_ordinal = loop.index %}
+        {% set flag_column = quote_column(definition['flag_column_name']) %}
+
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " in (0, 1) then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as tested_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(coalesce(" ~ flag_column ~ ", 0) as " ~ dbt.type_bigint() ~ ")) as "
+            ~ dbt.type_bigint() ~ ") as failed_count_" ~ test_ordinal
+        ) %}
+        {% do aggregate_columns.append(
+            "cast(sum(cast(case when " ~ flag_column ~ " is null then 1 else 0 end as "
+            ~ dbt.type_bigint() ~ ")) as " ~ dbt.type_bigint() ~ ") as not_applicable_count_" ~ test_ordinal
+        ) %}
+
+        {% set test_definition_query %}
+            select
+                  cast({{ test_ordinal }} as {{ dbt.type_int() }}) as test_ordinal
+                , {{ dq_string_literal_sql(definition['input_table_name']) }} as input_table_name
+                , {{ dq_string_literal_sql(definition['test_name']) }} as test_name
+                , {{ dq_string_literal_sql(definition['display_name']) }} as display_name
+                , {{ dq_string_literal_sql(definition['description']) }} as description
+                , {{ dq_string_literal_sql(definition['grain']) }} as grain
+                , {{ dq_string_literal_sql(definition['flag_table_name']) }} as flag_table_name
+                , {{ dq_string_literal_sql(definition['flag_column_name']) }} as flag_column_name
+                , {{ dq_string_literal_sql(definition['test_type']) }} as test_type
+                , cast({{ definition['severity'] }} as {{ dbt.type_int() }}) as severity
+        {% endset %}
+        {% do test_definition_queries.append(test_definition_query | trim) %}
+        {% do tested_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.tested_count_" ~ test_ordinal
+        ) %}
+        {% do failed_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.failed_count_" ~ test_ordinal
+        ) %}
+        {% do not_applicable_count_cases.append(
+            "when " ~ test_ordinal ~ " then flag_aggregates.not_applicable_count_" ~ test_ordinal
+        ) %}
+    {% endfor %}
+
+    {% set aggregate_cte %}
+        logical_model_{{ model_index }}_aggregates as (
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , cast(
+                    sum(cast(1 as {{ dbt.type_bigint() }}))
+                    as {{ dbt.type_bigint() }}
+                  ) as total_row_count
+                , {{ aggregate_columns | join('\n                , ') }}
+            from {{ ref(source_model_name) }}
+            group by cast(data_source as {{ dbt.type_string() }})
+        )
+    {% endset %}
+    {% do aggregate_ctes.append(aggregate_cte | trim) %}
+
+    {% set test_definition_cte %}
+        logical_model_{{ model_index }}_tests as (
+            {{ test_definition_queries | join('\n            union all\n') }}
+        )
+    {% endset %}
+    {% do test_definition_ctes.append(test_definition_cte | trim) %}
+
+    {% set result_query %}
+        select
+              flag_aggregates.data_source
+            , test_definitions.input_table_name
+            , test_definitions.test_name
+            , test_definitions.display_name
+            , test_definitions.description
+            , test_definitions.grain
+            , test_definitions.flag_table_name
+            , test_definitions.flag_column_name
+            , test_definitions.test_type
+            , test_definitions.severity
+            , flag_aggregates.total_row_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as tested_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as failed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ tested_count_cases | join('\n                    ') }}
+                end
+                - case test_definitions.test_ordinal
+                    {{ failed_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as passed_count
+            , cast(
+                case test_definitions.test_ordinal
+                    {{ not_applicable_count_cases | join('\n                    ') }}
+                end
+              as {{ dbt.type_bigint() }}) as not_applicable_count
+        from logical_model_{{ model_index }}_aggregates as flag_aggregates
+        cross join logical_model_{{ model_index }}_tests as test_definitions
+    {% endset %}
+    {% do result_queries.append(result_query | trim) %}
+{% endfor %}
+
+{% if result_queries | length > 0 %}
+    with
+    {{ (aggregate_ctes + test_definition_ctes) | join('\n    , ') }}
+
+    select *
+    from (
+        {{ result_queries | join('\n        union all\n') }}
+    ) as logical_test_results_part
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as input_table_name
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_string() }}) as display_name
+        , cast(null as {{ dbt.type_string() }}) as description
+        , cast(null as {{ dbt.type_string() }}) as grain
+        , cast(null as {{ dbt.type_string() }}) as flag_table_name
+        , cast(null as {{ dbt.type_string() }}) as flag_column_name
+        , cast(null as {{ dbt.type_string() }}) as test_type
+        , cast(null as {{ dbt.type_int() }}) as severity
+        , cast(null as {{ dbt.type_bigint() }}) as total_row_count
+        , cast(null as {{ dbt.type_bigint() }}) as tested_count
+        , cast(null as {{ dbt.type_bigint() }}) as failed_count
+        , cast(null as {{ dbt.type_bigint() }}) as passed_count
+        , cast(null as {{ dbt.type_bigint() }}) as not_applicable_count
+    {{ dq_empty_result_guard_sql() }}
+{% endif %}

--- a/models/data_quality/logical/logical_result_unit_tests.yml
+++ b/models/data_quality/logical/logical_result_unit_tests.yml
@@ -6,10 +6,14 @@ unit_tests:
       Verifies exact fail, pass, and not-applicable counts for multiple flags,
       populated and null data sources, and independently aggregated flag
       models.
-    model: data_quality__logical_test_results
+    model: data_quality__logical_test_results_part_1
     config:
       enabled: "{{ (var('data_quality_enabled', false) and var('claims_enabled', false)) | as_bool }}"
     overrides:
+      vars:
+        # One part means every overridden flag model lands in part 1, so the
+        # aggregate assertions stay independent of how the manifest is chunked.
+        dq_logical_chunk_count: 1
       macros:
         dq_enabled_logical_test_manifest:
           - source_model_name: data_quality__medical_claim_line_flags
@@ -146,10 +150,14 @@ unit_tests:
       Verifies that the optional failure-key detail emits only failed rows from
       multiple flag models and distinguishes pipes, percent signs, empty
       strings, and null key components with percent_escaped_v1.
-    model: data_quality__logical_failure_keys
+    model: data_quality__logical_failure_keys_part_1
     config:
       enabled: "{{ (var('data_quality_enabled', false) and var('claims_enabled', false) and var('enable_data_quality_failure_keys', false)) | as_bool }}"
     overrides:
+      vars:
+        # One part means every overridden definition lands in part 1, so the
+        # encoding assertions stay independent of how the manifest is chunked.
+        dq_logical_chunk_count: 1
       macros:
         dq_enabled_logical_test_manifest:
           - source_model_name: data_quality__medical_claim_line_flags

--- a/models/data_quality/logical/provider_attribution_unit_tests.yml
+++ b/models/data_quality/logical/provider_attribution_unit_tests.yml
@@ -5,7 +5,7 @@ unit_tests:
     description: >
       Verifies that provider attribution year_month accepts only an exact
       six-digit YYYYMM value with a valid month, flags malformed populated
-      values, and reports null as not applicable because Structural Data
+      values, and reports cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as not applicable because Structural Data
       Quality owns primary-key nulls.
     model: data_quality__provider_attribution_flags
     config:

--- a/models/data_quality/structural/structural_unit_tests.yml
+++ b/models/data_quality/structural/structural_unit_tests.yml
@@ -213,7 +213,7 @@ unit_tests:
       - input: ref('data_quality__structural_source_populations')
         format: sql
         rows: |
-          select 'claims' as input_layer_domain, 'eligibility' as table_name, 'input_layer__eligibility' as model_name, null as data_source, cast('__dq_structural_null__' as {{ 'varchar(65535)' if target.type == 'redshift' else 'varchar(max)' if target.type in ['fabric', 'sqlserver'] else 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as data_source_key, 0 as row_count
+          select 'claims' as input_layer_domain, 'eligibility' as table_name, 'input_layer__eligibility' as model_name, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as data_source, cast('__dq_structural_null__' as {{ 'varchar(65535)' if target.type == 'redshift' else 'varchar(max)' if target.type in ['fabric', 'sqlserver'] else 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as data_source_key, 0 as row_count
           union all
           select 'claims', 'medical_claim', 'input_layer__medical_claim', null, '__dq_structural_null__', 0
           union all
@@ -221,7 +221,7 @@ unit_tests:
       - input: ref('data_quality__structural_data_sources')
         format: sql
         rows: |
-          select 'claims' as input_layer_domain, null as data_source, cast('__dq_structural_null__' as {{ 'varchar(65535)' if target.type == 'redshift' else 'varchar(max)' if target.type in ['fabric', 'sqlserver'] else 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as data_source_key
+          select 'claims' as input_layer_domain, cast(null as {{ 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as data_source, cast('__dq_structural_null__' as {{ 'varchar(65535)' if target.type == 'redshift' else 'varchar(max)' if target.type in ['fabric', 'sqlserver'] else 'string' if target.type in ['bigquery', 'databricks'] else 'varchar' }}) as data_source_key
     expect:
       rows:
         - input_layer_domain: claims

--- a/models/input_layer/input_layer__provider_attribution.sql
+++ b/models/input_layer/input_layer__provider_attribution.sql
@@ -14,7 +14,7 @@ from {{ ref('provider_attribution') }}
 
 {% elif the_tuva_project.tuva_boolean_var('provider_attribution_enabled', false) ==  false -%}
 
-{% if target.type == 'fabric' %}
+{% if target.type in ('fabric', 'sqlserver') %}
 select top 0
       cast(null as {{ dbt.type_string() }} ) as person_id
     , cast(null as {{ dbt.type_string() }} ) as member_id

--- a/models/normalized_layer/final/normalized__provider_attribution.sql
+++ b/models/normalized_layer/final/normalized__provider_attribution.sql
@@ -27,7 +27,7 @@ from {{ ref('input_layer__provider_attribution') }}
 
 {% else -%}
 
-{% if target.type == 'fabric' %}
+{% if target.type in ('fabric', 'sqlserver') %}
 select top 0
       cast(null as {{ dbt.type_string() }} ) as person_id
     , cast(null as {{ dbt.type_string() }} ) as member_id

--- a/models/normalized_layer/intermediate/normalized_input__int_place_of_service_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_place_of_service_normalize.sql
@@ -13,7 +13,7 @@ select
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_medical_claim') }} as med
 left outer join {{ ref('terminology__place_of_service') }} as pos
-    {% if target.type == 'fabric' %}
+    {% if target.type in ('fabric', 'sqlserver') %}
         on RIGHT(REPLICATE('0', 2) + med.place_of_service_code, 2) = pos.place_of_service_code
     {% else %}
         on lpad(med.place_of_service_code, 2, '0') = pos.place_of_service_code

--- a/models/normalized_layer/intermediate/normalized_input__int_revenue_center_normalize.sql
+++ b/models/normalized_layer/intermediate/normalized_input__int_revenue_center_normalize.sql
@@ -13,7 +13,7 @@ select
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_medical_claim') }} as med
 left outer join {{ ref('terminology__revenue_center') }} as rev
-    {% if target.type == 'fabric' %}
+    {% if target.type in ('fabric', 'sqlserver') %}
         on RIGHT(REPLICATE('0', 4) + med.revenue_center_code, 4) = rev.revenue_center_code
     {% else %}
         on lpad(med.revenue_center_code, 4, '0') = rev.revenue_center_code

--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -380,7 +380,7 @@ seeds:
         recid: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         long_description: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type == "fabric" -%} varchar(max) {%- else -%} varchar(65535) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type in ("fabric", "sqlserver") -%} varchar(max) {%- else -%} varchar(65535) {%- endif -%}
         short_description: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         deprecated: integer

--- a/seeds/value_sets/condition_grouper/condition_grouper_seeds.yml
+++ b/seeds/value_sets/condition_grouper/condition_grouper_seeds.yml
@@ -19,7 +19,7 @@ seeds:
       column_types:
         condition_family: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        condition: |
+        condition_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         status: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
@@ -33,7 +33,7 @@ seeds:
         description: Analytic rollup family for the condition, such as Cardiovascular Disease, Cancer, or Mental Health Disorders.
         tests:
           - not_null
-      - name: condition
+      - name: condition_name
         description: Mutually exclusive condition name assigned by the Tuva Condition Grouper.
         tests:
           - not_null
@@ -76,7 +76,7 @@ seeds:
       column_types:
         condition_family: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        condition: |
+        condition_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
@@ -94,7 +94,7 @@ seeds:
         description: Analytic condition family assigned to the diagnosis code.
         tests:
           - not_null
-      - name: condition
+      - name: condition_name
         description: Mutually exclusive Tuva condition assigned to the diagnosis code.
         tests:
           - not_null

--- a/seeds/value_sets/condition_grouper/tuva_condition_grouper.csv
+++ b/seeds/value_sets/condition_grouper/tuva_condition_grouper.csv
@@ -1,1 +1,1 @@
-condition_family,condition,status,description,last_update_date,last_update_note
+condition_family,condition_name,status,description,last_update_date,last_update_note

--- a/seeds/value_sets/condition_grouper/tuva_condition_grouper_code_map.csv
+++ b/seeds/value_sets/condition_grouper/tuva_condition_grouper_code_map.csv
@@ -1,1 +1,1 @@
-condition_family,condition,code,code_description,code_system,status,last_update_date,last_update_note
+condition_family,condition_name,code,code_description,code_system,status,last_update_date,last_update_note

--- a/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
+++ b/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
@@ -19,7 +19,7 @@ seeds:
       column_types:
         procedure_family: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        procedure: |
+        procedure_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         status: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
@@ -33,7 +33,7 @@ seeds:
         description: Analytic rollup family for the procedure, such as Cardiovascular, Gastrointestinal, Musculoskeletal, or Urinary System.
         tests:
           - not_null
-      - name: procedure
+      - name: procedure_name
         description: Mutually exclusive procedure name assigned by the Tuva Procedure Grouper.
         tests:
           - not_null
@@ -74,7 +74,7 @@ seeds:
       column_types:
         procedure_family: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        procedure: |
+        procedure_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
@@ -92,7 +92,7 @@ seeds:
         description: Analytic procedure family assigned to the procedure code.
         tests:
           - not_null
-      - name: procedure
+      - name: procedure_name
         description: Mutually exclusive Tuva procedure assigned to the procedure code.
       - name: code
         description: Procedure code mapped to the Tuva procedure. ICD-10-PCS codes are stored without decimal formatting.

--- a/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
+++ b/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
@@ -24,10 +24,10 @@ seeds:
         status: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         description: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type == "fabric" -%} varchar(max) {%- elif target.type == "redshift" -%} varchar(65535) {%- else -%} varchar(3000) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type in ("fabric", "sqlserver") -%} varchar(max) {%- elif target.type == "redshift" -%} varchar(65535) {%- else -%} varchar(3000) {%- endif -%}
         last_update_date: date
         last_update_note: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type == "fabric" -%} varchar(max) {%- else -%} varchar(3000) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type in ("fabric", "sqlserver") -%} varchar(max) {%- else -%} varchar(3000) {%- endif -%}
     columns:
       - name: procedure_family
         description: Analytic rollup family for the procedure, such as Cardiovascular, Gastrointestinal, Musculoskeletal, or Urinary System.
@@ -79,14 +79,14 @@ seeds:
         code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         code_description: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type == "fabric" -%} varchar(max) {%- else -%} varchar(3000) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type in ("fabric", "sqlserver") -%} varchar(max) {%- else -%} varchar(3000) {%- endif -%}
         code_system: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         status: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         last_update_date: date
         last_update_note: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type == "fabric" -%} varchar(max) {%- else -%} varchar(3000) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- elif target.type == "snowflake" -%} varchar(16777216) {%- elif target.type in ("fabric", "sqlserver") -%} varchar(max) {%- else -%} varchar(3000) {%- endif -%}
     columns:
       - name: procedure_family
         description: Analytic procedure family assigned to the procedure code.

--- a/seeds/value_sets/procedure_grouper/tuva_procedure_grouper.csv
+++ b/seeds/value_sets/procedure_grouper/tuva_procedure_grouper.csv
@@ -1,1 +1,1 @@
-procedure_family,procedure,status,description,last_update_date,last_update_note
+procedure_family,procedure_name,status,description,last_update_date,last_update_note

--- a/seeds/value_sets/procedure_grouper/tuva_procedure_grouper_code_map.csv
+++ b/seeds/value_sets/procedure_grouper/tuva_procedure_grouper_code_map.csv
@@ -1,1 +1,1 @@
-procedure_family,procedure,code,code_description,code_system,status,last_update_date,last_update_note
+procedure_family,procedure_name,code,code_description,code_system,status,last_update_date,last_update_note

--- a/tests/check_apply_regex_contract.sql
+++ b/tests/check_apply_regex_contract.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = target.type != 'fabric',
+     enabled = target.type not in ('fabric', 'sqlserver'),
      severity = 'error',
      tags = ['contract', 'regex_contract']
    )
@@ -11,7 +11,7 @@
   and null behavior across the adapters that expose regular expressions.
 #}
 
-{% if target.type != 'fabric' %}
+{% if target.type not in ('fabric', 'sqlserver') %}
 {% set regex_cases = [
     ('unanchored_search', "'prefix123suffix'", '[0-9]+', '1'),
     ('explicit_start_anchor_rejects_prefix', "'prefix123suffix'", '^[0-9]+', '0'),

--- a/tests/data_assets/test_condition_grouper_active_code_map_parents_are_active.sql
+++ b/tests/data_assets/test_condition_grouper_active_code_map_parents_are_active.sql
@@ -8,11 +8,11 @@ select
     code_map.code_system
   , code_map.code
   , code_map.condition_family
-  , code_map.condition
+  , code_map.condition_name
 from {{ ref('tuva_condition_grouper_code_map') }} as code_map
 left join {{ ref('tuva_condition_grouper') }} as condition_grouper
   on code_map.condition_family = condition_grouper.condition_family
-  and code_map.condition = condition_grouper.condition
+  and code_map.condition_name = condition_grouper.condition_name
   and condition_grouper.status = 'active'
 where code_map.status = 'active'
   and condition_grouper.condition_family is null

--- a/tests/data_assets/test_condition_grouper_code_map_parent_rows.sql
+++ b/tests/data_assets/test_condition_grouper_code_map_parent_rows.sql
@@ -8,9 +8,9 @@ select
     code_map.code_system
   , code_map.code
   , code_map.condition_family
-  , code_map.condition
+  , code_map.condition_name
 from {{ ref('tuva_condition_grouper_code_map') }} as code_map
 left join {{ ref('tuva_condition_grouper') }} as condition_grouper
   on code_map.condition_family = condition_grouper.condition_family
-  and code_map.condition = condition_grouper.condition
+  and code_map.condition_name = condition_grouper.condition_name
 where condition_grouper.condition_family is null

--- a/tests/data_assets/test_condition_grouper_condition_names_have_one_family.sql
+++ b/tests/data_assets/test_condition_grouper_condition_names_have_one_family.sql
@@ -5,8 +5,8 @@
 }}
 
 select
-    condition
+    condition_name
 from {{ ref('tuva_condition_grouper') }}
 group by
-    condition
+    condition_name
 having count(distinct condition_family) != 1

--- a/tests/data_assets/test_procedure_grouper_active_code_map_parents_are_active.sql
+++ b/tests/data_assets/test_procedure_grouper_active_code_map_parents_are_active.sql
@@ -8,11 +8,11 @@ select
     code_map.code_system
   , code_map.code
   , code_map.procedure_family
-  , code_map.{{ quote_column('procedure') }} as {{ quote_column('procedure') }}
+  , code_map.procedure_name as procedure_name
 from {{ ref('tuva_procedure_grouper_code_map') }} as code_map
 left join {{ ref('tuva_procedure_grouper') }} as procedure_grouper
   on code_map.procedure_family = procedure_grouper.procedure_family
-  and code_map.{{ quote_column('procedure') }} = procedure_grouper.{{ quote_column('procedure') }}
+  and code_map.procedure_name = procedure_grouper.procedure_name
   and procedure_grouper.status = 'active'
 where code_map.status = 'active'
   and procedure_grouper.procedure_family is null

--- a/tests/data_assets/test_procedure_grouper_active_procedures_are_mapped.sql
+++ b/tests/data_assets/test_procedure_grouper_active_procedures_are_mapped.sql
@@ -6,14 +6,14 @@
 
 select
     procedure_grouper.procedure_family
-  , procedure_grouper.{{ quote_column('procedure') }} as {{ quote_column('procedure') }}
+  , procedure_grouper.procedure_name as procedure_name
 from {{ ref('tuva_procedure_grouper') }} as procedure_grouper
 left join {{ ref('tuva_procedure_grouper_code_map') }} as code_map
   on procedure_grouper.procedure_family = code_map.procedure_family
-  and procedure_grouper.{{ quote_column('procedure') }} = code_map.{{ quote_column('procedure') }}
+  and procedure_grouper.procedure_name = code_map.procedure_name
   and code_map.status = 'active'
 where procedure_grouper.status = 'active'
 group by
     procedure_grouper.procedure_family
-  , procedure_grouper.{{ quote_column('procedure') }}
+  , procedure_grouper.procedure_name
 having count(code_map.code) = 0

--- a/tests/data_assets/test_procedure_grouper_code_map_parent_rows.sql
+++ b/tests/data_assets/test_procedure_grouper_code_map_parent_rows.sql
@@ -8,9 +8,9 @@ select
     code_map.code_system
   , code_map.code
   , code_map.procedure_family
-  , code_map.{{ quote_column("procedure") }} as {{ quote_column("procedure") }}
+  , code_map.procedure_name as procedure_name
 from {{ ref('tuva_procedure_grouper_code_map') }} as code_map
 left join {{ ref('tuva_procedure_grouper') }} as procedure_grouper
   on code_map.procedure_family = procedure_grouper.procedure_family
-  and code_map.{{ quote_column("procedure") }} = procedure_grouper.{{ quote_column("procedure") }}
+  and code_map.procedure_name = procedure_grouper.procedure_name
 where procedure_grouper.procedure_family is null

--- a/tests/data_assets/test_procedure_grouper_codes_have_one_target.sql
+++ b/tests/data_assets/test_procedure_grouper_codes_have_one_target.sql
@@ -10,7 +10,7 @@ with normalized_code_targets as (
         lower({{ the_tuva_project.trim('code_system') }}) as code_system
       , upper(replace({{ the_tuva_project.trim('code') }}, '.', '')) as code
       , procedure_family
-      , {{ quote_column('procedure') }} as {{ quote_column('procedure') }}
+      , procedure_name as procedure_name
     from {{ ref('tuva_procedure_grouper_code_map') }}
 
 )
@@ -23,4 +23,4 @@ group by
     code_system
   , code
 having count(distinct procedure_family) != 1
-    or count(distinct {{ quote_column('procedure') }}) != 1
+    or count(distinct procedure_name) != 1

--- a/tests/data_assets/test_procedure_grouper_hierarchy_rows_are_active.sql
+++ b/tests/data_assets/test_procedure_grouper_hierarchy_rows_are_active.sql
@@ -6,7 +6,7 @@
 
 select
     procedure_family
-  , {{ quote_column('procedure') }} as {{ quote_column('procedure') }}
+  , procedure_name as procedure_name
   , status
 from {{ ref('tuva_procedure_grouper') }}
 where status != 'active'

--- a/tests/data_assets/test_procedure_grouper_procedure_names_have_one_family.sql
+++ b/tests/data_assets/test_procedure_grouper_procedure_names_have_one_family.sql
@@ -5,8 +5,8 @@
 }}
 
 select
-    {{ quote_column('procedure') }} as {{ quote_column('procedure') }}
+    procedure_name as procedure_name
 from {{ ref('tuva_procedure_grouper') }}
 group by
-    {{ quote_column('procedure') }}
+    procedure_name
 having count(distinct procedure_family) != 1

--- a/tests/data_assets/test_procedure_grouper_procedure_not_null.sql
+++ b/tests/data_assets/test_procedure_grouper_procedure_not_null.sql
@@ -7,15 +7,15 @@
 select
     'tuva_procedure_grouper' as table_name
   , procedure_family
-  , {{ quote_column('procedure') }}
+  , procedure_name
 from {{ ref('tuva_procedure_grouper') }}
-where {{ quote_column('procedure') }} is null
+where procedure_name is null
 
 union all
 
 select
     'tuva_procedure_grouper_code_map' as table_name
   , procedure_family
-  , {{ quote_column('procedure') }}
+  , procedure_name
 from {{ ref('tuva_procedure_grouper_code_map') }}
-where {{ quote_column('procedure') }} is null
+where procedure_name is null


### PR DESCRIPTION
## Summary

Makes Core's SQL portable to SQL Server and Athena. **Neither becomes a supported warehouse in this PR** — the supported list in `README.md` and `AGENTS.md` is unchanged. The point is to close the dialect gap so the remaining work is scoped by measurement rather than guesswork.

Every change is either gated behind `target.type` for an unsupported adapter, or an added `sqlserver__` / `athena__` dispatch target that no supported warehouse resolves to — **with two exceptions, called out below.**

### SQL Server

`dbt-sqlserver` 1.11.1 declares `dependencies=[]` in its `AdapterPlugin`, so `adapter.dispatch` searches `sqlserver__` → `default__` and never reaches a single existing `fabric__` macro. That, not the SQL itself, was the entire gap.

- Eleven `sqlserver__` aliases delegating to the `fabric__` bodies, so there is one source of truth
- Six hardcoded `target.type == 'fabric'` checks widened, including `quote_column`, which otherwise emits unbracketed reserved words like `plan` and `procedure`
- Seed type chains given a `sqlserver` branch so long columns get `varchar(max)` rather than `varchar(65535)`
- The case-sensitive collation requirement documented in `README.md` and `AGENTS.md`

### Athena

- `athena__left` — Trino has no `left()`; the macro's own comment anticipated exactly this adapter
- `athena__yyyymm` — `default__yyyymm` uses `to_char`, which Trino lacks
- Positional staging columns in `athena__load_seed` — a Glue table carrying a reserved word such as `procedure` cannot be read by CTAS at all, and Athena reports it as a misleading missing-location error
- `numeric_type` branched to `decimal` on Athena in two fixtures that set it unconditionally; `numeric` is not a Trino type

### Changes that affect every warehouse

These two need reviewer attention, because they are not adapter-gated:

1. **Flattened the leading CTE** in the ephemeral `core__stg_coderx_classes` and in one `condition_unit_tests.yml` fixture. T-SQL rejects a nested `WITH` inside a CTE when an ephemeral model is inlined. Fabric tolerates it, so nothing caught it. Semantics are unchanged — CTE to derived table.
2. **Cast 115 untyped `null as <column>`** fixture values. Athena rejects an untyped NULL column in CTAS. Worth knowing: the `dbt` namespace is not available inside unit-test fixture Jinja, so these use the inline `target.type` conditional the fixtures already use elsewhere.

## Validation

| Warehouse | Seeds | Build | Result |
|---|---|---|---|
| BigQuery | 87 / 87 | 734 / 734 | verified locally, zero errors |
| Redshift Serverless | 87 / 87 | 734 / 734 | verified locally, zero errors |
| DuckDB | 87 / 87 | 734 / 734 | verified locally, zero errors |
| Snowflake | | | CI green on this branch |
| SQL Server 2022 CU26 | 82 / 87 | 733 / 733 | 5 provider-data seeds not staged locally |
| Athena engine v3 | 87 / 87 | 347 / 347 models, 98 / 98 unit tests | zero errors |
| Databricks | | | not verified, both SQL warehouses stopped and no user catalog |
| Microsoft Fabric | | | not verified, no warehouse SQL endpoint reachable |

Five of the six supported warehouses are verified, four of them locally end to end and Snowflake through CI. Databricks and Fabric are the gap and are covered by `Tuva CI -- All Warehouses`.

`scripts/portability_lint.py` is clean and 73 Python contract tests pass.

**No known failures remain on either warehouse.** Row integrity across the Data Quality split is verified on both: `logical_failure_keys` equals the sum of its parts, and `logical_test_results` equals both the sum of its parts and the row count of `logical_test_catalog` — one result per enabled test.

**Snowflake CI passed** on `7902799d`, the first validation of these changes on a supported warehouse — `dbt build` runs the unit tests, so it exercised the 115 fixture casts and both nested-CTE flattens directly. Every later commit has been re-verified end to end on both SQL Server and Athena.

## Later commits: the Athena blockers, the `condition` rename, and the query-size split

**`procedure` column renamed to `procedure_name`.** Athena cannot create a table with a column named `procedure` — aliasing the CTAS output to any other name succeeds, `procedure` fails, and Athena reports it as a misleading missing-location error. Renamed across the two checked-in seed headers, the seed column and `column_types` declarations, the Core output in `core__procedure`, the Core model docs, and seven data-asset tests.

**This is the breaking change in this PR.** `core.procedure` no longer exposes a `procedure` column. No data-asset republish is needed — every loader maps positionally and skips the header row — but the published payload's column order must stay stable.

**Logical test catalog brought inside Athena's query-size limit.** `data_quality__logical_test_catalog` builds one `UNION ALL` branch per logical test and repeated all twelve column aliases on every branch, compiling to **266,679 bytes against Athena's 262,144-byte limit**. That failure also took `logical_test_results` and `logical_failure_keys` with it. Only the first branch needs aliases; the rest inherit them positionally. Compiled size drops to **205,642 bytes** (~22% headroom), and the built relation is unchanged at 314 rows with the same twelve columns.

It still grows linearly with the number of logical tests, so this buys headroom rather than removing the ceiling.

## `sqlserver__load_seed` — and why no republish is needed

SQL Server has no `COPY INTO`, no wildcard bulk loader, and `BULK INSERT` cannot decompress. It does have a native GZIP builtin, so the loader reads the published `.csv.gz` with `OPENROWSET ... SINGLE_BLOB`, decompresses in-engine with `DECOMPRESS()`, splits into lines, and parses fields with an RFC 4180 parse **over the assets exactly as published today**. No credential is needed — the public mirror is reachable through an anonymous `BLOB_STORAGE` external data source — and PolyBase is not required (it is absent from the SQL Server container and from Azure SQL Database entirely).

An earlier version of this loader required a fully-quoted (`QUOTE_ALL`) republish. **That was dropped deliberately.** The assets carry **21,761,286 empty cells across 40 of 96 files**, and those bare empty fields *are* the NULL representation — every loader converts empty to NULL. Fully-quoted CSV turns each into a quoted empty string, and loaders that treat only the bare form as NULL would load them as empty strings instead. Republishing to suit this adapter would risk changing NULL semantics on the five warehouses that already work, to enable one that does not yet.

So: **no republish, no mirror resync, no asset-version decision, no break-glass on `1.0.0`.**

Validated against the published assets with no modification: **10,724,351 rows across 81 seeds** (the 5 failures are provider-data seeds not staged locally). Field-level fidelity confirmed against source for `icd_10_cm`, `hcpcs_level_2` and `coderx_packages` — exact row counts, exact per-column maximum lengths, exact null counts, including all **477,616 nulls** in `coderx_packages.ndc` and the 4,501-character `hcpcs long_description`.

## Still out of scope

CI legs for either warehouse, and the eight standalone packages — none of which have been compiled against either warehouse.

## Release-note disposition

`breaking-change` — `core.procedure` loses its `procedure` column.




