### PR TITLE
fix: unblock release validation and document GitHub installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,22 @@ compatibility, and release lifecycle.
 
 ## Install Tuva Core
 
-Add a published version to the parent project's `packages.yml`:
+Install a published GitHub release directly from the parent project's
+`packages.yml`. Use its exact tag, including the `v` prefix:
+
+```yaml
+packages:
+  - git: "https://github.com/tuva-health/tuva-core.git"
+    revision: "<published-release-tag>"
+```
+
+For example, a published `v1.0.0` release uses `revision: "v1.0.0"`.
+Git installation does not require the release to be indexed by dbt Hub.
+An exact 40-character commit can also identify a reviewed development revision.
+Avoid mutable branch names for production installations.
+
+Once the version is available on dbt Hub, this alternative installs the same
+package. Use one form per package, not both:
 
 ```yaml
 packages:
@@ -68,13 +83,11 @@ packages:
     version: "<published-version>"
 ```
 
-For development against an explicitly reviewed Git ref:
-
-```yaml
-packages:
-  - git: "https://github.com/tuva-health/tuva-core.git"
-    revision: "<immutable-tag-or-commit>"
-```
+Add each optional Tuva package to the same root `packages.yml` using its own
+repository URL and published tag. The parent project installs Core explicitly;
+standalone packages do not install it for you. Semantic Layer also requires
+the sibling packages listed in its installation instructions. Existing
+dependencies such as `dbt-labs/dbt_utils` can continue to resolve through Hub.
 
 Install dependencies with `dbt deps`. The parent project must expose the Tuva
 Input Layer models and enable the domains it maps:

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -310,7 +310,7 @@ models:
             data_type: varchar
   - name: core__condition
     description: |
-      The condition table stores diagnoses and problems from claims and clinical sources. Claims-derived rows come from the diagnosis code columns in input_layer.medical_claim. Clinical rows come from input_layer.condition. The Normalized Layer matches source codes to ICD-10-CM, ICD-9-CM, and SNOMED CT terminology as supported by each source path. core.condition unions normalized clinical and claims condition rows, then applies the Tuva Condition Grouper to supported normalized ICD-10-CM and SNOMED CT codes to populate condition_family and condition.
+      The condition table stores diagnoses and problems from claims and clinical sources. Claims-derived rows come from the diagnosis code columns in input_layer.medical_claim. Clinical rows come from input_layer.condition. The Normalized Layer matches source codes to ICD-10-CM, ICD-9-CM, and SNOMED CT terminology as supported by each source path. core.condition unions normalized clinical and claims condition rows, then applies the Tuva Condition Grouper to supported normalized ICD-10-CM and SNOMED CT codes to populate condition_family and condition_name.
 
       All clinical condition records and every populated medical-claim diagnosis position from the enabled Input Layer sources flow through to core.condition, including invalid codes that do not appear in the supported terminology sets. Unmatched codes retain their source_code and have null normalized_code and normalized_description. Claims diagnoses are retained regardless of claim_type or encounter assignment; diagnoses without an encounter assignment have a null encounter_id.
 

--- a/seeds/value_sets/condition_grouper/condition_grouper_seeds.yml
+++ b/seeds/value_sets/condition_grouper/condition_grouper_seeds.yml
@@ -7,7 +7,7 @@ seeds:
     config:
       meta:
         primary_key_columns:
-          - condition
+          - condition_name
         primary_key_strategy: natural_single_column
       post_hook: "{{ load_versioned_seed('value_sets','tuva_condition_grouper.csv.gz') }}"
       schema: |

--- a/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
+++ b/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
@@ -7,7 +7,7 @@ seeds:
     config:
       meta:
         primary_key_columns:
-          - procedure
+          - procedure_name
         primary_key_strategy: natural_single_column
       post_hook: "{{ load_versioned_seed('value_sets','tuva_procedure_grouper.csv.gz') }}"
       schema: |

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -158,6 +158,24 @@ class DataAssetContractTest(unittest.TestCase):
                 self.assertTrue(all(header), seed_name)
                 self.assertIsNone(next(rows, None), seed_name)
 
