### PR TITLE
Finalize Core 1.0 release checks and tagged mart integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
         required: true
         type: string
       scope:
-        description: Package scope to validate (core or all-packages)
+        description: Dependency mode (core uses checked-in tags; all-packages snapshots mains)
         required: true
         type: string
       source_lock:
@@ -210,8 +210,6 @@ jobs:
               "fabric",
               "redshift"
             ];
-            const coreSelector =
-              "package:integration_tests package:the_tuva_project";
             const allPackagesSelector = [
               "package:integration_tests",
               "package:the_tuva_project",
@@ -342,7 +340,7 @@ jobs:
               fail(`Unsupported CI request: ${warehouse}:${scope}`);
             }
             if (scope === "core" && sourceLock) {
-              fail("Core-only CI must not receive a standalone package source lock.");
+              fail("Checked-in dependency CI must not receive a main-branch package source lock.");
             }
             if (shouldRun && !checkoutRef) {
               fail("checkout_ref is required.");
@@ -426,9 +424,8 @@ jobs:
               ? `${schemaBase}_r${runId}_a${runAttempt}`
               : "";
             const adapterMatrix = warehouse === "all" ? supportedWarehouses : [warehouse];
-            const selector = scope === "all-packages"
-              ? allPackagesSelector
-              : coreSelector;
+            // Both modes build the full ecosystem; only dependency resolution differs.
+            const selector = allPackagesSelector;
             const statusContext = scope === "all-packages"
               ? "Tuva CI / All Warehouses"
               : "Tuva CI / Snowflake";
@@ -853,15 +850,45 @@ jobs:
           dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/snowflake
           if [[ "$CI_SCOPE" == "core" ]]; then
             # Regression for #1392: explicit claims=false must not mask clinical=true.
-            dbt --quiet ls \
-              --project-dir ./integration_tests \
-              --profiles-dir ./integration_tests/profiles/snowflake \
-              --no-partial-parse \
-              --resource-type model \
-              --select core__person_id_crosswalk \
-              --output name \
-              --vars '{"claims_enabled": false, "clinical_enabled": true, "provider_attribution_enabled": false, "data_quality_enabled": false, "parity_enabled": false, "use_coderx_enterprise": false}' \
-              | grep -Fxq core__person_id_crosswalk
+            # Claims marts require claims models, so isolate this Core-only parse.
+            python3 - <<'PYTHON'
+          import json
+          import shutil
+          import subprocess
+          import sys
+          import tempfile
+          from pathlib import Path
+
+          source = Path("integration_tests").resolve()
+          with tempfile.TemporaryDirectory(prefix="tuva-clinical-ci-") as temporary:
+              project = Path(temporary)
+              shutil.copy2(source / "dbt_project.yml", project / "dbt_project.yml")
+              for directory in ("models", "macros", "tests"):
+                  (project / directory).symlink_to(source / directory, target_is_directory=True)
+              (project / "dbt_packages").mkdir()
+              for package in ("the_tuva_project", "dbt_utils"):
+                  (project / "dbt_packages" / package).symlink_to(
+                      (source / "dbt_packages" / package).resolve(), target_is_directory=True
+                  )
+              variables = {
+                  "claims_enabled": False, "clinical_enabled": True,
+                  "provider_attribution_enabled": False, "data_quality_enabled": False,
+                  "parity_enabled": False, "use_coderx_enterprise": False,
+              }
+              result = subprocess.run(
+                  ["dbt", "--quiet", "ls", "--project-dir", str(project),
+                   "--profiles-dir", str(source / "profiles/snowflake"),
+                   "--no-partial-parse", "--resource-type", "model",
+                   "--select", "core__person_id_crosswalk", "--output", "name",
+                   "--vars", json.dumps(variables)],
+                  capture_output=True, text=True,
+              )
+              print(result.stdout, end="")
+              print(result.stderr, end="", file=sys.stderr)
+              result.check_returncode()
+              if "core__person_id_crosswalk" not in result.stdout.splitlines():
+                  raise SystemExit("Clinical-only Core person ID crosswalk is not enabled")
+          PYTHON
           fi
           dbt build --full-refresh \
             --project-dir ./integration_tests \
@@ -869,6 +896,91 @@ jobs:
             --sqlparse "$DBT_SQLPARSE_OPTIONS" \
             --select "${ci_selectors[@]}" \
             --vars "$CI_DBT_VARS"
+
+      - name: Verify tagged-package Snowflake results
+        if: env.CI_SCOPE == 'core'
+        env:
+          CI_CHECKOUT_REF: ${{ needs.resolve.outputs.checkout_ref }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          from pathlib import Path
+
+          import yaml
+
+          project = Path("integration_tests")
+          expected = {
+              "ahrq_quality_indicators": "ahrq_quality_indicators",
+              "ccsr": "ccsr",
+              "cms_chronic_conditions": "cms_chronic_conditions",
+              "cms_hcc": "cms_hcc",
+              "fhir_preprocessing": "fhir_preprocessing",
+              "nyu_ed_classification": "nyu_ed_classification",
+              "quality_measures": "quality_measures",
+              "semantic_layer": "semantic-layer",
+          }
+          declared = yaml.safe_load((project / "packages.yml").read_text())["packages"]
+          locked = yaml.safe_load((project / "package-lock.yml").read_text())["packages"]
+          by_name = {package.get("name"): package for package in locked}
+          if {"local": "../"} not in declared or by_name.get("the_tuva_project") != {
+              "local": "../", "name": "the_tuva_project"
+          }:
+              raise SystemExit("Snowflake must build the checked-out local Core")
+          manifest = json.loads((project / "target/manifest.json").read_text())
+          results = json.loads((project / "target/run_results.json").read_text())
+          successful_models = {}
+          for result in results["results"]:
+              node = manifest["nodes"].get(result["unique_id"], {})
+              if result["status"] == "success" and node.get("resource_type") == "model":
+                  package = node["package_name"]
+                  successful_models[package] = successful_models.get(package, 0) + 1
+          evidence = {"core_commit": os.environ["CI_CHECKOUT_REF"], "packages": []}
+          for name, repository in expected.items():
+              url = f"https://github.com/tuva-health/{repository}.git"
+              entries = [item for item in declared if item.get("git") == url]
+              tag = entries[0].get("revision", "") if len(entries) == 1 else ""
+              if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", tag):
+                  raise SystemExit(f"{name} must use one explicit stable Git release tag")
+              lock = by_name.get(name, {})
+              revision = lock.get("revision", "")
+              if lock.get("git") != url or not re.fullmatch(r"[0-9a-f]{40}", revision):
+                  raise SystemExit(f"{name} has no exact Git dependency lock")
+              installed = project / "dbt_packages" / name
+              version = str(yaml.safe_load((installed / "dbt_project.yml").read_text())["version"])
+              installed_revision = subprocess.check_output(
+                  ["git", "-C", str(installed), "rev-parse", "HEAD"], text=True
+              ).strip()
+              if version != tag[1:] or installed_revision != revision:
+                  raise SystemExit(f"{name} installed version/commit differs from its release lock")
+              if successful_models.get(name, 0) == 0:
+                  raise SystemExit(f"{name} has no successful model result in this Snowflake build")
+              evidence["packages"].append({
+                  "package": name, "repository": url, "tag": tag,
+                  "revision": revision, "version": version,
+                  "successful_models": successful_models[name],
+              })
+          (project / "ci-tagged-package-evidence.json").write_text(
+              json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+          )
+          print(json.dumps(evidence, indent=2))
+          PY
+
+      - name: Upload tagged-package Snowflake evidence
+        if: always() && env.CI_SCOPE == 'core'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tuva-snowflake-tagged-ci-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            integration_tests/ci-tagged-package-evidence.json
+            integration_tests/packages.yml
+            integration_tests/package-lock.yml
+            integration_tests/target/manifest.json
+            integration_tests/target/run_results.json
+          if-no-files-found: warn
+          retention-days: 90
 
       - name: Build on BigQuery
         if: matrix.warehouse == 'bigquery'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,8 +399,10 @@ would erase the case contract the checks exist to enforce.
 
 - Same-repository pull requests automatically run `Tuva CI -- Snowflake`: one
   fixed Snowflake `dbt build --full-refresh` against the small synthetic
-  dataset. It builds Tuva Core and the integration project, runs unit and data
-  tests, enables Data Quality and its optional failure-key relation, and keeps
+  dataset. It builds this PR's local Tuva Core, the integration project, and all
+  eight standalone packages pinned to Git release tags in
+  `integration_tests/packages.yml`. It runs unit and data tests, enables Data
+  Quality and its optional failure-key relation, and keeps
   parity disabled. A package-version change does not alter this automatic path.
   The Snowflake status is informational and is not required for merge.
 - Run `Tuva CI -- All Warehouses` manually for the final release PR. Its only
@@ -419,9 +421,14 @@ would erase the case contract the checks exist to enforce.
   dbt commands, selectors, or flags.
 - Automatic secrets-backed CI never executes fork code. After review, a
   maintainer runs `External PR Snowflake CI` and supplies only the PR number.
-  That workflow validates code only and does not inspect package versions.
-- Routine Snowflake CI does not install standalone packages. Only manual
-  all-warehouse CI snapshots all eight package `main` branches before building.
+  That workflow uses the same checked-in package tags and does not choose or
+  compare Core release versions or perform release operations.
+- Routine Snowflake CI installs and builds all eight standalone packages from
+  the checked-in Git release tags. It verifies installed versions and commit
+  locks and requires successful model results from every package. The manifest,
+  run results, dependency lock, and package evidence are retained as artifacts.
+  Manual all-warehouse CI independently snapshots all eight package `main`
+  branches before building; it does not use the checked-in release tags.
 - Parity comparison is a separate manually initiated Snowflake release
   validation.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,22 @@ compatibility, and release lifecycle.
 
 ## Install Tuva Core
 
-Add a published version to the parent project's `packages.yml`:
+Install a published GitHub release directly from the parent project's
+`packages.yml`. Use its exact tag, including the `v` prefix:
+
+```yaml
+packages:
+  - git: "https://github.com/tuva-health/tuva-core.git"
+    revision: "<published-release-tag>"
+```
+
+For example, a published `v1.0.0` release uses `revision: "v1.0.0"`.
+Git installation does not require the release to be indexed by dbt Hub.
+An exact 40-character commit can also identify a reviewed development revision.
+Avoid mutable branch names for production installations.
+
+Once the version is available on dbt Hub, this alternative installs the same
+package. Use one form per package, not both:
 
 ```yaml
 packages:
@@ -68,13 +83,11 @@ packages:
     version: "<published-version>"
 ```
 
-For development against an explicitly reviewed Git ref:
-
-```yaml
-packages:
-  - git: "https://github.com/tuva-health/tuva-core.git"
-    revision: "<immutable-tag-or-commit>"
-```
+Add each optional Tuva package to the same root `packages.yml` using its own
+repository URL and published tag. The parent project installs Core explicitly;
+standalone packages do not install it for you. Semantic Layer also requires
+the sibling packages listed in its installation instructions. Existing
+dependencies such as `dbt-labs/dbt_utils` can continue to resolve through Hub.
 
 Install dependencies with `dbt deps`. The parent project must expose the Tuva
 Input Layer models and enable the domains it maps:

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,2 +1,18 @@
 packages:
   - local: ../
+  - git: https://github.com/tuva-health/ahrq_quality_indicators.git
+    revision: v1.0.0
+  - git: https://github.com/tuva-health/ccsr.git
+    revision: v1.0.0
+  - git: https://github.com/tuva-health/cms_chronic_conditions.git
+    revision: v1.0.0
+  - git: https://github.com/tuva-health/cms_hcc.git
+    revision: v1.0.0
+  - git: https://github.com/tuva-health/fhir_preprocessing.git
+    revision: v1.0.0
+  - git: https://github.com/tuva-health/nyu_ed_classification.git
+    revision: v1.0.0
+  - git: https://github.com/tuva-health/quality_measures.git
+    revision: v1.0.0
+  - git: https://github.com/tuva-health/semantic-layer.git
+    revision: v1.0.0

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -310,7 +310,7 @@ models:
             data_type: varchar
   - name: core__condition
     description: |
-      The condition table stores diagnoses and problems from claims and clinical sources. Claims-derived rows come from the diagnosis code columns in input_layer.medical_claim. Clinical rows come from input_layer.condition. The Normalized Layer matches source codes to ICD-10-CM, ICD-9-CM, and SNOMED CT terminology as supported by each source path. core.condition unions normalized clinical and claims condition rows, then applies the Tuva Condition Grouper to supported normalized ICD-10-CM and SNOMED CT codes to populate condition_family and condition.
+      The condition table stores diagnoses and problems from claims and clinical sources. Claims-derived rows come from the diagnosis code columns in input_layer.medical_claim. Clinical rows come from input_layer.condition. The Normalized Layer matches source codes to ICD-10-CM, ICD-9-CM, and SNOMED CT terminology as supported by each source path. core.condition unions normalized clinical and claims condition rows, then applies the Tuva Condition Grouper to supported normalized ICD-10-CM and SNOMED CT codes to populate condition_family and condition_name.
 
       All clinical condition records and every populated medical-claim diagnosis position from the enabled Input Layer sources flow through to core.condition, including invalid codes that do not appear in the supported terminology sets. Unmatched codes retain their source_code and have null normalized_code and normalized_description. Claims diagnoses are retained regardless of claim_type or encounter assignment; diagnoses without an encounter assignment have a null encounter_id.
 

--- a/seeds/value_sets/condition_grouper/condition_grouper_seeds.yml
+++ b/seeds/value_sets/condition_grouper/condition_grouper_seeds.yml
@@ -7,7 +7,7 @@ seeds:
     config:
       meta:
         primary_key_columns:
-          - condition
+          - condition_name
         primary_key_strategy: natural_single_column
       post_hook: "{{ load_versioned_seed('value_sets','tuva_condition_grouper.csv.gz') }}"
       schema: |

--- a/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
+++ b/seeds/value_sets/procedure_grouper/procedure_grouper_seeds.yml
@@ -7,7 +7,7 @@ seeds:
     config:
       meta:
         primary_key_columns:
-          - procedure
+          - procedure_name
         primary_key_strategy: natural_single_column
       post_hook: "{{ load_versioned_seed('value_sets','tuva_procedure_grouper.csv.gz') }}"
       schema: |

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -158,6 +158,24 @@ class DataAssetContractTest(unittest.TestCase):
                 self.assertTrue(all(header), seed_name)
                 self.assertIsNone(next(rows, None), seed_name)
 
+    def test_grouper_primary_keys_reference_existing_columns(self):
+        for family in ("condition", "procedure"):
+            folder = ROOT / "seeds" / "value_sets" / f"{family}_grouper"
+            yaml_text = (folder / f"{family}_grouper_seeds.yml").read_text()
+            for suffix in ("", "_code_map"):
+                seed_name = f"tuva_{family}_grouper{suffix}"
+                with self.subTest(seed=seed_name):
+                    definition = seed_definition(yaml_text, seed_name)
+                    keys_match = re.search(
+                        r"(?m)^        primary_key_columns:\n((?:          - .+\n)+)",
+                        definition,
+                    )
+                    self.assertIsNotNone(keys_match, seed_name)
+                    keys = re.findall(r"(?m)^          - (\S+)$", keys_match.group(1))
+                    with (folder / f"{seed_name}.csv").open(newline="") as handle:
+                        header = next(csv.reader(handle))
+                    self.assertTrue(set(keys).issubset(header), (seed_name, keys, header))
+
     def test_refreshed_terminology_headers_preserve_lifecycle_contract(self):
         seed_root = ROOT / "seeds" / "terminology"
         for filename, expected_header in TERMINOLOGY_LIFECYCLE_HEADERS.items():

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -234,10 +234,6 @@ class DataAssetContractTest(unittest.TestCase):
             'require-dbt-version: ">=1.10.5,<3.0.0"',
             project_text,
         )
-        self.assertIn(
-            'version: "1.2.1"',
-            (ROOT / "packages.yml").read_text(),
-        )
         runtime_config_path = (
             ROOT / "macros" / "system_utils" / ("get_runtime_" + "config.sql")
         )


### PR DESCRIPTION
The integration project previously installed only local Core, and ordinary Snowflake CI selected only Core and the integration project. A green check therefore did not verify installation or execution of the standalone release tags. This PR installs all eight marts from their GitHub `v1.0.0` tags and makes routine Snowflake CI build their models alongside Core. It verifies each declared tag, resolved lock SHA, installed Git HEAD, installed version, and successful model coverage, and retains native manifest/run results plus dependency evidence.

The clinical-only Core crosswalk check runs in a temporary Core-only project because the installed claims marts require claims models. The manual all-warehouse workflow continues to pin current mart main branches into its existing exact source lock. Credential boundaries, fork guards, and release automation remain unchanged.

This PR also incorporates the reviewed corrections from #1447: remove the obsolete dbt_utils 1.2.1 assertion that blocks release creation, correct the grouper primary-key metadata and condition description, and document direct GitHub installation. No transformation SQL, seed payload, asset version, or top-level Core version changes. #1447 is closed as incorporated in this merged PR.

Validation:

- Actual tagged-mart Snowflake CI passed on this exact head, including the final consistency reporter: https://github.com/tuva-health/tuva-core/actions/runs/34164127124 . Native manifest/run results contain 1,463 successful results with the same result IDs as the final matrix Snowflake build. All eight installed release SHAs and versions match the table below, all nine stable Data Quality models succeeded, and the clinical-only crosswalk check passed.
- Final all-warehouse run against the finished Core candidate and exact mart main commits passed on its first attempt: https://github.com/tuva-health/tuva-core/actions/runs/34161051423 . All five warehouse jobs and the final consistency reporter are green; 7,314 result records succeeded, including full package and Data Quality failure-key coverage. All five source-lock files match SHA-256 `30e10195467e410abc03ae6148df91b108457fbf50834f35527d08db07613d5e`.
- The eight mart release commits below differ from the tested sources only in README guidance and top-level package version. Existing package checks and both package PR workflows passed before their releases.
- Clean Git installation of all eight actual `v1.0.0` tags and combined DuckDB parse passed using dbt Core 1.11.14, with Data Quality and failure keys enabled. Every installed Git HEAD equals its expected release commit and generated lock; all installed versions are 1.0.0. This local check is installation/parse validation; hosted Snowflake provides model-build acceptance.
- `actionlint`, 59 portability checks, 3 variable-inventory checks, 11 asset-contract checks, and `git diff --check` passed. The prepared routing/evidence tests and the actual isolated clinical-only helper also passed.

| Mart release | Verified tag commit |
| --- | --- |
| [ahrq_quality_indicators](https://github.com/tuva-health/ahrq_quality_indicators/releases/tag/v1.0.0) | `ea6ee7b14d1cb2d789354cfd0d0807bbfb6b2e95` |
| [ccsr](https://github.com/tuva-health/ccsr/releases/tag/v1.0.0) | `114156b7e1d93de3b59665151d17287a5d654a0d` |
| [cms_chronic_conditions](https://github.com/tuva-health/cms_chronic_conditions/releases/tag/v1.0.0) | `322d6b08b86eaeef35f8ef188802a0527469d88b` |
| [cms_hcc](https://github.com/tuva-health/cms_hcc/releases/tag/v1.0.0) | `6343066e5d3e9326e4b42529b76cf22db9b5cc14` |
| [fhir_preprocessing](https://github.com/tuva-health/fhir_preprocessing/releases/tag/v1.0.0) | `e21e0225700bc45589f0e0f84754b43ebb4216f2` |
| [nyu_ed_classification](https://github.com/tuva-health/nyu_ed_classification/releases/tag/v1.0.0) | `4cb5a09e3b76b4cd9732160f0fd7eff778095bbe` |
| [quality_measures](https://github.com/tuva-health/quality_measures/releases/tag/v1.0.0) | `18af7484c86c0c3ad756071dbd774f59b068d469` |
| [semantic_layer](https://github.com/tuva-health/semantic-layer/releases/tag/v1.0.0) | `a88efcccd47ad74ce42bd95e536890bf0bde0a6d` |

The hosted Snowflake run on this PR passed with the actual eight tagged marts. This PR merged at `131d12a5225282563917b76af92718b555c24d4d`; its tree exactly matches the validated test merge. [Create Release](https://github.com/tuva-health/tuva-core/actions/runs/34169755512) passed and created the `v1.0.0` tag at that commit plus a **draft GitHub release only**. Aaron will publish Core separately. Docs and DAG Viewer publication remains held.

Release-note disposition: `bug` (includes the release-blocking contract correction from #1447).
