### PR TITLE
Fix all-warehouse Core dependency injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,8 +703,9 @@ jobs:
           )
           PY
 
-      # Standalone packages declare their released Core dependency. Resolve
-      # that graph first, then replace only Core with this PR's test merge.
+      # Resolve the standalone package graph first, then add this PR's test
+      # merge as the root project's Core dependency. Standalone packages must
+      # not bring their own Core dependency.
       - name: Resolve standalone package dependencies
         if: env.CI_SCOPE == 'all-packages'
         run: >-
@@ -712,7 +713,7 @@ jobs:
           --project-dir ./integration_tests
           --profiles-dir ./integration_tests/profiles/${{ matrix.warehouse }}
 
-      - name: Promote candidate Core in dependency lock
+      - name: Add candidate Core to dependency lock
         if: env.CI_SCOPE == 'all-packages'
         env:
           CI_SOURCE_LOCK: ${{ needs.resolve.outputs.source_lock }}
@@ -745,9 +746,10 @@ jobs:
               for item in locked_packages
               if item.get("name") == "the_tuva_project"
           ]
-          if len(core_entries) != 1:
+          if core_entries:
               raise SystemExit(
-                  "resolved package lock must contain exactly one Core dependency"
+                  "resolved standalone package lock must not contain Core; "
+                  "candidate Core is injected by the root project"
               )
 
           expected_packages = {


### PR DESCRIPTION
## Summary\n\nFixes all-warehouse CI after the standalone packages adopted the root-owned Core dependency contract for their dbt Hub releases.\n\nThe workflow now requires the resolved standalone-package graph to contain no transitive Core package, then injects the exact checked-out PR candidate as the single local Core dependency.\n\n## Validation\n\n- \n- Replayed the retained zero-Core dependency lock from failed run 33918599055 through the patched workflow step.\n- Confirmed dbt 1.11.14 consumes the rewritten lock with one local Core, all eight exact standalone-package revisions, and dbt_utils.\n- Parsed the complete package graph on DuckDB and confirmed enabled nodes from Core, integration_tests, and all eight standalone packages.\n- Confirmed a transitive Core entry is rejected.\n- Automatic Snowflake CI will rerun on this pull request.\n- A new all-warehouse dispatch is required after this trusted workflow change reaches main.\n\n## Release-note disposition\n\n- ignore-for-release\n\n## Linked issue\n\n- None