### PR TITLE
Add paid_reduced_by to the Input Layer and Core medical_claim contracts

### DIFF
--- a/integration_tests/models/medical_claim.sql
+++ b/integration_tests/models/medical_claim.sql
@@ -45,6 +45,7 @@
     , copayment_amount
     , deductible_amount
     , total_cost_amount
+    , cast(null as {{ dbt.type_float() }}) as paid_reduced_by
     , diagnosis_code_type
     , diagnosis_code_1
     , diagnosis_code_2

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -2095,6 +2095,15 @@ models:
         config:
           meta:
             data_type: number
+      - name: paid_reduced_by
+        description: Amount by which the payer reduced its payment on the claim
+          line under a prospective or population-based payment arrangement, such
+          as the Medicare Population-Based Payment (PBP) reduction. paid_amount
+          reflects the payment after this reduction. Null when the source does
+          not report a reduction.
+        config:
+          meta:
+            data_type: number
       - name: in_network_flag
         description: Indicator for whether the claim was in network. Accepted values are
           1 for in network, 0 for out of network, and null when unknown.

--- a/models/core/final/core__medical_claim.sql
+++ b/models/core/final/core__medical_claim.sql
@@ -62,6 +62,7 @@
     , med.copayment_amount
     , med.deductible_amount
     , med.total_cost_amount
