### PR TITLE
Scope medication unit tests to their required input domains

### DIFF
--- a/models/core/coderx_unit_tests.yml
+++ b/models/core/coderx_unit_tests.yml
@@ -205,7 +205,7 @@ unit_tests:
       Verifies an unmatched CodeRx Enterprise package remains unenriched and does not fall back to CodeRx Open terminology.
     model: core__medication
     config:
-      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
     overrides:
       vars:
         clinical_enabled: false
@@ -293,7 +293,7 @@ unit_tests:
       Verifies a matched CodeRx Enterprise package enriches claims medication with NDC, RxNorm, and ATC codes and descriptions.
     model: core__medication
     config:
-      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+      enabled: "{{ var('claims_enabled', false) | as_bool }}"
     overrides:
       vars:
         clinical_enabled: false
@@ -456,7 +456,7 @@ unit_tests:
       Core medication grain, so both domain records must remain present.
     model: core__medication
     config:
-      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+      enabled: "{{ (var('claims_enabled', false) and var('clinical_enabled', false)) | as_bool }}"
     overrides:
       vars:
         claims_enabled: true

--- a/models/data_quality/logical/clinical_semantic_unit_tests.yml
+++ b/models/data_quality/logical/clinical_semantic_unit_tests.yml
@@ -1497,7 +1497,7 @@ unit_tests:
       preservation of raw source fields.
     model: core__medication
     config:
-      enabled: "{{ (var('claims_enabled', false) or var('clinical_enabled', false)) | as_bool }}"
+      enabled: "{{ var('clinical_enabled', false) | as_bool }}"
     overrides:
       vars:
         claims_enabled: false


### PR DESCRIPTION
Single-domain projects currently select medication unit tests whose fixtures require disabled parent models. Claims-only builds can fail looking for `normalized__medication`; clinical-only builds can fail looking for `core__stg_claims_medication`.

Match four unit-test enablement guards to their actual inputs: the two claims CodeRx Enterprise tests require claims, the clinical normalization test requires clinical, and the overlapping-ID test requires both domains. The existing fixtures and assertions remain unchanged, including both expected records in the mixed-domain test. No transformation SQL changes.

Validation:
- Reproduced the missing-parent errors before the change in claims-only and clinical-only configurations.
- Focused Snowflake unit tests pass with Data Quality disabled: 2 claims-only, 1 clinical-only, and all 4 with both domains enabled.
- `scripts/dbt-local deps`, `scripts/dbt-local parse --no-partial-parse`, and `git diff --check` pass. Existing Snowflake development assets were reused without seeding.
- The four-guard patch was also applied to the previously validated production Core source. A focused claims-only build materialized `core__medication` and passed its two applicable unit tests and six data tests without reloading seeds.
- [Automatic Snowflake CI](https://github.com/tuva-health/tuva-core/actions/runs/33718900657) passed all 894 resources, including 101 unit tests and 360 data tests, with zero warnings, errors, or skips.

Release-note disposition: `bug`.

Companion PRs: https://github.com/tuva-health/ccsr/pull/20 and https://github.com/tuva-health/cms_hcc/pull/42.

Combined validation on 2026-09-03:
- A full-refresh Snowflake build of Core, the integration project, CCSR, and CMS HCC passed all 852 results: 104 seeds, 361 models, 306 data tests, 80 unit tests, and one hook. Zero failing, warning, or skipped results. Seeds were included in this build.
- A subsequent warehouse metadata check confirmed all 104 required asset tables are populated and all 1,291 expected seed columns match, including the current Core grouper names.
- All seven unit tests covering the three companion PRs passed. The build used the exact PR merge candidates and integration defaults: small synthetic data, claims and clinical enabled, Data Quality and parity disabled.

```bash
TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local build --full-refresh \
  --select package:integration_tests package:the_tuva_project package:ccsr package:cms_hcc
```
