### PR TITLE
Make the SQL Server seed data source creation race safe

### DIFF
--- a/macros/cross_database_utils/load_seed.sql
+++ b/macros/cross_database_utils/load_seed.sql
@@ -461,9 +461,22 @@ WITH (
   {%- set data_source_name = 'tuva_seed_' ~ container | replace('-', '_') | replace('.', '_') -%}
   {%- set object_path = blob_path ~ '/' ~ pattern -%}
   {%- set source_args = "'" ~ object_path ~ "', data_source = '" ~ data_source_name ~ "', single_blob" -%}
+  {#
+      Seeds run concurrently, so two threads can both pass the existence check
+      before either creates the data source. Swallow the resulting duplicate
+      error and re-check, rather than letting a harmless race fail the load.
+  #}
   {% set ensure_source %}
     if not exists (select 1 from sys.external_data_sources where name = '{{ data_source_name }}')
-      exec('create external data source [{{ data_source_name }}] with (type = BLOB_STORAGE, location = ''{{ storage_root }}/{{ container }}'')');
+    begin
+      begin try
+        exec('create external data source [{{ data_source_name }}] with (type = BLOB_STORAGE, location = ''{{ storage_root }}/{{ container }}'')');
+      end try
+      begin catch
+        if not exists (select 1 from sys.external_data_sources where name = '{{ data_source_name }}')
+          throw;
+      end catch
+    end
   {% endset %}
   {% call statement('sqlserver_seed_source', fetch_result=false) %}{{ ensure_source }}{% endcall %}
 {%- else -%}


### PR DESCRIPTION
## Summary

Seeds run concurrently, so two threads can both pass the `if not exists` check before either creates the external data source. The loser failed the whole seed with:

```
Type with name 'tuva_seed_tuva_public_resources' already exists. (46502)
```

Surfaced while building `cms_hcc` against SQL Server, where the package loads Core's seeds with the default four threads. Core's own runs did not hit it because the data source already existed from an earlier single-threaded load, which is exactly the kind of gap a fresh environment exposes.

The creation is now wrapped in `TRY`/`CATCH` and re-checks existence before rethrowing, so a concurrent create is harmless while a real failure still surfaces.

## Validation

- Five seeds loaded concurrently at eight threads from a dropped data source: zero errors.
- `scripts/portability_lint.py` clean; the CI-wired var inventory test passes.

## Release-note disposition

`bug`