+    def test_grouper_primary_keys_reference_existing_columns(self):
+        for family in ("condition", "procedure"):
+            folder = ROOT / "seeds" / "value_sets" / f"{family}_grouper"
+            yaml_text = (folder / f"{family}_grouper_seeds.yml").read_text()
+            for suffix in ("", "_code_map"):
+                seed_name = f"tuva_{family}_grouper{suffix}"
+                with self.subTest(seed=seed_name):
+                    definition = seed_definition(yaml_text, seed_name)
+                    keys_match = re.search(
+                        r"(?m)^        primary_key_columns:\n((?:          - .+\n)+)",
+                        definition,
+                    )
+                    self.assertIsNotNone(keys_match, seed_name)
+                    keys = re.findall(r"(?m)^          - (\S+)$", keys_match.group(1))
+                    with (folder / f"{seed_name}.csv").open(newline="") as handle:
+                        header = next(csv.reader(handle))
+                    self.assertTrue(set(keys).issubset(header), (seed_name, keys, header))
+
     def test_refreshed_terminology_headers_preserve_lifecycle_contract(self):
         seed_root = ROOT / "seeds" / "terminology"
         for filename, expected_header in TERMINOLOGY_LIFECYCLE_HEADERS.items():

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -234,10 +234,6 @@ class DataAssetContractTest(unittest.TestCase):
             'require-dbt-version: ">=1.10.5,<3.0.0"',
             project_text,
         )
-        self.assertIn(
-            'version: "1.2.1"',
-            (ROOT / "packages.yml").read_text(),
-        )
         runtime_config_path = (
             ROOT / "macros" / "system_utils" / ("get_runtime_" + "config.sql")
         )


### PR DESCRIPTION
All changes in this PR were incorporated in merged PR #1448 at commit 131d12a5225282563917b76af92718b555c24d4d. Its merged tree exactly matches the successful tagged-mart Snowflake test merge. This superseded PR is closed as incorporated.

Core release creation failed because the asset-contract test still required dbt_utils 1.2.1 while packages.yml supports >=1.3.2,<2.0.0. Remove that obsolete assertion and preserve the asset/version/loader/release-workflow checks. Correct the two grouper seed primary-key metadata declarations to condition_name/procedure_name and the Core condition description. Document direct GitHub installation while new dbt Hub registrations are pending. Transformation SQL, dependency declarations, versions, and seed CSVs are unchanged.

Validation:

- All 11 asset-contract tests pass, including checks that failed before the stale assertion and grouper metadata corrections.
- DuckDB Git dependency installation and the combined Core/eight-mart parse pass with Data Quality and failure keys enabled; git diff --check passes.
- Latest-head routine Snowflake CI passed: https://github.com/tuva-health/tuva-core/actions/runs/34148255276 .
- Final all-warehouse run passed on its first attempt after the corrected public asset snapshots were released: https://github.com/tuva-health/tuva-core/actions/runs/34161051423 . Snowflake, BigQuery, Databricks, Fabric, Redshift, and the final consistency reporter are green. Every warehouse built Core and all eight mart main revisions, with 578 models, 127 seeds, 173 unit tests, and 584 data tests (583 on Fabric because its existing regex-contract test is intentionally disabled). All result records succeeded.
- All five source locks are byte-identical: SHA-256 30e10195467e410abc03ae6148df91b108457fbf50834f35527d08db07613d5e. The tested Core merge 67155e5b207761ce9f785adf6cd547f022803fdd has this PR head 24ed80b3f6774d4457b2e0e262b9759a0ebea7ab and base 228282a57fd099348e2480bba19803c460e59bee. All eight mart revisions match the reviewed release baselines.

The eight mart 1.0.0 releases are now published. Final Core PR #1448 incorporates these corrections and installs/builds those actual tags; its Snowflake run 34164127124 passed. PR #1448 is now merged and this superseded draft is closed as incorporated. Core’s GitHub release will remain a draft for Aaron to publish.

Release-note disposition: `bug`.