+    , med.paid_reduced_by
     , med.in_network_flag
     , cast(
         case

--- a/models/core/medical_claim_unit_tests.yml
+++ b/models/core/medical_claim_unit_tests.yml
@@ -49,15 +49,16 @@ unit_tests:
                 , cast(2 as {{ numeric_type }}) as copayment_amount
                 , cast(3 as {{ numeric_type }}) as deductible_amount
                 , cast(16 as {{ numeric_type }}) as total_cost_amount
+                , cast(5 as {{ numeric_type }}) as paid_reduced_by
                 , 1 as in_network_flag
                 , cast('2024-01-31' as date) as file_date
                 , cast('2024-02-01 00:00:00' as {{ timestamp_type }}) as ingest_datetime
                 , 'medical_claim.csv' as file_name
                 , 'source-a' as data_source
               union all
-              select 'mc-u-2', 'undetermined_claim', 2, 'undetermined', 'person-1', 'member-1', 'payer-a', 'plan-a', cast('2024-01-01' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), cast(2 as {{ numeric_type }}), 'A0425', '1111111111', cast('2024-01-10' as date), cast(20 as {{ numeric_type }}), cast(22 as {{ numeric_type }}), cast(25 as {{ numeric_type }}), cast(2 as {{ numeric_type }}), cast(3 as {{ numeric_type }}), cast(4 as {{ numeric_type }}), cast(31 as {{ numeric_type }}), 0, cast('2024-01-31' as date), cast('2024-02-01 00:00:00' as {{ timestamp_type }}), 'medical_claim.csv', 'source-a'
+              select 'mc-u-2', 'undetermined_claim', 2, 'undetermined', 'person-1', 'member-1', 'payer-a', 'plan-a', cast('2024-01-01' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), cast('2024-01-02' as date), cast(2 as {{ numeric_type }}), 'A0425', '1111111111', cast('2024-01-10' as date), cast(20 as {{ numeric_type }}), cast(22 as {{ numeric_type }}), cast(25 as {{ numeric_type }}), cast(2 as {{ numeric_type }}), cast(3 as {{ numeric_type }}), cast(4 as {{ numeric_type }}), cast(31 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), 0, cast('2024-01-31' as date), cast('2024-02-01 00:00:00' as {{ timestamp_type }}), 'medical_claim.csv', 'source-a'
               union all
-              select 'mc-p-1', 'professional_claim', 1, 'professional', 'person-2', 'member-2', 'payer-b', 'plan-b', cast('2024-03-01' as date), cast('2024-03-01' as date), cast('2024-03-01' as date), cast('2024-03-01' as date), cast(1 as {{ numeric_type }}), '99214', '2222222222', cast('2024-03-10' as date), cast(30 as {{ numeric_type }}), cast(32 as {{ numeric_type }}), cast(35 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(32 as {{ numeric_type }}), 1, cast('2024-03-31' as date), cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'medical_claim.csv', 'source-b'
+              select 'mc-p-1', 'professional_claim', 1, 'professional', 'person-2', 'member-2', 'payer-b', 'plan-b', cast('2024-03-01' as date), cast('2024-03-01' as date), cast('2024-03-01' as date), cast('2024-03-01' as date), cast(1 as {{ numeric_type }}), '99214', '2222222222', cast('2024-03-10' as date), cast(30 as {{ numeric_type }}), cast(32 as {{ numeric_type }}), cast(35 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(0 as {{ numeric_type }}), cast(32 as {{ numeric_type }}), cast(12.5 as {{ numeric_type }}), 1, cast('2024-03-31' as date), cast('2024-04-01 00:00:00' as {{ timestamp_type }}), 'medical_claim.csv', 'source-b'
           {% endset %}
           select
               base.*
@@ -148,6 +149,7 @@ unit_tests:
           paid_amount: 10
           allowed_amount: 12
           charge_amount: 15
+          paid_reduced_by: 5
           data_source: source-a
         - medical_claim_id: mc-u-2
           claim_id: undetermined_claim
@@ -162,6 +164,7 @@ unit_tests:
           paid_amount: 20
           allowed_amount: 22
           charge_amount: 25
+          paid_reduced_by: 0
           data_source: source-a
         - medical_claim_id: mc-p-1
           claim_id: professional_claim
@@ -176,4 +179,5 @@ unit_tests:
           paid_amount: 30
           allowed_amount: 32
           charge_amount: 35
+          paid_reduced_by: 12.5
           data_source: source-b

--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -263,6 +263,12 @@ models:
         config:
           meta:
             data_type: float
+      - name: paid_reduced_by
+        description: >-
+          Amount by which the payer reduced its payment on the claim line under a prospective or population-based payment arrangement, such as the Medicare Population-Based Payment (PBP) reduction reported in CCLF demonstration code files. paid_amount reflects the payment after this reduction, so paid_amount plus paid_reduced_by approximates the fee-for-service payment before the reduction. Null when the source does not report a reduction.
+        config:
+          meta:
+            data_type: float
       - name: diagnosis_code_type
         description: >-
           Coding system used for diagnosis codes on the claim. Accepted values are icd-9-cm and icd-10-cm. This is header-level and should be consistent across all lines for the same claim_id.

--- a/models/normalized_layer/final/normalized__medical_claim.sql
+++ b/models/normalized_layer/final/normalized__medical_claim.sql
@@ -64,6 +64,7 @@ select
     , cast(med.copayment_amount as {{ dbt.type_numeric() }}) as copayment_amount
     , cast(med.deductible_amount as {{ dbt.type_numeric() }}) as deductible_amount
     , cast(med.total_cost_amount as {{ dbt.type_numeric() }}) as total_cost_amount
+    , cast(med.paid_reduced_by as {{ dbt.type_numeric() }}) as paid_reduced_by
     , cast(med.diagnosis_code_type as {{ dbt.type_string() }}) as diagnosis_code_type
     {% for i in index_cols %}
     , cast(replace(med.diagnosis_code_{{ i }}, '.', '') as {{ dbt.type_string() }}) as diagnosis_code_{{ i }}

--- a/models/normalized_layer/normalized_layer_models.yml
+++ b/models/normalized_layer/normalized_layer_models.yml
@@ -704,6 +704,8 @@ models:
         description: The total amount charged on the claim by the provider.
       - name: total_cost_amount
         description: The total amount paid on the claim by different parties.
+      - name: paid_reduced_by
+        description: The amount by which the payer reduced its payment on the claim line under a prospective or population-based payment arrangement.
       - name: diagnosis_code_type
         description: Indicates the type of diagnosis code (e.g. ICD-10-CM).
         config:

--- a/models/normalized_layer/staging/normalized_input__stg_medical_claim.sql
+++ b/models/normalized_layer/staging/normalized_input__stg_medical_claim.sql
@@ -45,6 +45,7 @@ select
     , copayment_amount
     , deductible_amount
     , total_cost_amount
+    , paid_reduced_by
     , diagnosis_code_type
     , diagnosis_code_1
     , diagnosis_code_2


### PR DESCRIPTION
## Summary

Adds a new column, **`paid_reduced_by`**, to the Input Layer and Core `medical_claim` contracts.

`paid_reduced_by` is the amount by which the payer reduced its payment on a claim line under a prospective or population-based payment arrangement. The motivating source is Medicare CCLF: the CCLFA / CCLFB demonstration code files report `CLM_PBP_RDCTN_AMT`, the amount the fee-for-service payment was reduced because the ACO is paid prospectively under Population-Based Payment. In that data `paid_amount` alone understates the cost of care, and `paid_amount + paid_reduced_by` approximates the fee-for-service payment before the reduction. The matching connector change is tuva-health/medicare_cclf_connector#89.

## Changes

| File | Change |
|---|---|
| `models/input_layer/input_layer__medical_claim.yml` | New nullable column, `meta.data_type: float`, placed after `total_cost_amount` like the other amount fields |
| `models/normalized_layer/staging/normalized_input__stg_medical_claim.sql` | Pass the column through |
| `models/normalized_layer/final/normalized__medical_claim.sql`, `normalized_layer_models.yml` | Cast to `dbt.type_numeric()` like the other amount fields, plus column description |
| `models/core/final/core__medical_claim.sql`, `core_models.yml` | Expose the column after `total_cost_amount`, `meta.data_type: number`, plus column description |
| `models/core/medical_claim_unit_tests.yml` | Fixture and expected rows cover the passthrough (5, 0, 12.5) |
| `integration_tests/models/medical_claim.sql` | Maps `cast(null as float)` because the synthetic seed has no such column. No seed or synthetic data change. |

## Contract impact

This adds a column to the Input Layer `medical_claim` contract. Projects whose `medical_claim` Input Layer model does not yet include `paid_reduced_by` will need to add it (a null value is acceptable) before upgrading, the same as for any other Input Layer column. Structural Data Quality will report it in `structural_missing_columns` until then. No existing column, grain, identifier, or variable changes.

**Release-note disposition:** `breaking-change` (new Input Layer column that connectors must map). I do not have permission to apply labels on this repository, so the label needs to be set by a maintainer. Happy to downgrade to `enhancement` if additive Input Layer columns are treated as non-breaking in 1.x.

## Validation

Run from `integration_tests` through `scripts/dbt-local` against a local DuckDB profile with dbt Core 1.10.20 and dbt-duckdb 1.10.1:

- `scripts/dbt-local parse --no-partial-parse`: clean.
- `scripts/dbt-local build --select +core__medical_claim +medical_claim`: `core.medical_claim`, `normalized__medical_claim`, and the Input Layer view build with the new column present at every layer (float in the Input Layer, numeric in normalized and Core). All `core__medical_claim` data tests and the `core__medical_claim` unit test pass. The six errors in that run are singular tests referencing relations outside the selection (`snomed_ct`, `cvx`, `tuva_condition_grouper_code_map`, `orphaned_claim__encounter_grain`), not related to this change.
- `scripts/dbt-local test --select test_type:unit`: 47 pass. The four `cost_utilization_unit_tests.yml` errors are "relation doesn't exist" fixture-introspection errors from the partial build and fail identically on `main` in the same environment.
- `python3 scripts/portability_lint.py`: clean.
- `git diff --check`: clean.

Not run: Snowflake CI (fork PR, needs a maintainer to run `External PR Snowflake CI`).
