### PR TITLE
Fix require-dbt-version to use split setting

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'the_tuva_project'
 version: '1.0.0'
 config-version: 2
-require-dbt-version: ">=1.10.5,<3.0.0"
+require-dbt-version: [">=1.10.5", "<3.0.0"]
 
 profile: default
 

--- a/tests/unit/test_data_asset_contract.py
+++ b/tests/unit/test_data_asset_contract.py
@@ -249,7 +249,7 @@ class DataAssetContractTest(unittest.TestCase):
         self.assertIsNotNone(asset_version_match)
         self.assertEqual(asset_version_match.group(1), "1.0.0")
         self.assertIn(
-            'require-dbt-version: ">=1.10.5,<3.0.0"',
+            'require-dbt-version: [">=1.10.5", "<3.0.0"]',
             project_text,
         )
         runtime_config_path = (


### PR DESCRIPTION
The comma-separated `require-dbt-version` range parses correctly in a dbt project, but dbt Core's Hub resolver treats it as one semantic-version constraint and fails during dependency resolution. Express the same `>=1.10.5` and `<3.0.0` bounds as a YAML list. Update the existing release-contract assertion to expect that list format. Models, supported versions, and the existing `v1.0.0` tag are unchanged.

Validation: reproduced the reported failure with dbt Core 1.12.3 and a Hub dependency pinned to Tuva 0.18.0. Normalizing only the 1.0.0 registry requirement allows all 135 indexed versions to be checked and resolves both 0.18.0 and 1.0.0; compatibility boundary checks pass. All 11 release-contract tests pass after updating the assertion; the original PR reproduced one assertion failure. [External PR Snowflake CI](https://github.com/tuva-health/tuva-core/actions/runs/34241291484) passed on the final revision: 1,463 successful results, zero warnings/errors/skips, including all eight tagged packages.

Refs #1449. The existing Hub 1.0.0 metadata needs a separate upstream correction; merging this source fix does not repair the already indexed entry. Release-note disposition: `bug`.
